### PR TITLE
Implement wildcard issuance policy.

### DIFF
--- a/acme/common.go
+++ b/acme/common.go
@@ -49,6 +49,12 @@ type Authorization struct {
 	Identifier Identifier   `json:"identifier"`
 	Challenges []*Challenge `json:"challenges"`
 	Expires    string       `json:"expires"`
+	// Wildcard is a Let's Encrypt specific Authorization field that indicates the
+	// authorization was created as a result of an order containing a name with
+	// a `*.`wildcard prefix. This will help convey to users that an
+	// Authorization with the identifier `example.com` and one DNS-01 challenge
+	// corresponds to a name `*.example.com` from an associated order.
+	Wildcard bool `json:"wildcard,omitempty"`
 }
 
 // A Challenge is used to validate an Authorization


### PR DESCRIPTION
This commit adds a simplified duplication of [the Boulder wildcard
issuance policy](https://github.com/letsencrypt/boulder/commit/1c99f91733ec136f205e6a192f1abe0ae1c3f342) for Pebble.

This primarily consists of allowing identifiers to take values with
a wildcard prefix (`"*."`) internally. When an authorization for an
identifier with a wildcard issuance is created only a DNS-01 challenge
is added to the authorization. The WFE and VA strip the "*." prefix from
the identifier as required for presentation to the user (to match ACME
semantics) and for validation.

Resolves https://github.com/letsencrypt/pebble/issues/75
