### PR TITLE
Don't hold order lock while iterating authorizations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ before_script:
   - until </dev/tcp/localhost/14000 ; do sleep 0.1 ; done
 
 script:
-  - python ./certbot/tools/chisel2.py example.letsencrypt.org
+  - python ./certbot/tools/chisel2.py example.letsencrypt.org elpmaxe.letsencrypt.org

--- a/va/va.go
+++ b/va/va.go
@@ -200,7 +200,9 @@ func (va VAImpl) process(task *vaTask) {
 func (va VAImpl) maybeIssue(order *core.Order) {
 	// Lock the order for reading to check whether all authorizations are valid
 	order.RLock()
-	for _, authz := range order.AuthorizationObjects {
+	authzs := order.AuthorizationObjects
+	order.RUnlock()
+	for _, authz := range authzs {
 		// Lock the authorization for reading to check its status
 		authz.RLock()
 		authzStatus := authz.Status
@@ -210,7 +212,6 @@ func (va VAImpl) maybeIssue(order *core.Order) {
 			return
 		}
 	}
-	order.RUnlock()
 	// All the authorizations are valid, ask the CA to complete the order in
 	// a separate goroutine
 	go va.ca.CompleteOrder(order)


### PR DESCRIPTION
Prior to this PR `VA.maybeIssue` held a `RLock` on the order object
it was checking for completeness while it iterated over each of the
authorizations associated with the order, locking them in turn.

This PR changes this function to instead acquire a read lock on the
order only to read the `[]*Authorization` field of the order before
freeing the lock for other readers. This allows the iteration over the
authorizations to continue independent of the order. The
`CA.CompleteOrder` function will lock it again before modifying if the
order was in fact complete and ready to issue.

This fixes the deadlock observed when submitting a CSR with more than
one name. I reverted fb1eb47 to demonstrate this as part of this PR.

Resolves https://github.com/letsencrypt/pebble/issues/38