### PR TITLE
Certificate issuance

### DIFF
--- a/acme/common.go
+++ b/acme/common.go
@@ -12,9 +12,10 @@ const (
 )
 
 const (
-	StatusPending = "pending"
-	StatusInvalid = "invalid"
-	StatusValid   = "valid"
+	StatusPending    = "pending"
+	StatusInvalid    = "invalid"
+	StatusValid      = "valid"
+	StatusProcessing = "processing"
 
 	IdentifierDNS = "dns"
 
@@ -49,10 +50,10 @@ type Order struct {
 
 // An Authorization is created for each identifier in an order
 type Authorization struct {
-	Status     string      `json:"status"`
-	Identifier Identifier  `json:"identifier"`
-	Challenges []Challenge `json:"challenges"`
-	Expires    string      `json:"expires"`
+	Status     string       `json:"status"`
+	Identifier Identifier   `json:"identifier"`
+	Challenges []*Challenge `json:"challenges"`
+	Expires    string       `json:"expires"`
 }
 
 // A Challenge is used to validate an Authorization

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -1,0 +1,214 @@
+package ca
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"math"
+	"math/big"
+	"time"
+
+	"github.com/letsencrypt/pebble/core"
+	"github.com/letsencrypt/pebble/db"
+)
+
+const (
+	rootCAPrefix         = "Pebble Root CA "
+	intermediateCAPrefix = "Pebble Intermediate CA "
+)
+
+type CAImpl struct {
+	log *log.Logger
+	db  *db.MemoryStore
+
+	root         *issuer
+	intermediate *issuer
+}
+
+type issuer struct {
+	key  crypto.Signer
+	cert *core.Certificate
+}
+
+func makeSerial() *big.Int {
+	serial, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		panic(fmt.Sprintf("unable to create random serial number: %s", err.Error()))
+	}
+	return serial
+}
+
+// makeKey and makeRootCert are adapted from MiniCA:
+// https://github.com/jsha/minica/blob/3a621c05b61fa1c24bcb42fbde4b261db504a74f/main.go
+
+// makeKey creates a new 2048 bit RSA private key
+func makeKey() (*rsa.PrivateKey, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func (ca *CAImpl) makeRootCert(
+	subjectKey crypto.Signer,
+	subjCNPrefix string,
+	signer *issuer) (*core.Certificate, error) {
+
+	serial := makeSerial()
+	template := &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: subjCNPrefix + hex.EncodeToString(serial.Bytes()[:3]),
+		},
+		SerialNumber: serial,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(30, 0, 0),
+
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:           true,
+		MaxPathLenZero: true,
+	}
+
+	var signerKey crypto.Signer
+	if signer != nil && signer.key != nil {
+		signerKey = signer.key
+	} else {
+		signerKey = subjectKey
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, subjectKey.Public(), signerKey)
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, err
+	}
+
+	hexSerial := hex.EncodeToString(cert.SerialNumber.Bytes())
+	newCert := &core.Certificate{
+		ID:   hexSerial,
+		Cert: cert,
+		DER:  der,
+	}
+	if signer != nil && signer.cert != nil {
+		newCert.Issuer = signer.cert
+	}
+	_, err = ca.db.AddCertificate(newCert)
+	if err != nil {
+		return nil, err
+	}
+	return newCert, nil
+}
+
+func (ca *CAImpl) newRootIssuer() {
+	// Make a root private key
+	rk, err := makeKey()
+	if err != nil {
+		panic(fmt.Sprintf("Unable to create a new root private key: %s", err.Error()))
+	}
+	// Make a self-signed root certificate
+	rc, err := ca.makeRootCert(rk, rootCAPrefix, nil)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to create a new root certificate: %s", err.Error()))
+	}
+
+	ca.root = &issuer{
+		key:  rk,
+		cert: rc,
+	}
+	ca.log.Printf("Generated new root issuer with serial %s\n", rc.ID)
+}
+
+func (ca *CAImpl) newIntermediateIssuer() {
+	if ca.root == nil {
+		panic("error: newIntermediateIssuer() called before newRootIssuer()")
+	}
+
+	// Make an intermediate private key
+	ik, err := makeKey()
+	if err != nil {
+		panic(fmt.Sprintf(
+			"Unable to create a new intermediate private key: %s", err.Error()))
+	}
+
+	// Make an intermediate certificate with the root issuer
+	ic, err := ca.makeRootCert(ik, intermediateCAPrefix, ca.root)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to create a new intermediate certificate: %s", err.Error()))
+	}
+	ca.intermediate = &issuer{
+		key:  ik,
+		cert: ic,
+	}
+	ca.log.Printf("Generated new intermediate issuer with serial %s\n", ic.ID)
+}
+
+func (ca *CAImpl) NewCertificate(domains []string, key crypto.PublicKey) (*core.Certificate, error) {
+	var cn string
+	if len(domains) > 0 {
+		cn = domains[0]
+	} else {
+		return nil, fmt.Errorf("must specify at least one domain name")
+	}
+
+	issuer := ca.intermediate
+	if issuer == nil || issuer.cert == nil {
+		return nil, fmt.Errorf("cannot sign certificate - nil issuer")
+	}
+
+	serial := makeSerial()
+	template := &x509.Certificate{
+		DNSNames: domains,
+		Subject: pkix.Name{
+			CommonName: cn,
+		},
+		SerialNumber: serial,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(5, 0, 0),
+
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA: false,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, issuer.cert.Cert, key, issuer.key)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, err
+	}
+
+	hexSerial := hex.EncodeToString(cert.SerialNumber.Bytes())
+	newCert := &core.Certificate{
+		ID:     hexSerial,
+		Cert:   cert,
+		DER:    der,
+		Issuer: issuer.cert,
+	}
+	_, err = ca.db.AddCertificate(newCert)
+	if err != nil {
+		return nil, err
+	}
+	return newCert, nil
+}
+
+func New(log *log.Logger, db *db.MemoryStore) *CAImpl {
+	ca := &CAImpl{
+		log: log,
+		db:  db,
+	}
+	ca.newRootIssuer()
+	ca.newIntermediateIssuer()
+	return ca
+}

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -7,7 +7,9 @@ import (
 	"os"
 
 	"github.com/jmhodges/clock"
+	"github.com/letsencrypt/pebble/ca"
 	"github.com/letsencrypt/pebble/cmd"
+	"github.com/letsencrypt/pebble/db"
 	"github.com/letsencrypt/pebble/va"
 	"github.com/letsencrypt/pebble/wfe"
 )
