### PR TITLE
Remove secondary ToS check.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -877,13 +877,6 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(
 		return
 	}
 
-	// Accounts must agree to the ToS before finalizing any orders
-	if !existingAcct.ToSAgreed {
-		wfe.sendError(acme.UnauthorizedProblem(
-			"Must agree to subscriber agreement before finalizing orders"), response)
-		return
-	}
-
 	// Find the order specified by the order ID
 	orderID := strings.TrimPrefix(request.URL.Path, orderFinalizePath)
 	existingOrder := wfe.db.GetOrderByID(orderID)


### PR DESCRIPTION
terms-of-service-agreed is checked at initial signup and doesn't need to be
rechecked.