### PR TITLE
Pebble client: Fix nil panic from missing `new-nonce` endpoint.

### DIFF
--- a/cmd/pebble-client/main.go
+++ b/cmd/pebble-client/main.go
@@ -157,10 +157,10 @@ func (c *client) updateDirectory() error {
 }
 
 func (c *client) updateNonce() error {
-	nonceURL := c.directory["new-nonce"].(string)
-	if nonceURL == "" {
+	if rawNonceURL, present := c.directory["new-nonce"]; !present || rawNonceURL.(string) == "" {
 		return fmt.Errorf("Missing \"new-nonce\" entry in server directory")
 	}
+	nonceURL := c.directory["new-nonce"].(string)
 	fmt.Printf("Requesting nonce from %q\n", nonceURL)
 
 	before := c.nonce


### PR DESCRIPTION
The check for whether the `/directory` JSON response had a `new-nonce`
key was broken: if there wasn't a `new-nonce` entry a `.(string)` cast
caused a nil pointer exception. This commit updates the check to ensure
it operates correctly when there isn't a `new-nonce` key.