### PR TITLE
fix path to chisel2.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,6 @@ The easiest way to test issue with Pebble is to use `chisel2` from the
 3. `letsencrypt-auto-source/letsencrypt-auto --os-packages-only`
 4. `./tools/venv.sh`
 5. `. venev/bin/activate`
-6. `python ./certbot/tools/chisel2.py example.com`
+6. `python ./tools/chisel2.py example.com`
 
 


### PR DESCRIPTION
step 2 changes into the certbot directory so the command in step 6 should not reference certbot