### PR TITLE
Update pebble shell for HTTPS.

### DIFF
--- a/cmd/pebble-client/main.go
+++ b/cmd/pebble-client/main.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -41,7 +43,7 @@ type client struct {
 	nonce     string
 }
 
-func newClient(server, email string) (*client, error) {
+func newClient(server, email string, pebbleCAPool *x509.CertPool) (*client, error) {
 	url, err := url.Parse(server)
 	if err != nil {
 		return nil, err
@@ -55,7 +57,13 @@ func newClient(server, email string) (*client, error) {
 	c := &client{
 		server: url,
 		email:  email,
-		http:   &http.Client{},
+		http: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs: pebbleCAPool,
+				},
+			},
+		},
 		privKey: jose.SigningKey{
 			Key:       privKey,
 			Algorithm: jose.RS256,
@@ -355,13 +363,20 @@ func (c *client) repl() error {
 }
 
 func main() {
-	server := flag.String("server", "http://localhost:14000/dir", "Directory address for Pebble server")
+	server := flag.String("server", "https://localhost:14000/dir", "Directory address for Pebble server")
 	email := flag.String("email", "", "Email address for ACME registration contact")
+	caCert := flag.String("ca", "test/certs/pebble.minica.pem", "CA Certificate used to validate Pebble server HTTPS certificate")
 	flag.Parse()
+
+	pebbleCA, err := ioutil.ReadFile(*caCert)
+	cmd.FailOnError(err,
+		fmt.Sprintf("Unable to read CA certificate file specified: %q", *caCert))
+	pebbleCAs := x509.NewCertPool()
+	pebbleCAs.AppendCertsFromPEM(pebbleCA)
 
 	fmt.Println("welcome to the pebble shell")
 
-	c, err := newClient(*server, *email)
+	c, err := newClient(*server, *email, pebbleCAs)
 	cmd.FailOnError(err,
 		fmt.Sprintf("Failed to make new pebble client with email %q", *email))
 


### PR DESCRIPTION
The Pebble API is now only accessible over HTTPS. This commit updates
the Pebble shell to use HTTPS & to trust the MiniCA CA by default.