### PR TITLE
Fix the expectedURL to match HTTPS.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -434,7 +434,9 @@ func (wfe *WebFrontEndImpl) verifyPOST(
 		return nil, nil, acme.MalformedProblem("JWS header parameter 'url' required.")
 	}
 	expectedURL := url.URL{
-		Scheme: "http",
+		// NOTE(@cpu): ACME **REQUIRES** HTTPS and Pebble is hardcoded to offer the
+		// API over HTTPS.
+		Scheme: "https",
 		Host:   request.Host,
 		Path:   request.RequestURI,
 	}


### PR DESCRIPTION
We moved Pebble to only offer the API over HTTPS per ACME spec
requirement but forgot to update the expected URL to know that the
scheme should always be "https".