### PR TITLE
Small clean-up, adopt ACME-09 camelCase convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pebble
 
 A miniature version of [Boulder](https://github.com/letsencrypt/boulder), Pebble
-is a small [ACME-08](https://tools.ietf.org/html/draft-ietf-acme-acme-08) test
+is a small [ACME-09](https://tools.ietf.org/html/draft-ietf-acme-acme-09) test
 server not suited for use as a production CA.
 
 ## !!! WARNING !!!
@@ -16,17 +16,17 @@ randomize keys/certificates used for issuance.
 ## Goals
 
 1. Produce a simplified testing front end
-2. Move rapidly to gain [ACME draft-08](https://tools.ietf.org/html/draft-ietf-acme-acme-08) experience
+2. Move rapidly to gain [ACME draft-09](https://tools.ietf.org/html/draft-ietf-acme-acme-09) experience
 3. Write "idealized" code that can be adopted back into Boulder
 4. Aggressively build in guardrails against non-testing usage
 
 Pebble aims to address the need for ACME clients to have an easier to use,
 self-contained version of Boulder to test their clients against while developing
-ACME-08 support. Boulder is multi-process, requires heavy dependencies (MariaDB,
+ACME-09 support. Boulder is multi-process, requires heavy dependencies (MariaDB,
 RabbitMQ, etc), and is operationally complex to integrate with other projects.
 
 Where possible Pebble aims to produce code that can be used to inform the
-pending Boulder support for ACME-08, through contribution of code as well as
+pending Boulder support for ACME-09, through contribution of code as well as
 design lessons learned. Development of Pebble is meant to be rapid, and to
 produce a minimum working prototype on a short schedule.
 

--- a/acme/common.go
+++ b/acme/common.go
@@ -26,9 +26,9 @@ type Identifier struct {
 type Account struct {
 	Status             string   `json:"status"`
 	Contact            []string `json:"contact"`
-	ToSAgreed          bool     `json:"terms-of-service-agreed"`
+	ToSAgreed          bool     `json:"termsOfServiceAgreed"`
 	Orders             string   `json:"orders,omitempty"`
-	OnlyReturnExisting bool     `json:"only-return-existing"`
+	OnlyReturnExisting bool     `json:"onlyReturnExisting"`
 }
 
 // An Order is created to request issuance for a CSR
@@ -36,7 +36,7 @@ type Order struct {
 	Status         string       `json:"status"`
 	Expires        string       `json:"expires"`
 	Identifiers    []Identifier `json:"identifiers,omitempty"`
-	FinalizeURL    string       `json:"finalizeURL"`
+	Finalize       string       `json:"finalize"`
 	NotBefore      string       `json:"notBefore,omitempty"`
 	NotAfter       string       `json:"notAfter,omitempty"`
 	Authorizations []string     `json:"authorizations"`

--- a/acme/common.go
+++ b/acme/common.go
@@ -4,14 +4,6 @@ package acme
 type Resource string
 
 const (
-	ResourceNewNonce   = Resource("new-nonce")
-	ResourceNewAccount = Resource("new-account")
-	ResourceNewOrder   = Resource("new-order")
-	// TODO(@cpu): Should there be a resource for challenge or just use 'authz'?
-	ResourceChallenge = Resource("challenge")
-)
-
-const (
 	StatusPending    = "pending"
 	StatusInvalid    = "invalid"
 	StatusValid      = "valid"

--- a/cmd/pebble-client/main.go
+++ b/cmd/pebble-client/main.go
@@ -157,10 +157,10 @@ func (c *client) updateDirectory() error {
 }
 
 func (c *client) updateNonce() error {
-	if rawNonceURL, present := c.directory["new-nonce"]; !present || rawNonceURL.(string) == "" {
-		return fmt.Errorf("Missing \"new-nonce\" entry in server directory")
+	if rawNonceURL, present := c.directory["newNonce"]; !present || rawNonceURL.(string) == "" {
+		return fmt.Errorf("Missing \"newNonce\" entry in server directory")
 	}
-	nonceURL := c.directory["new-nonce"].(string)
+	nonceURL := c.directory["newNonce"].(string)
 	fmt.Printf("Requesting nonce from %q\n", nonceURL)
 
 	before := c.nonce
@@ -171,20 +171,20 @@ func (c *client) updateNonce() error {
 	after := c.nonce
 
 	if before == after {
-		return fmt.Errorf("Did not recieve a fresh nonce from new-nonce URL")
+		return fmt.Errorf("Did not recieve a fresh nonce from newNonce URL")
 	}
 	return nil
 }
 
 func (c *client) register() error {
-	if acctURL, ok := c.directory["new-account"]; !ok || acctURL.(string) == "" {
-		return fmt.Errorf("Missing \"new-account\" entry in server directory")
+	if acctURL, ok := c.directory["newAccount"]; !ok || acctURL.(string) == "" {
+		return fmt.Errorf("Missing \"newAccount\" entry in server directory")
 	}
-	acctURL := c.directory["new-account"].(string)
+	acctURL := c.directory["newAccount"].(string)
 	fmt.Printf("Registering new account with %q\n", acctURL)
 
 	reqBody := struct {
-		ToSAgreed bool `json:"terms-of-service-agreed"`
+		ToSAgreed bool `json:"termsOfServiceAgreed"`
 		Contact   []string
 	}{
 		ToSAgreed: true,
@@ -290,7 +290,7 @@ func (c *client) endpoints() []string {
 func (c *client) readEndpoint() (string, error) {
 	var endpoint string
 	scanner := bufio.NewScanner(os.Stdin)
-	fmt.Printf("$> Enter a directory endpoint to POST: ")
+	fmt.Printf("$> Enter a directory endpoint or a URL to POST: ")
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line == "" || line == "exit" || line == "q" {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -236,9 +236,9 @@ func (wfe *WebFrontEndImpl) Directory(
 	request *http.Request) {
 
 	directoryEndpoints := map[string]string{
-		"new-nonce":   noncePath,
-		"new-account": newAccountPath,
-		"new-order":   newOrderPath,
+		"newNonce":   noncePath,
+		"newAccount": newAccountPath,
+		"newOrder":   newOrderPath,
 	}
 
 	response.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -261,7 +261,7 @@ func (wfe *WebFrontEndImpl) relativeDirectory(request *http.Request, directory m
 		relativeDir[k] = wfe.relativeEndpoint(request, v)
 	}
 	relativeDir["meta"] = map[string]string{
-		"terms-of-service": ToSURL,
+		"termsOfService": ToSURL,
 	}
 
 	directoryJSON, err := marshalIndent(relativeDir)
@@ -615,7 +615,7 @@ func (wfe *WebFrontEndImpl) NewAccount(
 	}
 
 	if newAcct.ToSAgreed == false {
-		response.Header().Add("Link", link(ToSURL, "terms-of-service"))
+		response.Header().Add("Link", link(ToSURL, "termsOfService"))
 		wfe.sendError(
 			acme.AgreementRequiredProblem(
 				"Provided account did not agree to the terms of service"),
@@ -847,7 +847,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 	wfe.log.Printf("There are now %d orders in the db\n", count)
 
 	// Populate a finalization URL for this order
-	order.FinalizeURL = wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", orderFinalizePath, order.ID))
+	order.Finalize = wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", orderFinalizePath, order.ID))
 
 	orderURL := wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", orderPath, order.ID))
 	response.Header().Add("Location", orderURL)
@@ -869,7 +869,7 @@ func (wfe *WebFrontEndImpl) orderForDisplay(
 	defer order.RUnlock()
 
 	// Populate a finalization URL for this order
-	order.FinalizeURL = wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", orderFinalizePath, order.ID))
+	order.Finalize = wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", orderFinalizePath, order.ID))
 
 	// If the order has a cert ID then set the certificate URL by constructing
 	// a relative path based on the HTTP request & the cert ID


### PR DESCRIPTION
There is a new [ACME-09](https://tools.ietf.org/html/draft-ietf-acme-acme-09) draft replacing ACME-08. This PR updates the README accordingly.

This PR also includes a small clean up removing unused `Resource` types, as well as an update to use the ACME-09 [camelCase convention](https://github.com/ietf-wg-acme/acme/commit/7bace61b89d58bab68b4dfed285abaede46fbd1f) throughout Pebble & the Pebble shell.

_Note: This will break CI until the chisel2/acme module are updated to support the new camelCase directory endpoints & resource fields. Sorry!_