@@ -38,9 +40,10 @@ func main() {
 	cmd.FailOnError(err, "Reading JSON config file into config structure")
 
 	clk := clock.Default()
-
+	db := db.NewMemoryStore()
 	va := va.New(logger, clk, c.Pebble.HTTPPort)
-	wfe, err := wfe.New(logger, clk, va)
+	ca := ca.New(logger, db)
+	wfe := wfe.New(logger, clk, db, va, ca)
 	muxHandler := wfe.Handler()
 
 	srv := &http.Server{

--- a/core/types.go
+++ b/core/types.go
@@ -86,8 +86,8 @@ func (c Certificate) Chain() []byte {
 	// Add zero or more issuers
 	issuer := c.Issuer
 	for {
-		// if the issuer is nil, or the issuer's issuer is nil then it isn't a leaf
-		// or an intermediate. Don't put it in the chain
+		// if the issuer is nil, or the issuer's issuer is nil then we've reached
+		// the root of the chain and can break
 		if issuer == nil || issuer.Issuer == nil {
 			break
 		}
@@ -96,5 +96,5 @@ func (c Certificate) Chain() []byte {
 	}
 
 	// Return the chain, leaf cert first
-	return bytes.Join(chain, []byte{})
+	return bytes.Join(chain, nil)
 }

--- a/core/types.go
+++ b/core/types.go
@@ -1,9 +1,12 @@
 package core
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
+	"fmt"
 	"time"
 
 	"github.com/letsencrypt/pebble/acme"
@@ -12,8 +15,10 @@ import (
 
 type Order struct {
 	acme.Order
-	ID        string
-	ParsedCSR *x509.CertificateRequest
+	ID                   string
+	ParsedCSR            *x509.CertificateRequest
+	ExpiresDate          time.Time
+	AuthorizationObjects []*Authorization
 }
 
 type Registration struct {
@@ -27,6 +32,7 @@ type Authorization struct {
 	ID          string
 	URL         string
 	ExpiresDate time.Time
+	Order       *Order
 }
 
 type Challenge struct {
@@ -47,4 +53,48 @@ func (ch Challenge) ExpectedKeyAuthorization(key *jose.JSONWebKey) string {
 	}
 
 	return ch.Token + "." + base64.RawURLEncoding.EncodeToString(thumbprint)
+}
+
+type Certificate struct {
+	ID     string
+	Cert   *x509.Certificate
+	DER    []byte
+	Issuer *Certificate
+}
+
+func (c Certificate) PEM() []byte {
+	var buf bytes.Buffer
+
+	err := pem.Encode(&buf, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: c.DER,
+	})
+	if err != nil {
+		panic(fmt.Sprintf("Unable to encode certificate %q to PEM: %s",
+			c.ID, err.Error()))
+	}
+
+	return buf.Bytes()
+}
+
+func (c Certificate) Chain() []byte {
+	chain := make([][]byte, 0)
+
+	// Add the leaf certificate
+	chain = append(chain, c.PEM())
+
+	// Add zero or more issuers
+	issuer := c.Issuer
+	for {
+		// if the issuer is nil, or the issuer's issuer is nil then it isn't a leaf
+		// or an intermediate. Don't put it in the chain
+		if issuer == nil || issuer.Issuer == nil {
+			break
+		}
+		chain = append(chain, issuer.PEM())
+		issuer = issuer.Issuer
+	}
+
+	// Return the chain, leaf cert first
+	return bytes.Join(chain, []byte{})
 }

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -1,4 +1,4 @@
-package wfe
+package db
 
 import (
 	"fmt"
@@ -10,7 +10,7 @@ import (
 // Pebble keeps all of its various objects (registrations, orders, etc)
 // in-memory, not persisted anywhere. MemoryStore implements this in-memory
 // "database"
-type memoryStore struct {
+type MemoryStore struct {
 	sync.RWMutex
 
 	// Each Registration's ID is the hex encoding of a SHA256 sum over its public
@@ -22,18 +22,21 @@ type memoryStore struct {
 	authorizationsByID map[string]*core.Authorization
 
 	challengesByID map[string]*core.Challenge
+
+	certificatesByID map[string]*core.Certificate
 }
 
-func newMemoryStore() *memoryStore {
-	return &memoryStore{
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
 		registrationsByID:  make(map[string]*core.Registration),
 		ordersByID:         make(map[string]*core.Order),
 		authorizationsByID: make(map[string]*core.Authorization),
 		challengesByID:     make(map[string]*core.Challenge),
+		certificatesByID:   make(map[string]*core.Certificate),
 	}
 }
 
-func (m *memoryStore) getRegistrationByID(id string) *core.Registration {
+func (m *MemoryStore) GetRegistrationByID(id string) *core.Registration {
 	m.RLock()
 	defer m.RUnlock()
 	if reg, present := m.registrationsByID[id]; present {
@@ -42,13 +45,13 @@ func (m *memoryStore) getRegistrationByID(id string) *core.Registration {
 	return nil
 }
 
-func (m *memoryStore) addRegistration(reg *core.Registration) (int, error) {
+func (m *MemoryStore) AddRegistration(reg *core.Registration) (int, error) {
 	m.Lock()
 	defer m.Unlock()
 
 	regID := reg.ID
 	if len(regID) == 0 {
-		return 0, fmt.Errorf("registration must have a non-empty ID to add to memoryStore")
+		return 0, fmt.Errorf("registration must have a non-empty ID to add to MemoryStore")
 	}
 
 	if reg.Key == nil {
@@ -63,13 +66,13 @@ func (m *memoryStore) addRegistration(reg *core.Registration) (int, error) {
 	return len(m.registrationsByID), nil
 }
 
-func (m *memoryStore) addOrder(order *core.Order) (int, error) {
+func (m *MemoryStore) AddOrder(order *core.Order) (int, error) {
 	m.Lock()
 	defer m.Unlock()
 
 	orderID := order.ID
 	if len(orderID) == 0 {
-		return 0, fmt.Errorf("order must have a non-empty ID to add to memoryStore")
+		return 0, fmt.Errorf("order must have a non-empty ID to add to MemoryStore")
 	}
 
 	if _, present := m.ordersByID[orderID]; present {
@@ -80,7 +83,7 @@ func (m *memoryStore) addOrder(order *core.Order) (int, error) {
 	return len(m.ordersByID), nil
 }
 
-func (m *memoryStore) getOrderByID(id string) *core.Order {
+func (m *MemoryStore) GetOrderByID(id string) *core.Order {
 	m.RLock()
 	defer m.RUnlock()
 	if order, present := m.ordersByID[id]; present {
@@ -89,13 +92,13 @@ func (m *memoryStore) getOrderByID(id string) *core.Order {
 	return nil
 }
 
-func (m *memoryStore) addAuthorization(authz *core.Authorization) (int, error) {
+func (m *MemoryStore) AddAuthorization(authz *core.Authorization) (int, error) {
 	m.Lock()
 	defer m.Unlock()
 
 	authzID := authz.ID
 	if len(authzID) == 0 {
-		return 0, fmt.Errorf("authz must have a non-empty ID to add to memoryStore")
+		return 0, fmt.Errorf("authz must have a non-empty ID to add to MemoryStore")
 	}
 
 	if _, present := m.authorizationsByID[authzID]; present {
@@ -106,7 +109,7 @@ func (m *memoryStore) addAuthorization(authz *core.Authorization) (int, error) {
 	return len(m.authorizationsByID), nil
 }
 
-func (m *memoryStore) getAuthorizationByID(id string) *core.Authorization {
+func (m *MemoryStore) GetAuthorizationByID(id string) *core.Authorization {
 	m.RLock()
 	defer m.RUnlock()
 	if authz, present := m.authorizationsByID[id]; present {
@@ -115,13 +118,13 @@ func (m *memoryStore) getAuthorizationByID(id string) *core.Authorization {
 	return nil
 }
 
-func (m *memoryStore) addChallenge(chal *core.Challenge) (int, error) {
+func (m *MemoryStore) AddChallenge(chal *core.Challenge) (int, error) {
 	m.Lock()
 	defer m.Unlock()
 
 	chalID := chal.ID
 	if len(chalID) == 0 {
-		return 0, fmt.Errorf("challenge must have a non-empty ID to add to memoryStore")
+		return 0, fmt.Errorf("challenge must have a non-empty ID to add to MemoryStore")
 	}
 
 	if _, present := m.challengesByID[chalID]; present {
@@ -132,11 +135,37 @@ func (m *memoryStore) addChallenge(chal *core.Challenge) (int, error) {
 	return len(m.challengesByID), nil
 }
 
-func (m *memoryStore) getChallengeByID(id string) *core.Challenge {
+func (m *MemoryStore) GetChallengeByID(id string) *core.Challenge {
 	m.RLock()
 	defer m.RUnlock()
 	if chal, present := m.challengesByID[id]; present {
 		return chal
+	}
+	return nil
+}
+
+func (m *MemoryStore) AddCertificate(cert *core.Certificate) (int, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	certID := cert.ID
+	if len(certID) == 0 {
+		return 0, fmt.Errorf("cert must have a non-empty ID to add to MemoryStore")
+	}
+
+	if _, present := m.certificatesByID[certID]; present {
+		return 0, fmt.Errorf("cert %q already exists", certID)
+	}
+
+	m.certificatesByID[certID] = cert
+	return len(m.certificatesByID), nil
+}
+
+func (m *MemoryStore) GetCertificateByID(id string) *core.Certificate {
+	m.RLock()
+	defer m.RUnlock()
+	if cert, present := m.certificatesByID[id]; present {
+		return cert
 	}
 	return nil
 }

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -39,10 +39,7 @@ func NewMemoryStore() *MemoryStore {
 func (m *MemoryStore) GetRegistrationByID(id string) *core.Registration {
 	m.RLock()
 	defer m.RUnlock()
-	if reg, present := m.registrationsByID[id]; present {
-		return reg
-	}
-	return nil
+	return m.registrationsByID[id]
 }
 
 func (m *MemoryStore) AddRegistration(reg *core.Registration) (int, error) {
@@ -86,10 +83,7 @@ func (m *MemoryStore) AddOrder(order *core.Order) (int, error) {
 func (m *MemoryStore) GetOrderByID(id string) *core.Order {
 	m.RLock()
 	defer m.RUnlock()
-	if order, present := m.ordersByID[id]; present {
-		return order
-	}
-	return nil
+	return m.ordersByID[id]
 }
 
 func (m *MemoryStore) AddAuthorization(authz *core.Authorization) (int, error) {
@@ -112,10 +106,7 @@ func (m *MemoryStore) AddAuthorization(authz *core.Authorization) (int, error) {
 func (m *MemoryStore) GetAuthorizationByID(id string) *core.Authorization {
 	m.RLock()
 	defer m.RUnlock()
-	if authz, present := m.authorizationsByID[id]; present {
-		return authz
-	}
-	return nil
+	return m.authorizationsByID[id]
 }
 
 func (m *MemoryStore) AddChallenge(chal *core.Challenge) (int, error) {
@@ -138,10 +129,7 @@ func (m *MemoryStore) AddChallenge(chal *core.Challenge) (int, error) {
 func (m *MemoryStore) GetChallengeByID(id string) *core.Challenge {
 	m.RLock()
 	defer m.RUnlock()
-	if chal, present := m.challengesByID[id]; present {
-		return chal
-	}
-	return nil
+	return m.challengesByID[id]
 }
 
 func (m *MemoryStore) AddCertificate(cert *core.Certificate) (int, error) {
@@ -164,8 +152,5 @@ func (m *MemoryStore) AddCertificate(cert *core.Certificate) (int, error) {
 func (m *MemoryStore) GetCertificateByID(id string) *core.Certificate {
 	m.RLock()
 	defer m.RUnlock()
-	if cert, present := m.certificatesByID[id]; present {
-		return cert
-	}
-	return nil
+	return m.certificatesByID[id]
 }

--- a/va/va.go
+++ b/va/va.go
@@ -64,6 +64,7 @@ func (va VAImpl) Validate(identifier string, chal *core.Challenge, reg *core.Reg
 		// Set the challenge and authorization to invalid
 		chal.Status = acme.StatusInvalid
 		authz.Status = acme.StatusInvalid
+		va.log.Printf("authz %s set INVALID by completed challenge %s", authz.ID, chal.ID)
 	} else {
 		// Update the expiry for the valid authorization
 		authz.ExpiresDate = now.Add(validAuthzExpire)
@@ -71,6 +72,7 @@ func (va VAImpl) Validate(identifier string, chal *core.Challenge, reg *core.Reg
 		// Set the authorization & challenge to valid
 		chal.Status = acme.StatusValid
 		authz.Status = acme.StatusValid
+		va.log.Printf("authz %s set VALID by completed challenge %s", authz.ID, chal.ID)
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds the initial CA skeleton for doing order issuance.

Pebble generates a root & intermediate keypair/certificate at startup. The intermediate is used for certificate signing purposes and the root issues the intermediate and is otherwise just there to mimick production. In the future we should introduce additional intermediates & chain options to use the full specification. 

Couple other changes:
* Fixed the embedded challenges in authorizations to use a pointer so that the embedded contents are updated when the challenge is completed.
* Replaced a few WFE `Printf`'s with log statements.
* Updated the VA to log whether an HTTP validation was a success or a failure.
* Added a pointer from Authorizations to the Order they belong to
* Added enforcement of Order expiry for authz updates.
* Moved the MemoryStore out of the `wfe` package. This was primarily to let the CA store the root & intermediate certificates in the DB. This allows using the `/certZ/` endpoint to retrieve the root & intermediate. 