### PR TITLE
Multi-validation & true async issuance

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,19 @@ randomize keys/certificates used for issuance.
 
 Pebble aims to address the need for ACME clients to have an easier to use,
 self-contained version of Boulder to test their clients against while developing
-ACME-04 support. Boulder is multi-process, requires heavy dependencies (MariaDB,
+ACME-06 support. Boulder is multi-process, requires heavy dependencies (MariaDB,
 RabbitMQ, etc), and is operationally complex to integrate with other projects.
 
 Where possible Pebble aims to produce code that can be used to inform the
 pending Boulder support for ACME-06, through contribution of code as well as
 design lessons learned. Development of Pebble is meant to be rapid, and to
 produce a minimum working prototype on a short schedule.
+
+In places where the ACME specification allows customization/CA choice Pebble
+aims to make choices different from Boulder. For instance, Pebble changes the
+path structures for its resources and directory endpoints to differ from
+Boulder. The goal is to emphasize client specification compatibility and to
+avoid "over-fitting" on Boulder and the Let's Encrypt production service.
 
 Lastly, Pebble will enforce it's test-only usage by aggressively building in
 guardrails that make using it in a production setting impossible or very
@@ -48,3 +54,17 @@ clients are not hardcoding URLs.)
 ## Usage
 
 `pebble -config ./test/config/pebble-config.json`
+
+## Issuance
+
+The easiest way to test issue with Pebble is to use `chisel2` from the
+`acme-v2` certbot branch (this is a work in progress).
+
+1. `git clone -b acme-v2 https://github.com/certbot/certbot`
+2. `cd certbot`
+3. `letsencrypt-auto-source/letsencrypt-auto --os-packages-only`
+4. `./tools/venv.sh`
+5. `. venev/bin/activate`
+6. `python ./certbot/tools/chisel2.py example.com`
+
+

--- a/acme/common.go
+++ b/acme/common.go
@@ -58,16 +58,11 @@ type Authorization struct {
 
 // A Challenge is used to validate an Authorization
 type Challenge struct {
-	Type              string `json:"type"`
-	URI               string `json:"uri"`
-	Token             string `json:"token"`
-	Status            string `json:"status"`
-	Validated         string `json:"validated,omitempty"`
-	ValidationRecords []ValidationRecord
-	KeyAuthorization  string          `json:"keyAuthorization,omitempty"`
-	Error             *ProblemDetails `json:"error,omitempty"`
-}
-
-type ValidationRecord struct {
-	URL string
+	Type             string          `json:"type"`
+	URI              string          `json:"uri"`
+	Token            string          `json:"token"`
+	Status           string          `json:"status"`
+	Validated        string          `json:"validated,omitempty"`
+	KeyAuthorization string          `json:"keyAuthorization,omitempty"`
+	Error            *ProblemDetails `json:"error,omitempty"`
 }

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -240,19 +240,17 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 	order.Status = acme.StatusProcessing
 
 	csr := order.ParsedCSR
-	domains := make([]string, len(csr.DNSNames))
-	copy(domains, csr.DNSNames)
-
 	// issue a certificate for the csr
-	cert, err := ca.newCertificate(domains, csr.PublicKey)
+	cert, err := ca.newCertificate(csr.DNSNames, csr.PublicKey)
 	if err != nil {
 		ca.log.Printf("Error: unable to issue order: %s", err.Error())
 		return
 	}
 	ca.log.Printf("Issued certificate serial %s\n", cert.ID)
 
-	// Update the order to valid status with a certificate URL
+	// Update the order to valid status and store a cert ID for the wfe to use to
+	// render the certificate URL for the order
 	order.Status = acme.StatusValid
-	order.Certificate = order.CertPathPrefix + cert.ID
+	order.CertID = cert.ID
 	ca.log.Printf("Order %s has Certificate %s", order.ID, order.Certificate)
 }

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -258,5 +258,5 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 	// Update the order to valid status and store a cert ID for the wfe to use to
 	// render the certificate URL for the order
 	order.Status = acme.StatusValid
