### PR TITLE
Allow disabling VA sleeps using PEBBLE_VA_NOSLEEP env var.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ clients are not hardcoding URLs.)
 
 `pebble -config ./test/config/pebble-config.json`
 
+### Testing at full speed
+
+By default Pebble will sleep a random number of seconds (from 1 to 15) between
+individual challenge validation attempts. This ensures clients don't make
+assumptions about when the challenge is solved from the CA side by observing
+a single request for a challenge response. Instead clients must poll the
+challenge to observe the state since the CA may send many validation requests.
+
+To test issuance "at full speed" with no artificial sleeps set the environment
+variable `PEBBLE_VA_NOSLEEP` to `1`. E.g.
+
+`PEBBLE_VA_NOSLEEP=1 pebble -config ./test/config/pebble-config.json`
+
 ## Issuance
 
 The easiest way to test issue with Pebble is to use `chisel2` from the


### PR DESCRIPTION
This commit adds support for a `PEBBLE_VA_NOSLEEP` env var. When set to `1` (or "true", "True" to be user friendly) the Pebble VA will not sleep a random amount of time between validation attempts. The README is updated to describe the default sleep behaviour and to add a description of using this env var to test validation at full speed without artificial delays.

This design is informed by the review on my previous (closed) PR: #34 