### PR TITLE
Remove proactive issuance and add order finalization.

### DIFF
--- a/acme/common.go
+++ b/acme/common.go
@@ -41,13 +41,14 @@ type Account struct {
 
 // An Order is created to request issuance for a CSR
 type Order struct {
-	Status         string   `json:"status"`
-	Expires        string   `json:"expires"`
-	CSR            string   `json:"csr"`
-	NotBefore      string   `json:"notBefore,omitempty"`
-	NotAfter       string   `json:"notAfter,omitempty"`
-	Authorizations []string `json:"authorizations"`
-	Certificate    string   `json:"certificate,omitempty"`
+	Status         string       `json:"status"`
+	Expires        string       `json:"expires"`
+	Identifiers    []Identifier `json:"identifiers,omitempty"`
+	FinalizeURL    string       `json:"finalizeURL"`
+	NotBefore      string       `json:"notBefore,omitempty"`
+	NotAfter       string       `json:"notAfter,omitempty"`
+	Authorizations []string     `json:"authorizations"`
+	Certificate    string       `json:"certificate,omitempty"`
 }
 
 // An Authorization is created for each identifier in an order

--- a/acme/problems.go
+++ b/acme/problems.go
@@ -44,6 +44,14 @@ func MalformedProblem(detail string) *ProblemDetails {
 	}
 }
 
+func NotFoundProblem(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       malformedErr,
+		Detail:     detail,
+		HTTPStatus: http.StatusNotFound,
+	}
+}
+
 func MethodNotAllowed() *ProblemDetails {
 	return &ProblemDetails{
 		Type:       malformedErr,

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -43,9 +43,9 @@ func main() {
 	clk := clock.Default()
 	db := db.NewMemoryStore()
 	ca := ca.New(logger, db)
-	va := va.New(logger, clk, c.Pebble.HTTPPort, c.Pebble.TLSPort, ca)
+	va := va.New(logger, clk, c.Pebble.HTTPPort, c.Pebble.TLSPort)
 
-	wfe := wfe.New(logger, clk, db, va)
+	wfe := wfe.New(logger, clk, db, va, ca)
 	muxHandler := wfe.Handler()
 
 	srv := &http.Server{

--- a/core/types.go
+++ b/core/types.go
@@ -18,6 +18,8 @@ type Order struct {
 	sync.RWMutex
 	acme.Order
 	ID                   string
+	AccountID            string
+	Names                []string
 	ParsedCSR            *x509.CertificateRequest
 	ExpiresDate          time.Time
 	AuthorizationObjects []*Authorization

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -775,7 +775,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		orderNames = append(orderNames, ident.Value)
 	}
 
-	// Store the unique lower version of the names on the order ob
+	// Store the unique lower version of the names on the order object
 	order.Names = uniqueLowerNames(orderNames)
 
 	// Create the authorizations for the order

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -970,10 +970,9 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(
 		}
 	}
 
-	// Lock and update the order to be in processing status with a parsed CSR available.
+	// Lock and update the order with the parsed CSR.
 	existingOrder.Lock()
 	existingOrder.ParsedCSR = parsedCSR
-	existingOrder.Status = acme.StatusProcessing
 	existingOrder.Unlock()
 
 	// Check whether the order is ready to issue, if it isn't, return a problem
@@ -1017,8 +1016,9 @@ func (wfe *WebFrontEndImpl) maybeIssue(order *core.Order) *acme.ProblemDetails {
 		}
 	}
 	// All the authorizations are valid, ask the CA to complete the order in
-	// a separate goroutine
-	wfe.log.Printf("Order %s is fully authorized. Completing finalization", orderID)
+	// a separate goroutine. CompleteOrder will transition the order status to
+	// pending.
+	wfe.log.Printf("Order %s is fully authorized. Processing finalization", orderID)
 	go wfe.ca.CompleteOrder(order)
 	return nil
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -603,7 +603,7 @@ func (wfe *WebFrontEndImpl) verifyOrder(order *core.Order, reg *core.Account) *a
 		return acme.InternalErrorProblem("Account is nil")
 	}
 	idents := order.Identifiers
-	if idents == nil || len(idents) == 0 {
+	if len(idents) == 0 {
 		return acme.MalformedProblem("Order did not specify any identifiers")
 	}
 	// Check that all of the identifiers in the new-order are DNS type


### PR DESCRIPTION
This commit implements https://github.com/ietf-wg-acme/acme/pull/342 - replacing proactive issuance and CSR as part of new-order with an explicit order finalization step that delivers the CSR.

This is largely a port of the work done to add order finalization to the WIP ACMEv2 support in Boulder:
https://github.com/letsencrypt/boulder/pull/3169 

I haven't tested this end-to-end yet - There are likely bugs lurking :-)