-	order.CertID = cert.ID
+	order.CertificateObject = cert
 }

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -230,7 +230,7 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 	}
 
 	if order.Status != acme.StatusPending {
-		ca.log.Printf("Error: Asked to complete orrder %s is not status pending, was status %s",
+		ca.log.Printf("Error: Asked to complete order %s is not status pending, was status %s",
 			order.ID, order.Status)
 		return
 	}

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -41,9 +41,9 @@ func main() {
 
 	clk := clock.Default()
 	db := db.NewMemoryStore()
-	va := va.New(logger, clk, c.Pebble.HTTPPort)
 	ca := ca.New(logger, db)
-	wfe := wfe.New(logger, clk, db, va, ca)
+	va := va.New(logger, clk, c.Pebble.HTTPPort, ca)
+	wfe := wfe.New(logger, clk, db, va)
 	muxHandler := wfe.Handler()
 
 	srv := &http.Server{

--- a/core/types.go
+++ b/core/types.go
@@ -21,7 +21,7 @@ type Order struct {
 	ParsedCSR            *x509.CertificateRequest
 	ExpiresDate          time.Time
 	AuthorizationObjects []*Authorization
-	CertID               string
+	CertificateObject    *Certificate
 }
 
 type Registration struct {

--- a/core/types.go
+++ b/core/types.go
@@ -19,6 +19,7 @@ type Order struct {
 	ParsedCSR            *x509.CertificateRequest
 	ExpiresDate          time.Time
 	AuthorizationObjects []*Authorization
+	CertPathPrefix       string
 }
 
 type Registration struct {
@@ -97,4 +98,10 @@ func (c Certificate) Chain() []byte {
 
 	// Return the chain, leaf cert first
 	return bytes.Join(chain, nil)
+}
+
+type ValidationRecord struct {
+	URL         string
+	Error       *acme.ProblemDetails
+	ValidatedAt time.Time
 }

--- a/core/types.go
+++ b/core/types.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/letsencrypt/pebble/acme"
@@ -14,6 +15,7 @@ import (
 )
 
 type Order struct {
+	sync.RWMutex
 	acme.Order
 	ID                   string
 	ParsedCSR            *x509.CertificateRequest
@@ -29,6 +31,7 @@ type Registration struct {
 }
 
 type Authorization struct {
+	sync.RWMutex
 	acme.Authorization
 	ID          string
 	URL         string
@@ -37,6 +40,7 @@ type Authorization struct {
 }
 
 type Challenge struct {
+	sync.RWMutex
 	acme.Challenge
 	ID            string
 	Authz         *Authorization

--- a/core/types.go
+++ b/core/types.go
@@ -19,7 +19,7 @@ type Order struct {
 	ParsedCSR            *x509.CertificateRequest
 	ExpiresDate          time.Time
 	AuthorizationObjects []*Authorization
-	CertPathPrefix       string
+	CertID               string
 }
 
 type Registration struct {

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -67,10 +67,12 @@ func (m *MemoryStore) AddOrder(order *core.Order) (int, error) {
 	m.Lock()
 	defer m.Unlock()
 
+	order.RLock()
 	orderID := order.ID
 	if len(orderID) == 0 {
 		return 0, fmt.Errorf("order must have a non-empty ID to add to MemoryStore")
 	}
+	order.RUnlock()
 
 	if _, present := m.ordersByID[orderID]; present {
 		return 0, fmt.Errorf("order %q already exists", orderID)
@@ -90,10 +92,12 @@ func (m *MemoryStore) AddAuthorization(authz *core.Authorization) (int, error) {
 	m.Lock()
 	defer m.Unlock()
 
+	authz.RLock()
 	authzID := authz.ID
 	if len(authzID) == 0 {
 		return 0, fmt.Errorf("authz must have a non-empty ID to add to MemoryStore")
 	}
+	authz.RUnlock()
 
 	if _, present := m.authorizationsByID[authzID]; present {
 		return 0, fmt.Errorf("authz %q already exists", authzID)
@@ -113,7 +117,9 @@ func (m *MemoryStore) AddChallenge(chal *core.Challenge) (int, error) {
 	m.Lock()
 	defer m.Unlock()
 
+	chal.RLock()
 	chalID := chal.ID
+	chal.RUnlock()
 	if len(chalID) == 0 {
 		return 0, fmt.Errorf("challenge must have a non-empty ID to add to MemoryStore")
 	}

--- a/va/va.go
+++ b/va/va.go
@@ -4,14 +4,17 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/pebble/acme"
+	"github.com/letsencrypt/pebble/ca"
 	"github.com/letsencrypt/pebble/core"
 )
 
@@ -21,6 +24,13 @@ const (
 
 	// How long do valid authorizations last before expiring?
 	validAuthzExpire = time.Hour
+
+	// How many VATasks can be in the channel before the WFE blocks on adding
+	// another?
+	taskQueueSize = 6
+
+	// How many concurrent validations are performed?
+	concurrentValidations = 3
 )
 
 func userAgent() string {
@@ -29,43 +39,95 @@ func userAgent() string {
 		userAgentBase, runtime.GOOS, runtime.GOARCH)
 }
 
+type vaTask struct {
+	Identifier   string
+	Challenge    *core.Challenge
+	Registration *core.Registration
+	Results      chan core.ValidationRecord
+}
+
 type VAImpl struct {
 	log      *log.Logger
 	clk      clock.Clock
 	httpPort int
+	tasks    chan *vaTask
+	ca       *ca.CAImpl
 }
 
-func New(log *log.Logger, clk clock.Clock, httpPort int) *VAImpl {
-	return &VAImpl{
+func New(log *log.Logger, clk clock.Clock, httpPort int, ca *ca.CAImpl) *VAImpl {
+	va := &VAImpl{
 		log:      log,
 		clk:      clk,
 		httpPort: httpPort,
+		tasks:    make(chan *vaTask, taskQueueSize),
+		ca:       ca,
 	}
+
+	go va.processTasks()
+	return va
 }
 
-func (va VAImpl) Validate(identifier string, chal *core.Challenge, reg *core.Registration) error {
-	// TODO(@cpu): Implement validation for DNS-01, TLS-SNI-02, etc
-	var prob *acme.ProblemDetails
-	switch chal.Type {
-	case acme.ChallengeHTTP01:
-		prob = va.validateHTTP01(identifier, chal, reg)
-	default:
-		return fmt.Errorf("Invalid challenge type: %q", chal.Type)
+func (va VAImpl) ValidateChallenge(ident string, chal *core.Challenge, reg *core.Registration) {
+	task := &vaTask{
+		Identifier:   ident,
+		Challenge:    chal,
+		Registration: reg,
+		Results:      make(chan core.ValidationRecord, concurrentValidations),
 	}
+	// Submit the task for validation
+	va.tasks <- task
+}
 
-	authz := chal.Authz
-	now := va.clk.Now().UTC()
-	// Update the validated date for the challenge regardless of good/bad outcome
-	chal.ValidatedDate = now
-	chal.Validated = chal.ValidatedDate.Format(time.RFC3339)
-	if prob != nil {
-		// Update the challenge Error
-		chal.Error = prob
-		// Set the challenge and authorization to invalid
-		chal.Status = acme.StatusInvalid
-		authz.Status = acme.StatusInvalid
-		va.log.Printf("authz %s set INVALID by completed challenge %s", authz.ID, chal.ID)
-	} else {
+func (va VAImpl) processTasks() {
+TaskLoop:
+	for {
+		// Pull a task off of the tasks channel
+		task, ok := <-va.tasks
+		if !ok {
+			break
+		}
+		va.log.Printf("Pulled a task from the Tasks queue: %#v", task)
+		va.log.Printf("Starting %d validations.", concurrentValidations)
+
+		var wg sync.WaitGroup
+		wg.Add(concurrentValidations)
+		// Start a number of go routines to perform concurrent validations
+		for i := 0; i < concurrentValidations; i++ {
+			go va.performValidation(task, &wg)
+		}
+		va.log.Printf("Waiting on validations")
+		// Wait for all of the go routines to finish
+		wg.Wait()
+		va.log.Printf("All %d validations finished.\n", concurrentValidations)
+
+		chal := task.Challenge
+		authz := chal.Authz
+
+		// Update the validated date for the challenge regardless of good/bad outcome
+		now := va.clk.Now().UTC()
+		chal.ValidatedDate = now
+		chal.Validated = chal.ValidatedDate.Format(time.RFC3339)
+
+		// Read a validation result from the task results channel for each of the
+		// concurrent validations into a slice for processing.
+		for i := 0; i < concurrentValidations; i++ {
+			va.log.Printf("Reading a result from task.Results")
+			result := <-task.Results
+
+			// If one of the results was an error, the challenge fails
+			if result.Error != nil {
+				// Update the challenge Error
+				chal.Error = result.Error
+				// Set the challenge and authorization to invalid
+				chal.Status = acme.StatusInvalid
+				authz.Status = acme.StatusInvalid
+				va.log.Printf("authz %s set INVALID by completed challenge %s", authz.ID, chal.ID)
+				// Continue immediately, the challenge is finished
+				continue TaskLoop
+			}
+		}
+
+		// If none of the results were an error then the challenge succeeded.
 		// Update the expiry for the valid authorization
 		authz.ExpiresDate = now.Add(validAuthzExpire)
 		authz.Expires = authz.ExpiresDate.Format(time.RFC3339)
@@ -73,52 +135,81 @@ func (va VAImpl) Validate(identifier string, chal *core.Challenge, reg *core.Reg
 		chal.Status = acme.StatusValid
 		authz.Status = acme.StatusValid
 		va.log.Printf("authz %s set VALID by completed challenge %s", authz.ID, chal.ID)
-	}
 
-	return nil
+		// Check whether validating this authorization completed the overall order
+		// TODO(@cpu): this will race if another thread updates an authorization for this order
+		order := authz.Order
+		for _, authz := range order.AuthorizationObjects {
+			// If any of the authorizations are invalid the order isn't ready to issue
+			if authz.Status != acme.StatusValid {
+				continue TaskLoop
+			}
+		}
+		// Ask the CA to complete the order in a separate goroutine
+		go va.ca.CompleteOrder(order)
+	}
 }
 
-func (va VAImpl) validateHTTP01(
-	identifier string,
-	chal *core.Challenge,
-	reg *core.Registration,
-) *acme.ProblemDetails {
-	body, err := va.fetchHTTP(identifier, chal)
+func (va VAImpl) performValidation(task *vaTask, wg *sync.WaitGroup) {
+	// Sleep for a random amount of time between 1-15s
+	len := time.Duration(rand.Intn(15))
+	va.log.Printf("Sleeping for %s seconds before validating", time.Second*len)
+	va.clk.Sleep(time.Second * len)
+
+	// TODO(@cpu): Implement validation for DNS-01, TLS-SNI-02, etc
+	switch task.Challenge.Type {
+	case acme.ChallengeHTTP01:
+		va.validateHTTP01(task)
+	default:
+		va.log.Printf("Error: performValidation(): Invalid challenge type: %q", task.Challenge.Type)
+	}
+	va.log.Printf("Finished a performValidation()")
+	wg.Done()
+}
+
+func (va VAImpl) validateHTTP01(task *vaTask) {
+	va.log.Printf("Validating HTTP01")
+	body, url, err := va.fetchHTTP(task.Identifier, task.Challenge.Token)
+
+	result := core.ValidationRecord{
+		URL:         url,
+		ValidatedAt: va.clk.Now(),
+	}
 	if err != nil {
-		return err
+		result.Error = err
 	}
 
-	expectedKeyAuthorization := chal.ExpectedKeyAuthorization(reg.Key)
+	expectedKeyAuthorization := task.Challenge.ExpectedKeyAuthorization(task.Registration.Key)
 	// The server SHOULD ignore whitespace characters at the end of the body
 	payload := strings.TrimRight(string(body), whitespaceCutset)
 	if payload != expectedKeyAuthorization {
-		return acme.UnauthorizedProblem(
+		result.Error = acme.UnauthorizedProblem(
 			fmt.Sprintf("The key authorization file from the server did not match this challenge %q != %q",
 				expectedKeyAuthorization, payload))
 	}
 
-	return nil
+	va.log.Printf("Returning result for validation task: %#v", result)
+	// Return the validation record
+	task.Results <- result
+	va.log.Printf("Wrote result.")
 }
 
 // NOTE(@cpu): fetchHTTP only fetches the ACME HTTP-01 challenge path for
 // a given challenge & identifier domain. It is not a challenge agnostic general
 // purpose HTTP function
-func (va VAImpl) fetchHTTP(identifier string, chal *core.Challenge) ([]byte, *acme.ProblemDetails) {
-	path := fmt.Sprintf("%s%s", acme.HTTP01BaseURL, chal.Token)
+func (va VAImpl) fetchHTTP(identifier string, token string) ([]byte, string, *acme.ProblemDetails) {
+	path := fmt.Sprintf("%s%s", acme.HTTP01BaseURL, token)
 
 	url := &url.URL{
 		Scheme: "http",
-		Host:   fmt.Sprintf("%s:%d", chal.Authz.Identifier.Value, va.httpPort),
+		Host:   fmt.Sprintf("%s:%d", identifier, va.httpPort),
 		Path:   path,
 	}
 
-	chal.ValidationRecords = []acme.ValidationRecord{
-		acme.ValidationRecord{url.String()},
-	}
-	va.log.Printf("Attempting to validate %s: %s\n", chal.Type, url)
+	va.log.Printf("Attempting to validate w/ HTTP: %s\n", url)
 	httpRequest, err := http.NewRequest("GET", url.String(), nil)
 	if err != nil {
-		return nil, acme.MalformedProblem(
+		return nil, url.String(), acme.MalformedProblem(
 			fmt.Sprintf("Invalid URL %q\n", url.String()))
 	}
 	httpRequest.Header.Set("User-Agent", userAgent())
@@ -137,7 +228,7 @@ func (va VAImpl) fetchHTTP(identifier string, chal *core.Challenge) ([]byte, *ac
 
 	resp, err := client.Do(httpRequest)
 	if err != nil {
-		return nil, acme.ConnectionProblem(err.Error())
+		return nil, url.String(), acme.ConnectionProblem(err.Error())
 	}
 
 	// NOTE: This is *not* using a `io.LimitedReader` and isn't suitable for
@@ -145,18 +236,18 @@ func (va VAImpl) fetchHTTP(identifier string, chal *core.Challenge) ([]byte, *ac
 	// use Pebble anywhere that isn't a testing rig!!!
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, acme.InternalErrorProblem(err.Error())
+		return nil, url.String(), acme.InternalErrorProblem(err.Error())
 	}
 	err = resp.Body.Close()
 	if err != nil {
-		return nil, acme.InternalErrorProblem(err.Error())
+		return nil, url.String(), acme.InternalErrorProblem(err.Error())
 	}
 
 	if resp.StatusCode != 200 {
-		return nil, acme.UnauthorizedProblem(
+		return nil, url.String(), acme.UnauthorizedProblem(
 			fmt.Sprintf("Non-200 status code from HTTP: %s returned %d",
 				url.String(), resp.StatusCode))
 	}
 
-	return body, nil
+	return body, url.String(), nil
 }

--- a/va/va.go
+++ b/va/va.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"runtime"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/jmhodges/clock"
@@ -25,7 +24,7 @@ const (
 	// How long do valid authorizations last before expiring?
 	validAuthzExpire = time.Hour
 
-	// How many VATasks can be in the channel before the WFE blocks on adding
+	// How many vaTasks can be in the channel before the WFE blocks on adding
 	// another?
 	taskQueueSize = 6
 
@@ -43,7 +42,6 @@ type vaTask struct {
 	Identifier   string
 	Challenge    *core.Challenge
 	Registration *core.Registration
-	Results      chan core.ValidationRecord
 }
 
 type VAImpl struct {
@@ -72,85 +70,110 @@ func (va VAImpl) ValidateChallenge(ident string, chal *core.Challenge, reg *core
 		Identifier:   ident,
 		Challenge:    chal,
 		Registration: reg,
-		Results:      make(chan core.ValidationRecord, concurrentValidations),
 	}
 	// Submit the task for validation
 	va.tasks <- task
 }
 
 func (va VAImpl) processTasks() {
-TaskLoop:
-	for {
-		// Pull a task off of the tasks channel
-		task, ok := <-va.tasks
-		if !ok {
-			break
-		}
-		va.log.Printf("Pulled a task from the Tasks queue: %#v", task)
-		va.log.Printf("Starting %d validations.", concurrentValidations)
-
-		var wg sync.WaitGroup
-		wg.Add(concurrentValidations)
-		// Start a number of go routines to perform concurrent validations
-		for i := 0; i < concurrentValidations; i++ {
-			go va.performValidation(task, &wg)
-		}
-		va.log.Printf("Waiting on validations")
-		// Wait for all of the go routines to finish
-		wg.Wait()
-		va.log.Printf("All %d validations finished.\n", concurrentValidations)
-
-		chal := task.Challenge
-		authz := chal.Authz
-
-		// Update the validated date for the challenge regardless of good/bad outcome
-		now := va.clk.Now().UTC()
-		chal.ValidatedDate = now
-		chal.Validated = chal.ValidatedDate.Format(time.RFC3339)
-
-		// Read a validation result from the task results channel for each of the
-		// concurrent validations into a slice for processing.
-		for i := 0; i < concurrentValidations; i++ {
-			va.log.Printf("Reading a result from task.Results")
-			result := <-task.Results
-
-			// If one of the results was an error, the challenge fails
-			if result.Error != nil {
-				// Update the challenge Error
-				chal.Error = result.Error
-				// Set the challenge and authorization to invalid
-				chal.Status = acme.StatusInvalid
-				authz.Status = acme.StatusInvalid
-				va.log.Printf("authz %s set INVALID by completed challenge %s", authz.ID, chal.ID)
-				// Continue immediately, the challenge is finished
-				continue TaskLoop
-			}
-		}
-
-		// If none of the results were an error then the challenge succeeded.
-		// Update the expiry for the valid authorization
-		authz.ExpiresDate = now.Add(validAuthzExpire)
-		authz.Expires = authz.ExpiresDate.Format(time.RFC3339)
-		// Set the authorization & challenge to valid
-		chal.Status = acme.StatusValid
-		authz.Status = acme.StatusValid
-		va.log.Printf("authz %s set VALID by completed challenge %s", authz.ID, chal.ID)
-
-		// Check whether validating this authorization completed the overall order
-		// TODO(@cpu): this will race if another thread updates an authorization for this order
-		order := authz.Order
-		for _, authz := range order.AuthorizationObjects {
-			// If any of the authorizations are invalid the order isn't ready to issue
-			if authz.Status != acme.StatusValid {
-				continue TaskLoop
-			}
-		}
-		// Ask the CA to complete the order in a separate goroutine
-		go va.ca.CompleteOrder(order)
+	for task := range va.tasks {
+		go va.process(task)
 	}
 }
 
-func (va VAImpl) performValidation(task *vaTask, wg *sync.WaitGroup) {
+func (va VAImpl) firstError(results chan *core.ValidationRecord) *acme.ProblemDetails {
+	for i := 0; i < concurrentValidations; i++ {
+		result := <-results
+		if result.Error != nil {
+			return result.Error
+		}
+	}
+	return nil
+}
+
+func (va VAImpl) process(task *vaTask) {
+	va.log.Printf("Pulled a task from the Tasks queue: %#v", task)
+	va.log.Printf("Starting %d validations.", concurrentValidations)
+
+	chal := task.Challenge
+	chal.Lock()
+	// Update the validated date for the challenge
+	now := va.clk.Now().UTC()
+	chal.ValidatedDate = now
+	chal.Validated = chal.ValidatedDate.Format(time.RFC3339)
+	authz := chal.Authz
+	chal.Unlock()
+
+	results := make(chan *core.ValidationRecord, concurrentValidations)
+
+	// Start a number of go routines to perform concurrent validations
+	for i := 0; i < concurrentValidations; i++ {
+		go va.performValidation(task, results)
+	}
+
+	err := va.firstError(results)
+	// If one of the results was an error, the challenge fails
+	if err != nil {
+		// Lock the challenge to update the error & status
+		chal.Lock()
+		// Update the challenge Error
+		chal.Error = err
+		// Set the challenge and authorization to invalid
+		chal.Status = acme.StatusInvalid
+		chal.Unlock()
+
+		// Lock the authz to update the authz status
+		authz.Lock()
+		authz.Status = acme.StatusInvalid
+		authz.Unlock()
+
+		va.log.Printf("authz %s set INVALID by completed challenge %s", authz.ID, chal.ID)
+		// Return immediately - there's no need to check for order issuance
+		return
+	} else {
+		// If none of the results were an error then the challenge succeeded.
+		// Update the expiry for the valid authorization
+		authz.Lock()
+		authz.ExpiresDate = now.Add(validAuthzExpire)
+		authz.Expires = authz.ExpiresDate.Format(time.RFC3339)
+		authz.Status = acme.StatusValid
+		authz.Unlock()
+
+		// Set the authorization & challenge to valid
+		chal.Lock()
+		chal.Status = acme.StatusValid
+		chal.Unlock()
+
+		va.log.Printf("authz %s set VALID by completed challenge %s", authz.ID, chal.ID)
+	}
+
+	// Lock the authz to read the order, check if it can be fulfilled
+	authz.RLock()
+	order := authz.Order
+	authz.RUnlock()
+	va.maybeIssue(order)
+}
+
+func (va VAImpl) maybeIssue(order *core.Order) {
+	// Lock the order for reading to check whether all authorizations are valid
+	order.RLock()
+	for _, authz := range order.AuthorizationObjects {
+		// Lock the authorization for reading to check its status
+		authz.RLock()
+		authzStatus := authz.Status
+		authz.RUnlock()
+		// If any of the authorizations are invalid the order isn't ready to issue
+		if authzStatus != acme.StatusValid {
+			return
+		}
+	}
+	order.RUnlock()
+	// All the authorizations are valid, ask the CA to complete the order in
+	// a separate goroutine
+	go va.ca.CompleteOrder(order)
+}
+
+func (va VAImpl) performValidation(task *vaTask, results chan<- *core.ValidationRecord) {
 	// Sleep for a random amount of time between 1-15s
 	len := time.Duration(rand.Intn(15))
 	va.log.Printf("Sleeping for %s seconds before validating", time.Second*len)
@@ -159,19 +182,16 @@ func (va VAImpl) performValidation(task *vaTask, wg *sync.WaitGroup) {
 	// TODO(@cpu): Implement validation for DNS-01, TLS-SNI-02, etc
 	switch task.Challenge.Type {
 	case acme.ChallengeHTTP01:
-		va.validateHTTP01(task)
+		results <- va.validateHTTP01(task)
 	default:
 		va.log.Printf("Error: performValidation(): Invalid challenge type: %q", task.Challenge.Type)
 	}
-	va.log.Printf("Finished a performValidation()")
-	wg.Done()
 }
 
-func (va VAImpl) validateHTTP01(task *vaTask) {
-	va.log.Printf("Validating HTTP01")
+func (va VAImpl) validateHTTP01(task *vaTask) *core.ValidationRecord {
 	body, url, err := va.fetchHTTP(task.Identifier, task.Challenge.Token)
 
-	result := core.ValidationRecord{
+	result := &core.ValidationRecord{
 		URL:         url,
 		ValidatedAt: va.clk.Now(),
 	}
@@ -188,10 +208,7 @@ func (va VAImpl) validateHTTP01(task *vaTask) {
 				expectedKeyAuthorization, payload))
 	}
 
-	va.log.Printf("Returning result for validation task: %#v", result)
-	// Return the validation record
-	task.Results <- result
-	va.log.Printf("Wrote result.")
+	return result
 }
 
 // NOTE(@cpu): fetchHTTP only fetches the ACME HTTP-01 challenge path for

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -622,11 +622,6 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		},
 		ExpiresDate: expires,
 		ParsedCSR:   parsedCSR,
-		// At the time we issue a certificate for an order we don't have the HTTP
-		// request to construct a path to access the certificate. To work around
-		// this we calculate the path prefix now append the cert ID later when we
-		// need the cert URL to complete the order.
-		CertPathPrefix: wfe.relativeEndpoint(request, certPath),
 	}
 
 	// Verify the details of the order before creating authorizations
@@ -674,6 +669,12 @@ func (wfe *WebFrontEndImpl) Order(
 	if order == nil {
 		response.WriteHeader(http.StatusNotFound)
 		return
+	}
+
+	// If the order has a cert ID then set the certificate URL by constructing
+	// a relative path based on the HTTP request & the cert ID
+	if order.CertID != "" {
+		order.Certificate = wfe.relativeEndpoint(request, certPath+order.CertID)
 	}
 
 	// Return only the initial OrderRequest not the internal object with the

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -406,17 +406,18 @@ func (wfe *WebFrontEndImpl) NewRegistration(
 	// createdReg is the internal Pebble account object
 	createdReg := core.Registration{
 		Registration: newReg,
+		Key:          key,
 	}
-	createdReg.Key = key
-
-	regID, err := keyToID(key)
+	keyID, err := keyToID(key)
 	if err != nil {
 		wfe.sendError(acme.MalformedProblem(err.Error()), response)
 		return
 	}
-	createdReg.ID = regID
+	createdReg.ID = keyID
 
-	if existingReg := wfe.db.GetRegistrationByID(regID); existingReg != nil {
+	// NOTE: We don't use wfe.getRegByKey here because we want to treat a
+	//       "missing" reg as a non-error
+	if existingReg := wfe.db.GetRegistrationByID(createdReg.ID); existingReg != nil {
 		regURL := wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", regPath, existingReg.ID))
 		response.Header().Set("Location", regURL)
 		wfe.sendError(acme.Conflict("Registration key is already in use"), response)
@@ -439,7 +440,7 @@ func (wfe *WebFrontEndImpl) NewRegistration(
 	}
 	wfe.log.Printf("There are now %d registrations in memory\n", count)
 
-	regURL := wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", regPath, regID))
+	regURL := wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", regPath, createdReg.ID))
 
 	response.Header().Add("Location", regURL)
 	err = wfe.writeJsonResponse(response, http.StatusCreated, newReg)
@@ -450,6 +451,10 @@ func (wfe *WebFrontEndImpl) NewRegistration(
 }
 
 func (wfe *WebFrontEndImpl) verifyOrder(order *core.Order, reg *core.Registration) *acme.ProblemDetails {
+	// Lock the order for reading
+	order.RLock()
+	defer order.RUnlock()
+
 	// Shouldn't happen - defensive check
 	if order == nil {
 		return acme.InternalErrorProblem("Order is nil")
@@ -480,11 +485,10 @@ func (wfe *WebFrontEndImpl) makeAuthorizations(order *core.Order, request *http.
 	var auths []string
 	var authObs []*core.Authorization
 
-	names := make([]string, len(order.ParsedCSR.DNSNames))
-	copy(names, order.ParsedCSR.DNSNames)
-
-	// Create one authz for each name in the CSR
-	for _, name := range names {
+	// Lock the order for reading
+	order.RLock()
+	// Create one authz for each name in the order's parsed CSR
+	for _, name := range order.ParsedCSR.DNSNames {
 		ident := acme.Identifier{
 			Type:  acme.IdentifierDNS,
 			Value: name,
@@ -517,9 +521,14 @@ func (wfe *WebFrontEndImpl) makeAuthorizations(order *core.Order, request *http.
 		auths = append(auths, authzURL)
 		authObs = append(authObs, authz)
 	}
+	// Unlock the order from reading
+	order.RUnlock()
 
+	// Lock the order for writing & update the order's authorizations
+	order.Lock()
 	order.Authorizations = auths
 	order.AuthorizationObjects = authObs
+	order.Unlock()
 	return nil
 }
 
@@ -548,10 +557,13 @@ func (wfe *WebFrontEndImpl) makeChallenges(authz *core.Authorization, request *h
 	wfe.log.Printf("There are now %d challenges in the db\n", count)
 	chals = append(chals, chal)
 
+	// Lock the authorization for writing to update the challenges
+	authz.Lock()
 	authz.Challenges = nil
 	for _, c := range chals {
 		authz.Challenges = append(authz.Challenges, &c.Challenge)
 	}
+	authz.Unlock()
 	return nil
 }
 
@@ -568,27 +580,15 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		return
 	}
 
-	// Compute the registration ID for the signer's key
-	regID, err := keyToID(key)
-	if err != nil {
-		wfe.log.Printf("keyToID err: %s\n", err.Error())
-		wfe.sendError(acme.MalformedProblem("Error computing key digest"), response)
-		return
-	}
-	wfe.log.Printf("received new-order req from reg ID %s\n", regID)
-
-	// Find the existing registration object for that key ID
-	var existingReg *core.Registration
-	if existingReg = wfe.db.GetRegistrationByID(regID); existingReg == nil {
-		wfe.sendError(
-			acme.MalformedProblem("No existing registration for signer's public key"),
-			response)
+	existingReg, prob := wfe.getRegByKey(key)
+	if prob != nil {
+		wfe.sendError(prob, response)
 		return
 	}
 
 	// Unpack the order request body
 	var newOrder acme.Order
-	err = json.Unmarshal(body, &newOrder)
+	err := json.Unmarshal(body, &newOrder)
 	if err != nil {
 		wfe.sendError(
 			acme.MalformedProblem("Error unmarshaling body JSON: "+err.Error()), response)
@@ -671,6 +671,10 @@ func (wfe *WebFrontEndImpl) Order(
 		return
 	}
 
+	// Lock the order for reading
+	order.RLock()
+	defer order.RUnlock()
+
 	// If the order has a cert ID then set the certificate URL by constructing
 	// a relative path based on the HTTP request & the cert ID
 	if order.CertID != "" {
@@ -735,11 +739,103 @@ func (wfe *WebFrontEndImpl) getChallenge(
 		return
 	}
 
+	// Lock the challenge for reading in order to write the response
+	chal.RLock()
+	defer chal.RUnlock()
+
 	err := wfe.writeJsonResponse(response, http.StatusOK, chal.Challenge)
 	if err != nil {
 		wfe.sendError(acme.InternalErrorProblem("Error marshalling challenge"), response)
 		return
 	}
+}
+
+// getRegByKey finds a registration by key or returns a problem pointer if an
+// existing reg can't be found or the key is invalid.
+func (wfe *WebFrontEndImpl) getRegByKey(key crypto.PublicKey) (*core.Registration, *acme.ProblemDetails) {
+	// Compute the registration ID for the signer's key
+	regID, err := keyToID(key)
+	if err != nil {
+		wfe.log.Printf("keyToID err: %s\n", err.Error())
+		return nil, acme.MalformedProblem("Error computing key digest")
+	}
+
+	// Find the existing registration object for that key ID
+	var existingReg *core.Registration
+	if existingReg = wfe.db.GetRegistrationByID(regID); existingReg == nil {
+		return nil, acme.MalformedProblem("No existing registration for signer's public key")
+	}
+	return existingReg, nil
+}
+
+func (wfe *WebFrontEndImpl) validateChallengeUpdate(
+	chal *core.Challenge,
+	update *acme.Challenge,
+	reg *core.Registration) (*core.Authorization, *acme.ProblemDetails) {
+	// Lock the challenge for reading to do validation
+	chal.RLock()
+	defer chal.RUnlock()
+
+	// Check that the challenge update is the same type as the challenge
+	// NOTE: Boulder doesn't do this at the time of writing and instead increments
+	//       a "StartChallengeWrongType" stat
+	if update.Type != chal.Type {
+		return nil, acme.MalformedProblem(
+			fmt.Sprintf("Challenge update was type %s, existing challenge is type %s",
+				update.Type, chal.Type))
+	}
+
+	// Check that the existing challenge is Pending
+	if chal.Status != acme.StatusPending {
+		return nil, acme.MalformedProblem(
+			fmt.Sprintf("Cannot update challenge with status %s, only status %s",
+				chal.Status, acme.StatusPending))
+	}
+
+	// Calculate the expected key authorization for the owning registration's key
+	expectedKeyAuth := chal.ExpectedKeyAuthorization(reg.Key)
+
+	// Validate the expected key auth matches the provided key auth
+	if expectedKeyAuth != update.KeyAuthorization {
+		return nil, acme.MalformedProblem(
+			fmt.Sprintf("Incorrect key authorization: %q",
+				update.KeyAuthorization))
+	}
+
+	return chal.Authz, nil
+}
+
+// validateAuthzForChallenge checks an authz is:
+// 1) for a supported identifier type
+// 2) not expired
+// 3) associated to an order
+// The associated order is returned when no problems are found to avoid needing
+// another RLock() for the caller to get the order pointer later.
+func (wfe *WebFrontEndImpl) validateAuthzForChallenge(authz *core.Authorization) (*core.Order, *acme.ProblemDetails) {
+	// Lock the authz for reading
+	authz.RLock()
+	defer authz.RUnlock()
+
+	ident := authz.Identifier
+	if ident.Type != acme.IdentifierDNS {
+		return nil, acme.MalformedProblem(
+			fmt.Sprintf("Authorization identifier was type %s, only %s is supported",
+				ident.Type, acme.IdentifierDNS))
+	}
+
+	now := wfe.clk.Now()
+	if now.After(authz.ExpiresDate) {
+		return nil, acme.MalformedProblem(
+			fmt.Sprintf("Authorization expired %s %s",
+				authz.ExpiresDate.Format(time.RFC3339)))
+	}
+
+	existingOrder := authz.Order
+	if existingOrder == nil {
+		return nil, acme.InternalErrorProblem("authz missing associated order")
+	}
+
+	return existingOrder, nil
 }
 
 func (wfe *WebFrontEndImpl) updateChallenge(
@@ -754,26 +850,14 @@ func (wfe *WebFrontEndImpl) updateChallenge(
 		return
 	}
 
-	// Compute the registration ID for the signer's key
-	regID, err := keyToID(key)
-	if err != nil {
-		wfe.log.Printf("keyToID err: %s\n", err.Error())
-		wfe.sendError(acme.MalformedProblem("Error computing key digest"), response)
-		return
-	}
-	wfe.log.Printf("received update-challenge req from reg ID %s\n", regID)
-
-	// Find the existing registration object for that key ID
-	var existingReg *core.Registration
-	if existingReg = wfe.db.GetRegistrationByID(regID); existingReg == nil {
-		wfe.sendError(
-			acme.MalformedProblem("No existing registration for signer's public key"),
-			response)
+	existingReg, prob := wfe.getRegByKey(key)
+	if prob != nil {
+		wfe.sendError(prob, response)
 		return
 	}
 
 	var chalResp acme.Challenge
-	err = json.Unmarshal(body, &chalResp)
+	err := json.Unmarshal(body, &chalResp)
 	if err != nil {
 		wfe.sendError(
 			acme.MalformedProblem("Error unmarshaling body JSON"), response)
@@ -787,79 +871,45 @@ func (wfe *WebFrontEndImpl) updateChallenge(
 		return
 	}
 
-	existingAuthz := existingChal.Authz
-	if existingAuthz == nil {
+	authz, prob := wfe.validateChallengeUpdate(existingChal, &chalResp, existingReg)
+	if prob != nil {
+		wfe.sendError(prob, response)
+		return
+	}
+	if authz == nil {
 		wfe.sendError(
 			acme.InternalErrorProblem("challenge missing associated authz"), response)
 		return
 	}
 
-	ident := existingAuthz.Identifier
-	if ident.Type != acme.IdentifierDNS {
-		wfe.sendError(
-			acme.MalformedProblem(
-				fmt.Sprintf("Authorization identifier was type %s, only %s is supported",
-					ident.Type, acme.IdentifierDNS)), response)
+	existingOrder, prob := wfe.validateAuthzForChallenge(authz)
+	if prob != nil {
+		wfe.sendError(prob, response)
 		return
 	}
 
+	// Lock the order for reading to check the expiry date
+	existingOrder.RLock()
 	now := wfe.clk.Now()
-	if now.After(existingAuthz.ExpiresDate) {
-		wfe.sendError(
-			acme.MalformedProblem(fmt.Sprintf("Authorization expired %s %s",
-				existingAuthz.ExpiresDate.Format(time.RFC3339))), response)
-		return
-	}
-
-	existingOrder := existingAuthz.Order
-	if existingOrder == nil {
-		wfe.sendError(
-			acme.InternalErrorProblem("authz missing associated order"), response)
-		return
-	}
-
 	if now.After(existingOrder.ExpiresDate) {
 		wfe.sendError(
 			acme.MalformedProblem(fmt.Sprintf("order expired %s %s",
 				existingOrder.ExpiresDate.Format(time.RFC3339))), response)
 		return
 	}
+	existingOrder.RUnlock()
 
-	// Check that the challenge response is the same type as the challenge
-	// NOTE: Boulder doesn't do this at the time of writing and instead increments
-	//       a "StartChallengeWrongType" stat
-	if chalResp.Type != existingChal.Type {
-		wfe.sendError(
-			acme.MalformedProblem(
-				fmt.Sprintf("Challenge update was type %s, existing challenge is type %s",
-					chalResp.Type, existingChal.Type)), response)
-		return
-	}
-
-	// Check that the existing challenge is Pending
-	if existingChal.Status != acme.StatusPending {
-		wfe.sendError(
-			acme.MalformedProblem(
-				fmt.Sprintf("Cannot update challenge with status %s, only status %s",
-					existingChal.Status, acme.StatusPending)), response)
-		return
-	}
-
-	// Calculate the expected key authorization for the owning registration's key
-	expectedKeyAuth := existingChal.ExpectedKeyAuthorization(existingReg.Key)
-
-	// Validate the expected key auth matches the provided key auth
-	if expectedKeyAuth != chalResp.KeyAuthorization {
-		wfe.sendError(
-			acme.MalformedProblem(
-				fmt.Sprintf("Incorrect key authorization: %q",
-					chalResp.KeyAuthorization)), response)
-		return
-	}
+	// Lock the authorization to get the identifier value
+	authz.RLock()
+	ident := authz.Identifier.Value
+	authz.RUnlock()
 
 	// Submit a validation job to the VA, this will be processed asynchronously
-	wfe.va.ValidateChallenge(ident.Value, existingChal, existingReg)
+	wfe.va.ValidateChallenge(ident, existingChal, existingReg)
 
+	// Lock the challenge for reading in order to write the response
+	existingChal.RLock()
+	defer existingChal.RUnlock()
 	response.Header().Add("Link", link(existingChal.Authz.URL, "up"))
 	err = wfe.writeJsonResponse(response, http.StatusOK, existingChal.Challenge)
 	if err != nil {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -677,8 +677,10 @@ func (wfe *WebFrontEndImpl) Order(
 
 	// If the order has a cert ID then set the certificate URL by constructing
 	// a relative path based on the HTTP request & the cert ID
-	if order.CertID != "" {
-		order.Certificate = wfe.relativeEndpoint(request, certPath+order.CertID)
+	if order.CertificateObject != nil {
+		order.Certificate = wfe.relativeEndpoint(
+			request,
+			certPath+order.CertificateObject.ID)
 	}
 
 	// Return only the initial OrderRequest not the internal object with the


### PR DESCRIPTION
**Updates the README**
5491a24 updates the README to include Chisel usage instructions 
& reference the current-most draft.

**Adds multi-validation and true async issuance.**
7d615b5 splits the operation of the CA and VA across multiple
go-routines instead of doing all work on the WFE's handler routine.

The VA now performs multiple validations, sleeping a random amount of
time between each. This forces the ACME client to poll the
authorizations to learn when they have switched from pending to invalid
or valid. All validation attempts must succeed for the authorization to
be valid.

The WFE no longer communicates directly with the CA, instead when the VA
updates the last authorization on an order to valid status it invokes
the CA's CompleteOrder function in a separate goroutine. This will
complete the order & update it with a certificate pointer. The WFE uses
this pointer to construct the certificate URL as required.