### PR TITLE
Restore kebabcase for `terms-of-service` Link header.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -615,7 +615,7 @@ func (wfe *WebFrontEndImpl) NewAccount(
 	}
 
 	if newAcct.ToSAgreed == false {
-		response.Header().Add("Link", link(ToSURL, "termsOfService"))
+		response.Header().Add("Link", link(ToSURL, "terms-of-service"))
 		wfe.sendError(
 			acme.AgreementRequiredProblem(
 				"Provided account did not agree to the terms of service"),


### PR DESCRIPTION
The `Link` header key for the ToS URL shouldn't be snakeCase.

Thanks to @shred for pointing out this error :clap: :trophy: 