### PR TITLE
Return "orders" field of account even when empty.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Pebble is **NOT INTENDED FOR PRODUCTION USE**. Pebble is for **testing only**.
 By design Pebble will drop all of its state between invocations and will
 randomize keys/certificates used for issuance.
 
+Pebble is not yet a **complete** ACME implementation. It does not presently
+support revocation, account key rollover or account update/retreival.
+
 ## Goals
 
 1. Produce a simplified testing front end

--- a/acme/common.go
+++ b/acme/common.go
@@ -27,7 +27,7 @@ type Account struct {
 	Status             string   `json:"status"`
 	Contact            []string `json:"contact"`
 	ToSAgreed          bool     `json:"termsOfServiceAgreed"`
-	Orders             string   `json:"orders`
+	Orders             []string `json:"orders"`
 	OnlyReturnExisting bool     `json:"onlyReturnExisting"`
 }
 

--- a/acme/common.go
+++ b/acme/common.go
@@ -27,7 +27,7 @@ type Account struct {
 	Status             string   `json:"status"`
 	Contact            []string `json:"contact"`
 	ToSAgreed          bool     `json:"termsOfServiceAgreed"`
-	Orders             string   `json:"orders,omitempty"`
+	Orders             string   `json:"orders`
 	OnlyReturnExisting bool     `json:"onlyReturnExisting"`
 }
 


### PR DESCRIPTION
This commit updates the `acme/common.go` type for `Account` to remove
the `omitempty` json tag. This ensures the field is returned even when
empty (e.g. because the account was just created).

Also clarify that there isn't a way to get or update account details
presently. (E.g. the fact that `orders` is never populated is OK for now
because there's not any way to get an Account object in a response
except from a successful newAccount req that has an empty orders field).

cc @sophie-h

Resolves https://github.com/letsencrypt/pebble/issues/84