### PR TITLE
Use Chisel2.py from Boulder repo for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,16 @@ go:
   - 1.8
 
 before_install:
-  # The acme-v2 branch of certbot has some tweaks and an in-progress version of
-  # chisel, called chisel2, that works with the latest ACME spec. Check it out
-  # and run it against pebble.
+  # The acme-v2 branch of certbot has some tweaks required for using chisel2
+  # that haven't landed in master yet.
   - git clone -b acme-v2 https://github.com/certbot/certbot
   - cd certbot
   - letsencrypt-auto-source/letsencrypt-auto --os-packages-only
   - ./tools/venv.sh
   - . venv/bin/activate
   - cd -
+  # chisel2.py has moved to the Boulder repo and must be downloaded explicitly
+  - wget https://raw.githubusercontent.com/letsencrypt/boulder/master/test/chisel2.py
 
 before_script:
   - pebble &
@@ -26,4 +27,4 @@ before_script:
   - until </dev/tcp/localhost/14000 ; do sleep 0.1 ; done
 
 script:
-  - python ./certbot/tools/chisel2.py example.letsencrypt.org elpmaxe.letsencrypt.org
+  - DIRECTORY=http://localhost:14000/dir python ./chisel2.py example.letsencrypt.org elpmaxe.letsencrypt.org


### PR DESCRIPTION
Resolves https://github.com/letsencrypt/pebble/issues/45

Note: This PR fixes Travis being unable to run chisel2.py since it was removed from the Certbot repo. It *does not* fix CI failing. Chisel2 is reporting an error:
```
Traceback (most recent call last):
  File "./chisel2.py", line 216, in <module>
    auth_and_issue(domains)
  File "./chisel2.py", line 120, in auth_and_issue
    client = make_client(email)
  File "./chisel2.py", line 51, in make_client
    terms_of_service_agreed=True))
  File "/home/travis/gopath/src/github.com/letsencrypt/pebble/certbot/acme/acme/client.py", line 103, in register
    url = self.directory.new_reg
  File "/home/travis/gopath/src/github.com/letsencrypt/pebble/certbot/acme/acme/messages.py", line 199, in __getattr__
    raise AttributeError(str(error) + ': ' + name)
AttributeError: 'Directory field not found': new_reg

```