### PR TITLE
Rework NewAccount to ensure a status is returned.

### DIFF
--- a/acme/common.go
+++ b/acme/common.go
@@ -24,11 +24,9 @@ type Identifier struct {
 }
 
 type Account struct {
-	Status             string   `json:"status"`
-	Contact            []string `json:"contact"`
-	ToSAgreed          bool     `json:"termsOfServiceAgreed"`
-	Orders             string   `json:"orders,omitempty"`
-	OnlyReturnExisting bool     `json:"onlyReturnExisting"`
+	Status  string   `json:"status"`
+	Contact []string `json:"contact"`
+	Orders  string   `json:"orders,omitempty"`
 }
 
 // An Order is created to request issuance for a CSR


### PR DESCRIPTION
Prior to this commit `wfe.NewAccount` returned an account object with an
empty status field when it should be "valid". This commit ensures that
the initial account object is created with the `Status` field set to
"valid".

This commit also refactors the `NewAccount` code such that the
`acme.Account` type can be used for already created accounts and doesn't
need to maintain a `ToSAgreed` or `OnlyReturnExisting` field. Instead
the WFE uses a throw away struct for the new-account request that holds
the `ToSAgreed` and `OnlyReturnExisting` fields. This helps prevent the
client from POSTing their own `Status` or `Orders` field and makes the
internal types cleaner.

Thanks to @rmbolger for flagging this spec divergence. Resolves https://github.com/letsencrypt/pebble/issues/90