### PR TITLE
Do not expect/validate "Type" in challenge POST.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1104,15 +1104,6 @@ func (wfe *WebFrontEndImpl) validateChallengeUpdate(
 	chal.RLock()
 	defer chal.RUnlock()
 
-	// Check that the challenge update is the same type as the challenge
-	// NOTE: Boulder doesn't do this at the time of writing and instead increments
-	//       a "StartChallengeWrongType" stat
-	if update.Type != chal.Type {
-		return nil, acme.MalformedProblem(
-			fmt.Sprintf("Challenge update was type %s, existing challenge is type %s",
-				update.Type, chal.Type))
-	}
-
 	// Check that the existing challenge is Pending
 	if chal.Status != acme.StatusPending {
 		return nil, acme.MalformedProblem(


### PR DESCRIPTION
Previous to this commit the Pebble `validateChallengeUpdate` function
assumed that the POST JWS payload sent to the challenge update endpoint
contained both "type" and "keyAuthorization" fields. If the provided
"type" value didn't match the server's understanding of the challenge
type an error was returned.

The current ACME draft specification does not require this "type" field.
Section 7.5.1 only describes sending a "keyAuthorization". This
commit removes the expectation that a type field is sent, and the
constraint that it be equal to the expected challenge type.

This resolves #69 - Thanks to @sophie-h for flagging the divergence 
& reporting the bug! 