### PR TITLE
Support HTTP-01 challenge validation.

### DIFF
--- a/acme/common.go
+++ b/acme/common.go
@@ -1,8 +1,6 @@
 package acme
 
-import (
-	"gopkg.in/square/go-jose.v1"
-)
+import "gopkg.in/square/go-jose.v1"
 
 // acme.Resource values identify different types of ACME resources
 type Resource string
@@ -11,14 +9,20 @@ const (
 	ResourceNewNonce = Resource("new-nonce")
 	ResourceNewReg   = Resource("new-reg")
 	ResourceNewOrder = Resource("new-order")
+	// TODO(@cpu): Should there be a resource for challenge or just use 'authz'?
+	ResourceChallenge = Resource("challenge")
 )
 
 const (
 	StatusPending = "pending"
+	StatusInvalid = "invalid"
+	StatusValid   = "valid"
 
 	IdentifierDNS = "dns"
 
 	ChallengeHTTP01 = "http-01"
+
+	HTTP01BaseURL = ".well-known/acme-challenge/"
 )
 
 type Identifier struct {
@@ -51,11 +55,16 @@ type Authorization struct {
 	Status     string     `json:"status"`
 	Identifier Identifier `json:"identifier"`
 	Challenges []string   `json:"challenges"`
+	Expires    string     `json:"expires"`
 }
 
 // A Challenge is used to validate an Authorization
 type Challenge struct {
-	Type  string `json:"type"`
-	URL   string `json:"url"`
-	Token string `json:"token"`
+	Type                     string         `json:"type"`
+	URL                      string         `json:"url"`
+	Token                    string         `json:"token"`
+	Status                   string         `json:"status"`
+	Validated                string         `json:"validated,omitempty"`
+	ProvidedKeyAuthorization string         `json:"keyAuthorization,omitempty"`
+	Error                    ProblemDetails `json:"error,omitempty"`
 }

--- a/acme/problems.go
+++ b/acme/problems.go
@@ -11,6 +11,8 @@ const (
 	malformedErr      = errNS + "malformedRequest"
 	badNonceErr       = errNS + "badNonce"
 	agreementReqErr   = errNS + "agreementRequired"
+	connectionErr     = errNS + "connection"
+	unauthorizedErr   = errNS + "unauthorized"
 )
 
 type ProblemDetails struct {
@@ -68,5 +70,21 @@ func AgreementRequiredProblem(detail string) *ProblemDetails {
 		Type:       agreementReqErr,
 		Detail:     detail,
 		HTTPStatus: http.StatusForbidden,
+	}
+}
+
+func ConnectionProblem(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       connectionErr,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadGateway, // TODO(@cpu): Change this later?
+	}
+}
+
+func UnauthorizedProblem(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       unauthorizedErr,
+		Detail:     detail,
+		HTTPStatus: http.StatusUnauthorized,
 	}
 }

