### PR TITLE
Rename challenge field from uri to url

### DIFF
--- a/acme/common.go
+++ b/acme/common.go
@@ -61,7 +61,7 @@ type Authorization struct {
 // A Challenge is used to validate an Authorization
 type Challenge struct {
 	Type             string          `json:"type"`
-	URI              string          `json:"uri"`
+	URL              string          `json:"url"`
 	Token            string          `json:"token"`
 	Status           string          `json:"status"`
 	Validated        string          `json:"validated,omitempty"`

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -543,7 +543,7 @@ func (wfe *WebFrontEndImpl) makeChallenge(
 		Challenge: acme.Challenge{
 			Type:   chalType,
 			Token:  newToken(),
-			URI:    wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", challengePath, id)),
+			URL:    wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", challengePath, id)),
 			Status: acme.StatusPending,
 		},
 		Authz: authz,


### PR DESCRIPTION
I'm sorry, but I found another one... 😉 In the Challenge resource, the `uri` field has been renamed to `url`.