### PR TITLE
Make storage an interface

### DIFF
--- a/db/storage.go
+++ b/db/storage.go
@@ -1,0 +1,38 @@
+package db
+
+import "github.com/letsencrypt/pebble/core"
+
+type Storage interface {
+	// GetAccountByID returns the account corresponding to an ID
+	GetAccountByID(string) *core.Account
+
+	// AddAccount stores a new account
+	AddAccount(*core.Account) (int, error)
+
+	// AddOrder stores a new order
+	AddOrder(*core.Order) (int, error)
+
+	// GetOrderByID returns the order corresponding to an ID
+	GetOrderByID(string) *core.Order
+
+	// AddAuthorization stores a new authorization
+	AddAuthorization(*core.Authorization) (int, error)
+
+	// GetAuthorizationByID returns the authorization
+	// corresponding to an ID
+	GetAuthorizationByID(string) *core.Authorization
+
+	// AddChallenge stores a new challenge
+	AddChallenge(*core.Challenge) (int, error)
+
+	// GetChallengeByID returns the chanllenge corresponding
+	// to an ID
+	GetChallengeByID(string) *core.Challenge
+
+	// AddCertificate stores a new certificate
+	AddCertificate(*core.Certificate) (int, error)
+
+	// GetCertificateByID returns a certificate corresponding
+	// to an ID
+	GetCertificateByID(string) *core.Certificate
+}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -84,7 +84,7 @@ func (th *topHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 type WebFrontEndImpl struct {
 	log   *log.Logger
-	db    *db.MemoryStore
+	db    db.Storage
 	nonce *nonceMap
 	clk   clock.Clock
 	va    *va.VAImpl
@@ -95,7 +95,7 @@ const ToSURL = "data:text/plain,Do%20what%20thou%20wilt"
 func New(
 	log *log.Logger,
 	clk clock.Clock,
-	db *db.MemoryStore,
+	db db.Storage,
 	va *va.VAImpl) WebFrontEndImpl {
 	return WebFrontEndImpl{
 		log:   log,


### PR DESCRIPTION
This patch makes `WebFrontEndImpl` compatible with an interface type for storage.
The abstraction will let people write their own storage driver when using pebble as a library.