### PR TITLE
More validation fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,11 @@ language: go
 
 go:
   - 1.8
+
+before_install:
+  - git clone -b acme-v2 https://github.com/certbot/certbot
+  - cd certbot
+  - letsencrypt-auto-source/letsencrypt-auto --os-packages-only
+  - ./tools/venv.sh
+  - . venv/bin/activate
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,3 @@ language: go
 
 go:
   - 1.8
-
-before_install:
-  - git clone -b acme-v2 https://github.com/certbot/certbot
-  - cd certbot
-  - letsencrypt-auto-source/letsencrypt-auto --os-packages-only
-  - ./tools/venv.sh
-  - . venv/bin/activate
-

--- a/acme/common.go
+++ b/acme/common.go
@@ -57,11 +57,16 @@ type Authorization struct {
 
 // A Challenge is used to validate an Authorization
 type Challenge struct {
-	Type                     string          `json:"type"`
-	URI                      string          `json:"uri"`
-	Token                    string          `json:"token"`
-	Status                   string          `json:"status"`
-	Validated                string          `json:"validated,omitempty"`
-	ProvidedKeyAuthorization string          `json:"keyAuthorization,omitempty"`
-	Error                    *ProblemDetails `json:"error,omitempty"`
+	Type              string `json:"type"`
+	URI               string `json:"uri"`
+	Token             string `json:"token"`
+	Status            string `json:"status"`
+	Validated         string `json:"validated,omitempty"`
+	ValidationRecords []ValidationRecord
+	KeyAuthorization  string          `json:"keyAuthorization,omitempty"`
+	Error             *ProblemDetails `json:"error,omitempty"`
+}
+
+type ValidationRecord struct {
+	URL string
 }

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/pebble/cmd"
+	"github.com/letsencrypt/pebble/va"
 	"github.com/letsencrypt/pebble/wfe"
 )
 
 type config struct {
 	Pebble struct {
 		ListenAddress string
+		HTTPPort      int
 	}
 }
 
@@ -37,7 +39,8 @@ func main() {
 
 	clk := clock.Default()
 
-	wfe, err := wfe.New(logger, clk)
+	va := va.New(logger, clk, c.Pebble.HTTPPort)
+	wfe, err := wfe.New(logger, clk, va)
 	muxHandler := wfe.Handler()
 
 	srv := &http.Server{

--- a/core/types.go
+++ b/core/types.go
@@ -4,7 +4,6 @@ import (
 	"crypto"
 	"crypto/x509"
 	"encoding/base64"
-	"fmt"
 	"time"
 
 	"github.com/letsencrypt/pebble/acme"
@@ -37,15 +36,15 @@ type Challenge struct {
 	ValidatedDate time.Time
 }
 
-func (ch Challenge) ExpectedKeyAuthorization(key *jose.JSONWebKey) (string, error) {
+func (ch Challenge) ExpectedKeyAuthorization(key *jose.JSONWebKey) string {
 	if key == nil {
-		return "", fmt.Errorf("Cannot authorize a nil key")
+		panic("ExpectedKeyAuthorization called with nil key")
 	}
 
 	thumbprint, err := key.Thumbprint(crypto.SHA256)
 	if err != nil {
-		return "", err
+		panic("ExpectedKeyAuthorization: " + err.Error())
 	}
 
-	return ch.Token + "." + base64.RawURLEncoding.EncodeToString(thumbprint), nil
+	return ch.Token + "." + base64.RawURLEncoding.EncodeToString(thumbprint)
 }

--- a/test/config/pebble-config.json
+++ b/test/config/pebble-config.json
@@ -1,5 +1,6 @@
 {
   "pebble": {
-    "listenAddress": "0.0.0.0:14000"
+    "listenAddress": "0.0.0.0:14000",
+    "httpPort": 5002
   }
 }


### PR DESCRIPTION
Add an HTTPPort config and plumb it through.
Calculate the KeyAuthorization based on regID, rather than storing it on
challenge (wasn't getting stored previously).
Show URL in validation records for ease of debugging.