--- a/acme/problems.go
+++ b/acme/problems.go
@@ -75,16 +75,14 @@ func AgreementRequiredProblem(detail string) *ProblemDetails {
 
 func ConnectionProblem(detail string) *ProblemDetails {
 	return &ProblemDetails{
-		Type:       connectionErr,
-		Detail:     detail,
-		HTTPStatus: http.StatusBadGateway, // TODO(@cpu): Change this later?
+		Type:   connectionErr,
+		Detail: detail,
 	}
 }
 
 func UnauthorizedProblem(detail string) *ProblemDetails {
 	return &ProblemDetails{
-		Type:       unauthorizedErr,
-		Detail:     detail,
-		HTTPStatus: http.StatusUnauthorized,
+		Type:   unauthorizedErr,
+		Detail: detail,
 	}
 }

--- a/cmd/pebble-client/main.go
+++ b/cmd/pebble-client/main.go
@@ -238,7 +238,11 @@ func (c *client) readEndpoint() (string, error) {
 			break
 		}
 		if _, ok := c.directory[line]; !ok {
-			fmt.Printf("Unknown directory endpoint: %q.\nAvailable choices: %s\n",
+			if url, err := url.Parse(line); err == nil {
+				endpoint = url.String()
+				break
+			}
+			fmt.Printf("Unknown directory endpoint or invalid URL: %q.\nAvailable choices: %s\n",
 				line, strings.Join(c.endpoints(), ", "))
 			fmt.Printf("$> Enter a directory endpoint to POST: ")
 			continue

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/pebble/cmd"
 	"github.com/letsencrypt/pebble/wfe"
 )
@@ -34,7 +35,9 @@ func main() {
 	err := cmd.ReadConfigFile(*configFile, &c)
 	cmd.FailOnError(err, "Reading JSON config file into config structure")
 
-	wfe, err := wfe.New(logger)
+	clk := clock.Default()
+
+	wfe, err := wfe.New(logger, clk)
 	muxHandler := wfe.Handler()
 
 	srv := &http.Server{

--- a/va/va.go
+++ b/va/va.go
@@ -1,0 +1,162 @@
+package va
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/jmhodges/clock"
+	"github.com/letsencrypt/pebble/acme"
+	"github.com/letsencrypt/pebble/core"
+)
+
+const (
+	maxRedirect      = 10
+	whitespaceCutset = "\n\r\t"
+	userAgentBase    = "LetsEncrypt-Pebble-VA"
+
+	// How long do valid authorizations last before expiring?
+	validAuthzExpire = time.Hour
+)
+
+func userAgent() string {
+	return fmt.Sprintf(
+		"%s (%s; %s)",
+		userAgentBase, runtime.GOOS, runtime.GOARCH)
+}
+
+type VAImpl struct {
+	log *log.Logger
+	clk clock.Clock
+}
+
+func NewVA(log *log.Logger, clk clock.Clock) *VAImpl {
+	return &VAImpl{
+		log: log,
+		clk: clk,
+	}
+}
+
+func (va VAImpl) Validate(identifier string, chal *core.Challenge) error {
+	// TODO(@cpu): Implement validation for DNS-01, TLS-SNI-02, etc
+	var prob *acme.ProblemDetails
+	switch chal.Type {
+	case acme.ChallengeHTTP01:
+		prob = va.validateHTTP01(identifier, chal)
+	default:
+		return fmt.Errorf("Invalid challenge type: %q", chal.Type)
+	}
+
+	authz := chal.Authz
+	now := va.clk.Now()
+	// Update the validated date for the challenge regardless of good/bad outcome
+	chal.ValidatedDate = now
+	chal.Validated = chal.ValidatedDate.String()
+	if prob != nil {
+		// Update the challenge Error
+		chal.Error = *prob
+		// Set the challenge and authorization to invalid
+		chal.Status = acme.StatusInvalid
+		authz.Status = acme.StatusInvalid
+	} else {
+		// Update the expiry for the valid authorization
+		authz.ExpiresDate = now.Add(validAuthzExpire)
+		authz.Expires = authz.ExpiresDate.String()
+		// Set the authorization & challenge to valid
+		chal.Status = acme.StatusValid
+		authz.Status = acme.StatusValid
+	}
+
+	return nil
+}
+
+func (va VAImpl) validateHTTP01(identifier string, chal *core.Challenge) *acme.ProblemDetails {
+	body, err := va.fetchHTTP(identifier, chal)
+	if err != nil {
+		return err
+	}
+
+	// The server SHOULD ignore whitespace characters at the end of the body
+	payload := strings.TrimRight(string(body), whitespaceCutset)
+	if payload != chal.ProvidedKeyAuthorization {
+		return acme.UnauthorizedProblem(
+			fmt.Sprintf("The key authorization file from the server did not match this challenge %q != %q",
+				chal.ProvidedKeyAuthorization, payload))
+	}
+
+	return nil
+}
+
+// NOTE(@cpu): fetchHTTP only fetches the ACME HTTP-01 challenge path for
+// a given challenge & identifier domain. It is not a challenge agnostic general
+// purpose HTTP function
+func (va VAImpl) fetchHTTP(identifier string, chal *core.Challenge) ([]byte, *acme.ProblemDetails) {
+	path := fmt.Sprintf("%s%s", acme.HTTP01BaseURL, chal.Token)
+
+	url := &url.URL{
+		Scheme: "http",
+		Host:   chal.Authz.Identifier.Value,
+		Path:   path,
+	}
+
+	va.log.Printf("Attempting to validate %s: %s\n", chal.Type, url)
+	httpRequest, err := http.NewRequest("GET", url.String(), nil)
+	if err != nil {
+		return nil, acme.MalformedProblem(
+			fmt.Sprintf("Invalid URL %q\n", url.String()))
+	}
+	httpRequest.Header.Set("User-Agent", userAgent())
+	httpRequest.Header.Set("Accept", "*/*")
+
+	transport := &http.Transport{
+		// We don't expect to make multiple requests to a client, so close
+		// connection immediately.
+		DisableKeepAlives: true,
+	}
+
+	// TODO(@cpu) - should this be made to match Boulder more closely?
+	//              does the spec have constraints/guidance here?
+	logRedirect := func(req *http.Request, via []*http.Request) error {
+		if len(via) > maxRedirect {
+			return fmt.Errorf("Maximum redirects (%d) exceeded", maxRedirect)
+		}
+		return nil
+	}
+
+	client := &http.Client{
+		Transport:     transport,
+		CheckRedirect: logRedirect,
+		// TODO(@cpu) - configurable http timeout?
+		Timeout: time.Second * 5,
+	}
+
+	resp, err := client.Do(httpRequest)
+	if err != nil {
+		return nil, acme.ConnectionProblem(err.Error())
+	}
+
+	// NOTE: This is *not* using a `io.LimitedReader` and isn't suitable for
+	// production because a very large response will bog down the server. Don't
+	// use Pebble anywhere that isn't a testing rig!!!
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, acme.InternalErrorProblem(err.Error())
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		return nil, acme.InternalErrorProblem(err.Error())
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, acme.UnauthorizedProblem(
+			fmt.Sprintf("Non-200 status code from HTTP: %s returned %d",
+				url.String(), resp.StatusCode))
+	}
+
+	return body, nil
+}

--- a/va/va.go
+++ b/va/va.go
@@ -120,8 +120,7 @@ func (va VAImpl) fetchHTTP(identifier string, chal *core.Challenge) ([]byte, *ac
 
 	client := &http.Client{
 		Transport: transport,
-		// TODO(@cpu) - configurable http timeout?
-		Timeout: time.Second * 5,
+		Timeout:   time.Second * 5,
 	}
 
 	resp, err := client.Do(httpRequest)

--- a/va/va.go
+++ b/va/va.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	maxRedirect      = 10
 	whitespaceCutset = "\n\r\t"
 	userAgentBase    = "LetsEncrypt-Pebble-VA"
 
@@ -119,18 +118,8 @@ func (va VAImpl) fetchHTTP(identifier string, chal *core.Challenge) ([]byte, *ac
 		DisableKeepAlives: true,
 	}
 
-	// TODO(@cpu) - should this be made to match Boulder more closely?
-	//              does the spec have constraints/guidance here?
-	logRedirect := func(req *http.Request, via []*http.Request) error {
-		if len(via) > maxRedirect {
-			return fmt.Errorf("Maximum redirects (%d) exceeded", maxRedirect)
-		}
-		return nil
-	}
-
 	client := &http.Client{
-		Transport:     transport,
-		CheckRedirect: logRedirect,
+		Transport: transport,
 		// TODO(@cpu) - configurable http timeout?
 		Timeout: time.Second * 5,
 	}

--- a/wfe/memorystore.go
+++ b/wfe/memorystore.go
@@ -51,6 +51,10 @@ func (m *memoryStore) addRegistration(reg *core.Registration) (int, error) {
 		return 0, fmt.Errorf("registration must have a non-empty ID to add to memoryStore")
 	}
 
+	if reg.Key == nil {
+		return 0, fmt.Errorf("registration must not have a nil Key")
+	}
+
 	if _, present := m.registrationsByID[regID]; present {
 		return 0, fmt.Errorf("registration %q already exists", regID)
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -18,8 +18,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/pebble/acme"
 	"github.com/letsencrypt/pebble/core"
+	"github.com/letsencrypt/pebble/va"
 	"gopkg.in/square/go-jose.v1"
 )
 
@@ -34,6 +36,9 @@ const (
 	orderPath     = "/my-order/"
 	authzPath     = "/authZ/"
 	challengePath = "/chalZ/"
+
+	// How long do pending authorizations last before expiring?
+	pendingAuthzExpire = time.Hour
 )
 
 type requestEvent struct {
@@ -73,15 +78,19 @@ type WebFrontEndImpl struct {
 	log   *log.Logger
 	db    *memoryStore
 	nonce *nonceMap
+	clk   clock.Clock
+	va    *va.VAImpl
 }
 
 const ToSURL = "data:text/plain,Do%20what%20thou%20wilt"
 
-func New(log *log.Logger) (WebFrontEndImpl, error) {
+func New(log *log.Logger, clk clock.Clock) (WebFrontEndImpl, error) {
 	return WebFrontEndImpl{
 		log:   log,
 		db:    newMemoryStore(),
 		nonce: newNonceMap(),
+		clk:   clk,
+		va:    va.NewVA(log, clk),
 	}, nil
 }
 
@@ -153,7 +162,7 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	wfe.HandleFunc(m, newOrderPath, wfe.NewOrder, "POST")
 	wfe.HandleFunc(m, orderPath, wfe.Order, "GET")
 	wfe.HandleFunc(m, authzPath, wfe.Authz, "GET")
-	wfe.HandleFunc(m, challengePath, wfe.Challenge, "GET")
+	wfe.HandleFunc(m, challengePath, wfe.Challenge, "GET", "POST")
 
 	// TODO(@cpu): Handle regPath for existing reg updates
 	return m
@@ -375,6 +384,7 @@ func (wfe *WebFrontEndImpl) NewRegistration(
 	createdReg := core.Registration{
 		Registration: newReg,
 	}
+	createdReg.Key = key
 
 	regID, err := keyToID(key)
 	if err != nil {
@@ -455,11 +465,15 @@ func (wfe *WebFrontEndImpl) makeAuthorizations(order *core.Order, request *http.
 			Type:  acme.IdentifierDNS,
 			Value: name,
 		}
+		now := wfe.clk.Now()
+		expires := now.Add(pendingAuthzExpire)
 		authz := &core.Authorization{
-			ID: newToken(),
+			ID:          newToken(),
+			ExpiresDate: expires,
 			Authorization: acme.Authorization{
 				Status:     acme.StatusPending,
 				Identifier: ident,
+				Expires:    expires.String(),
 			},
 		}
 		authz.URL = wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", authzPath, authz.ID))
@@ -491,11 +505,14 @@ func (wfe *WebFrontEndImpl) makeChallenges(authz *core.Authorization, request *h
 	chal := &core.Challenge{
 		ID: newToken(),
 		Challenge: acme.Challenge{
-			Type:  acme.ChallengeHTTP01,
-			Token: newToken(),
-			URL:   authz.URL,
+			Type:   acme.ChallengeHTTP01,
+			Token:  newToken(),
+			URL:    authz.URL,
+			Status: acme.StatusPending,
 		},
+		Authz: authz,
 	}
+
 	count, err := wfe.db.addChallenge(chal)
 	if err != nil {
 		return err
@@ -660,6 +677,20 @@ func (wfe *WebFrontEndImpl) Challenge(
 	response http.ResponseWriter,
 	request *http.Request) {
 
+	if request.Method == "POST" {
+		wfe.updateChallenge(ctx, logEvent, response, request)
+		return
+	}
+
+	wfe.getChallenge(ctx, logEvent, response, request)
+}
+
+func (wfe *WebFrontEndImpl) getChallenge(
+	ctx context.Context,
+	logEvent *requestEvent,
+	response http.ResponseWriter,
+	request *http.Request) {
+
 	chalID := strings.TrimPrefix(request.URL.Path, challengePath)
 	chal := wfe.db.getChallengeByID(chalID)
 	if chal == nil {
@@ -670,6 +701,120 @@ func (wfe *WebFrontEndImpl) Challenge(
 	err := wfe.writeJsonResponse(response, http.StatusOK, chal.Challenge)
 	if err != nil {
 		wfe.sendError(acme.InternalErrorProblem("Error marshalling challenge"), response)
+		return
+	}
+}
+
+func (wfe *WebFrontEndImpl) updateChallenge(
+	ctx context.Context,
+	logEvent *requestEvent,
+	response http.ResponseWriter,
+	request *http.Request) {
+
+	body, key, prob := wfe.verifyPOST(ctx, logEvent, request, acme.ResourceChallenge)
+	if prob != nil {
+		wfe.sendError(prob, response)
+		return
+	}
+
+	// Compute the registration ID for the signer's key
+	regID, err := keyToID(key)
+	if err != nil {
+		wfe.log.Printf("keyToID err: %s\n", err.Error())
+		wfe.sendError(acme.MalformedProblem("Error computing key digest"), response)
+		return
+	}
+	wfe.log.Printf("received update-challenge req from reg ID %s\n", regID)
+
+	// Find the existing registration object for that key ID
+	var existingReg *core.Registration
+	if existingReg = wfe.db.getRegistrationByID(regID); existingReg == nil {
+		wfe.sendError(
+			acme.MalformedProblem("No existing registration for signer's public key"),
+			response)
+		return
+	}
+
+	var chalResp acme.Challenge
+	err = json.Unmarshal(body, &chalResp)
+	if err != nil {
+		wfe.sendError(
+			acme.MalformedProblem("Error unmarshaling body JSON"), response)
+		return
+	}
+
+	chalID := strings.TrimPrefix(request.URL.Path, challengePath)
+	existingChal := wfe.db.getChallengeByID(chalID)
+	if existingChal == nil {
+		response.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if existingChal.Authz == nil {
+		wfe.sendError(
+			acme.InternalErrorProblem("challenge missing associated authz"), response)
+		return
+	}
+
+	ident := existingChal.Authz.Identifier
+	if ident.Type != acme.IdentifierDNS {
+		wfe.sendError(
+			acme.MalformedProblem(
+				fmt.Sprintf("Authorization identifier was type %s, only %s is supported",
+					ident.Type, acme.IdentifierDNS)), response)
+		return
+	}
+
+	now := wfe.clk.Now()
+	if existingChal.Authz.ExpiresDate.After(now) {
+		wfe.sendError(
+			acme.MalformedProblem(fmt.Sprintf("Authorization expired %s", existingChal.Authz.Expires)), response)
+		return
+	}
+
+	// Check that the challenge response is the same type as the challenge
+	// NOTE: Boulder doesn't do this at the time of writing and instead increments
+	//       a "StartChallengeWrongType" stat
+	if chalResp.Type != existingChal.Type {
+		wfe.sendError(
+			acme.MalformedProblem(
+				fmt.Sprintf("Challenge update was type %s, existing challenge is type %s",
+					chalResp.Type, existingChal.Type)), response)
+		return
+	}
+
+	// Check that the existing challenge is Pending
+	if existingChal.Status != acme.StatusPending {
+		wfe.sendError(
+			acme.MalformedProblem(
+				fmt.Sprintf("Cannot update challenge with status %s, only status %s",
+					existingChal.Status, acme.StatusPending)), response)
+		return
+	}
+
+	// Calculate the expected key authorization for the owning registration's key
+	expectedKeyAuth, err := existingChal.ExpectedKeyAuthorization(existingReg.Key)
+	if err != nil {
+		wfe.sendError(
+			acme.InternalErrorProblem(
+				fmt.Sprintf("Unable to create expected key auth: %q", err)), response)
+		return
+	}
+
+	// Validate the expected key auth matches the provided key auth
+	if expectedKeyAuth != chalResp.ProvidedKeyAuthorization {
+		wfe.sendError(
+			acme.MalformedProblem(
+				fmt.Sprintf("Incorrect key authorization: %q",
+					chalResp.ProvidedKeyAuthorization)), response)
+		return
+	}
+
+	err = wfe.va.Validate(ident.Value, existingChal)
+	if err != nil {
+		wfe.sendError(
+			acme.InternalErrorProblem(
+				fmt.Sprintf("Failed to validate challenge: %q", err)), response)
 		return
 	}
 }


### PR DESCRIPTION
This commit adds initial support for HTTP-01 challenge validation. No
other challenge types are implemented at this time.

The implementation is largely a pared down version of what Boulder does
presently. For simplicities sake there are a number of important
differences that make Pebble *absolutely* unappropriate for production
uses:
  1) The validation is performed in the same goroutine as the WFE's HTTP
     handler instead of in a separate go routine. It might be worth
     revamping this in the near future.
  2) There is no read limit on the HTTP request body and timeouts are
     not as strict
  3) The validity of both pending and valid authzs is hardcoded at 1h.

As compared to Boulder the Pebble challenge design chooses to use
a separate endpoint (e.g. `/chalZ/9999` for chal 9999) instead of
referring to challenges subindexed from authorizations (e.g.
`/authZ/9999/1` for the first challenge of authz 9999). I believe this
is still within compliance with the overall specification and will
further exercise clients to not expect Boulder's choices to be
universal. The pebble client is updated to allow specifying a URL
to POST in addition to a directory endpoint to allow POSTing these
separate non-directory defined challenge URLs.