### PR TITLE
Refactored config, tuneable VA sleeps.

### DIFF
--- a/cmd/pebble-client/main.go
+++ b/cmd/pebble-client/main.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/letsencrypt/pebble/cmd"
+
 	"gopkg.in/square/go-jose.v2"
 )
 

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -9,18 +9,11 @@ import (
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/pebble/ca"
 	"github.com/letsencrypt/pebble/cmd"
+	"github.com/letsencrypt/pebble/core"
 	"github.com/letsencrypt/pebble/db"
 	"github.com/letsencrypt/pebble/va"
 	"github.com/letsencrypt/pebble/wfe"
 )
-
-type config struct {
-	Pebble struct {
-		ListenAddress string
-		HTTPPort      int
-		TLSPort       int
-	}
-}
 
 func main() {
 	configFile := flag.String(
@@ -36,14 +29,14 @@ func main() {
 	// Log to stdout
 	logger := log.New(os.Stdout, "Pebble ", log.LstdFlags)
 
-	var c config
-	err := cmd.ReadConfigFile(*configFile, &c)
+	var c core.Config
+	err := core.ReadConfigFile(*configFile, &c)
 	cmd.FailOnError(err, "Reading JSON config file into config structure")
 
 	clk := clock.Default()
 	db := db.NewMemoryStore()
 	ca := ca.New(logger, db)
-	va := va.New(logger, clk, c.Pebble.HTTPPort, c.Pebble.TLSPort, ca)
+	va := va.New(logger, clk, c, ca)
 
 	wfe := wfe.New(logger, clk, db, va)
 	muxHandler := wfe.Handler()

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+)
+
+// FailOnError exits and prints an error message if we encountered a problem
+//
+// Lifted from
+//   https://raw.githubusercontent.com/letsencrypt/boulder/master/cmd/shell.go
+func FailOnError(err error, msg string) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %s\n", msg, err)
+		os.Exit(1)
+	}
+}

--- a/core/config.go
+++ b/core/config.go
@@ -2,15 +2,50 @@ package core
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
+	"time"
 )
 
 type Config struct {
 	Pebble struct {
-		ListenAddress string
-		HTTPPort      int
-		TLSPort       int
+		ListenAddress   string
+		HTTPPort        int
+		TLSPort         int
+		ValidationSleep ConfigDuration
 	}
+}
+
+// ConfigDuration is just an alias for time.Duration that allows
+// serialization to JSON. It is borrowed from boulder/cmd/config.go
+type ConfigDuration struct {
+	time.Duration
+}
+
+// ErrDurationMustBeString is returned when a non-string value is
+// presented to be deserialized as a ConfigDuration
+var ErrDurationMustBeString = errors.New("cannot JSON unmarshal something other than a string into a ConfigDuration")
+
+// UnmarshalJSON parses a string into a ConfigDuration using
+// time.ParseDuration.  If the input does not unmarshal as a
+// string, then UnmarshalJSON returns ErrDurationMustBeString.
+func (d *ConfigDuration) UnmarshalJSON(b []byte) error {
+	s := ""
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		if _, ok := err.(*json.UnmarshalTypeError); ok {
+			return ErrDurationMustBeString
+		}
+		return err
+	}
+	dd, err := time.ParseDuration(s)
+	d.Duration = dd
+	return err
+}
+
+// MarshalJSON returns the string form of the duration, as a byte array.
+func (d ConfigDuration) MarshalJSON() ([]byte, error) {
+	return []byte(d.Duration.String()), nil
 }
 
 // ReadConfigFile takes a file path as an argument and attempts to

--- a/core/config.go
+++ b/core/config.go
@@ -1,11 +1,17 @@
-package cmd
+package core
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
-	"os"
 )
+
+type Config struct {
+	Pebble struct {
+		ListenAddress string
+		HTTPPort      int
+		TLSPort       int
+	}
+}
 
 // ReadConfigFile takes a file path as an argument and attempts to
 // unmarshal the content of the file into a struct containing a
@@ -19,15 +25,4 @@ func ReadConfigFile(filename string, out interface{}) error {
 		return err
 	}
 	return json.Unmarshal(configData, out)
-}
-
-// FailOnError exits and prints an error message if we encountered a problem
-//
-// Lifted from
-//   https://raw.githubusercontent.com/letsencrypt/boulder/master/cmd/shell.go
-func FailOnError(err error, msg string) {
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s: %s\n", msg, err)
-		os.Exit(1)
-	}
 }

--- a/test/config/pebble-config.json
+++ b/test/config/pebble-config.json
@@ -2,6 +2,7 @@
   "pebble": {
     "listenAddress": "0.0.0.0:14000",
     "httpPort": 5002,
-    "tlsPort": 5001
+    "tlsPort": 5001,
+    "validationSleep": "5s"
   }
 }

--- a/va/va.go
+++ b/va/va.go
@@ -75,13 +75,13 @@ type VAImpl struct {
 func New(
 	log *log.Logger,
 	clk clock.Clock,
-	httpPort, tlsPort int,
+	config core.Config,
 	ca *ca.CAImpl) *VAImpl {
 	va := &VAImpl{
 		log:      log,
 		clk:      clk,
-		httpPort: httpPort,
-		tlsPort:  tlsPort,
+		httpPort: config.Pebble.HTTPPort,
+		tlsPort:  config.Pebble.TLSPort,
 		tasks:    make(chan *vaTask, taskQueueSize),
 		ca:       ca,
 	}


### PR DESCRIPTION
#### Make pebble config accessible to components.

This PR refactors the Pebble config from being accessible only to the toplevel cmds and moves it such that it can be passed directly to the components (e.g. the VA) to reduce the number of parameters being added to constructors.

#### Allow configuring validation sleep in config.
This PR updates the VA to use a ConfigDuration read from the config file to determine the maximum random sleep between validation attempts. Setting this value to "0s" in the config will result in now sleeps between validation and can be useful for testing without incurring extra delays.