### PR TITLE
Removes "registration" references in favour of "account"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pebble
 
 A miniature version of [Boulder](https://github.com/letsencrypt/boulder), Pebble
-is a small [ACME-06](https://tools.ietf.org/html/draft-ietf-acme-acme-06) test
+is a small [ACME-07](https://tools.ietf.org/html/draft-ietf-acme-acme-07) test
 server not suited for use as a production CA.
 
 ## !!! WARNING !!!
@@ -16,7 +16,7 @@ randomize keys/certificates used for issuance.
 ## Goals
 
 1. Produce a simplified testing front end
-2. Move rapidly to gain [ACME draft-06](https://tools.ietf.org/html/draft-ietf-acme-acme-06) experience
+2. Move rapidly to gain [ACME draft-07](https://tools.ietf.org/html/draft-ietf-acme-acme-07) experience
 3. Write "idealized" code that can be adopted back into Boulder
 4. Aggressively build in guardrails against non-testing usage
 

--- a/acme/common.go
+++ b/acme/common.go
@@ -4,9 +4,9 @@ package acme
 type Resource string
 
 const (
-	ResourceNewNonce = Resource("new-nonce")
-	ResourceNewReg   = Resource("new-reg")
-	ResourceNewOrder = Resource("new-order")
+	ResourceNewNonce   = Resource("new-nonce")
+	ResourceNewAccount = Resource("new-account")
+	ResourceNewOrder   = Resource("new-order")
 	// TODO(@cpu): Should there be a resource for challenge or just use 'authz'?
 	ResourceChallenge = Resource("challenge")
 )
@@ -31,8 +31,7 @@ type Identifier struct {
 	Value string `json:"value"`
 }
 
-// TODO(@cpu) - Rename Registration to Account, update refs
-type Registration struct {
+type Account struct {
 	Status    string   `json:"status"`
 	Contact   []string `json:"contact"`
 	ToSAgreed bool     `json:"terms-of-service-agreed"`

--- a/cmd/pebble-client/main.go
+++ b/cmd/pebble-client/main.go
@@ -137,11 +137,11 @@ func (c *client) updateNonce() error {
 }
 
 func (c *client) register() error {
-	regURL := c.directory["new-reg"].(string)
-	if regURL == "" {
-		return fmt.Errorf("Missing \"new-reg\" entry in server directory")
+	if acctURL, ok := c.directory["new-account"]; !ok || acctURL.(string) == "" {
+		return fmt.Errorf("Missing \"new-account\" entry in server directory")
 	}
-	fmt.Printf("Registering new account with %q\n", regURL)
+	acctURL := c.directory["new-account"].(string)
+	fmt.Printf("Registering new account with %q\n", acctURL)
 
 	reqBody := struct {
 		ToSAgreed bool `json:"terms-of-service-agreed"`
@@ -156,7 +156,7 @@ func (c *client) register() error {
 		return err
 	}
 
-	_, resp, err := c.postAPI(regURL, reqBodyStr)
+	_, resp, err := c.postAPI(acctURL, reqBodyStr)
 	if err != nil {
 		return err
 	}

--- a/core/types.go
+++ b/core/types.go
@@ -24,8 +24,8 @@ type Order struct {
 	CertificateObject    *Certificate
 }
 
-type Registration struct {
-	acme.Registration
+type Account struct {
+	acme.Account
 	Key *jose.JSONWebKey `json:"key"`
 	ID  string
 }

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -7,15 +7,15 @@ import (
 	"github.com/letsencrypt/pebble/core"
 )
 
-// Pebble keeps all of its various objects (registrations, orders, etc)
+// Pebble keeps all of its various objects (accounts, orders, etc)
 // in-memory, not persisted anywhere. MemoryStore implements this in-memory
 // "database"
 type MemoryStore struct {
 	sync.RWMutex
 
-	// Each Registration's ID is the hex encoding of a SHA256 sum over its public
+	// Each Accounts's ID is the hex encoding of a SHA256 sum over its public
 	// key bytes.
-	registrationsByID map[string]*core.Registration
+	accountsByID map[string]*core.Account
 
 	ordersByID map[string]*core.Order
 
@@ -28,7 +28,7 @@ type MemoryStore struct {
 
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
-		registrationsByID:  make(map[string]*core.Registration),
+		accountsByID:       make(map[string]*core.Account),
 		ordersByID:         make(map[string]*core.Order),
 		authorizationsByID: make(map[string]*core.Authorization),
 		challengesByID:     make(map[string]*core.Challenge),
@@ -36,31 +36,31 @@ func NewMemoryStore() *MemoryStore {
 	}
 }
 
-func (m *MemoryStore) GetRegistrationByID(id string) *core.Registration {
+func (m *MemoryStore) GetAccountByID(id string) *core.Account {
 	m.RLock()
 	defer m.RUnlock()
-	return m.registrationsByID[id]
+	return m.accountsByID[id]
 }
 
-func (m *MemoryStore) AddRegistration(reg *core.Registration) (int, error) {
+func (m *MemoryStore) AddAccount(acct *core.Account) (int, error) {
 	m.Lock()
 	defer m.Unlock()
 
-	regID := reg.ID
-	if len(regID) == 0 {
-		return 0, fmt.Errorf("registration must have a non-empty ID to add to MemoryStore")
+	acctID := acct.ID
+	if len(acctID) == 0 {
+		return 0, fmt.Errorf("account must have a non-empty ID to add to MemoryStore")
 	}
 
-	if reg.Key == nil {
-		return 0, fmt.Errorf("registration must not have a nil Key")
+	if acct.Key == nil {
+		return 0, fmt.Errorf("account must not have a nil Key")
 	}
 
-	if _, present := m.registrationsByID[regID]; present {
-		return 0, fmt.Errorf("registration %q already exists", regID)
+	if _, present := m.accountsByID[acctID]; present {
+		return 0, fmt.Errorf("account %q already exists", acctID)
 	}
 
-	m.registrationsByID[regID] = reg
-	return len(m.registrationsByID), nil
+	m.accountsByID[acctID] = acct
+	return len(m.accountsByID), nil
 }
 
 func (m *MemoryStore) AddOrder(order *core.Order) (int, error) {


### PR DESCRIPTION
The ACME spec no longer talks about "registrations" and Pebble shouldn't either. This PR updates all registration occurrences to use the term "account" instead.
