### PR TITLE
Change go get path to prevent error

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ clients are not hardcoding URLs.)
 ## Install
 
 1. [Set up Go](https://golang.org/doc/install) and your `$GOPATH`
-2. `go get -u github.com/letsencrypt/pebble`
+2. `go get -u github.com/letsencrypt/pebble/cmd/pebble`
 3. `cd $GOPATH/src/github.com/letsencrypt/pebble && go install ./...`
 4. `pebble -h`
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ clients are not hardcoding URLs.)
 ## Install
 
 1. [Set up Go](https://golang.org/doc/install) and your `$GOPATH`
-2. `go get -u github.com/letsencrypt/pebble/cmd/pebble`
+2. `go get -u github.com/letsencrypt/pebble/...`
 3. `cd $GOPATH/src/github.com/letsencrypt/pebble && go install ./...`
 4. `pebble -h`
 


### PR DESCRIPTION
Change go get path to prevent error in docs
package github.com/letsencrypt/pebble: no Go files in $GOPATH/src/github.com/letsencrypt/pebble