### PR TITLE
Add support for updating existing user accounts

### DIFF
--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -42,6 +42,16 @@ func (m *MemoryStore) GetAccountByID(id string) *core.Account {
 	return m.accountsByID[id]
 }
 
+func (m *MemoryStore) UpdateAccountByID(id string, acct *core.Account) error {
+	m.RLock()
+	defer m.RUnlock()
+	if m.accountsByID[id] == nil {
+		return fmt.Errorf("account with ID %q does not exist", id)
+	}
+	m.accountsByID[id] = acct
+	return nil
+}
+
 func (m *MemoryStore) AddAccount(acct *core.Account) (int, error) {
 	m.Lock()
 	defer m.Unlock()

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -43,8 +43,8 @@ func (m *MemoryStore) GetAccountByID(id string) *core.Account {
 }
 
 func (m *MemoryStore) UpdateAccountByID(id string, acct *core.Account) error {
-	m.RLock()
-	defer m.RUnlock()
+	m.Lock()
+	defer m.Unlock()
 	if m.accountsByID[id] == nil {
 		return fmt.Errorf("account with ID %q does not exist", id)
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -570,7 +570,7 @@ func (wfe *WebFrontEndImpl) UpdateAccount(
 	err := json.Unmarshal(body, &updateAcctReq)
 	if err != nil {
 		wfe.sendError(
-			acme.MalformedProblem("Error unmarshaling body JSON"), response)
+			acme.MalformedProblem("Error unmarshaling account update JSON body"), response)
 		return
 	}
 


### PR DESCRIPTION
This PR adds support for a user posting an account update to the account's URL.

Currently, this just reads a new Account object from the request body, copying across the specified Contact field as required.

Section 7.3.2 of the spec however seems to show another kind of structure, one that I cannot see support for currently in Pebble, nor in the (upcoming) Golang ACMEv2 client (https://go-review.googlesource.com/c/crypto/+/86635):

```
7.3.2.  Account Update

   If the client wishes to update this information in the future, it
   sends a POST request with updated information to the account URL.
   The server MUST ignore any updates to "order" fields or any other
   fields it does not recognize.  If the server accepts the update, it
   MUST return a response with a 200 (OK) status code and the resulting
   account object.

   For example, to update the contact information in the above account,
   the client could send the following request:

   POST /acme/acct/1 HTTP/1.1
   Host: example.com
   Content-Type: application/jose+json

   {
     "protected": base64url({
       "alg": "ES256",
       "kid": "https://example.com/acme/acct/1",
       "nonce": "ax5RnthDqp_Yf4_HZnFLmA",
       "url": "https://example.com/acme/acct/1"
     }),
     "payload": base64url({
       "contact": [
         "mailto:certificates@example.com",
         "mailto:admin@example.com"
       ]
     }),
     "signature": "hDXzvcj8T6fbFbmn...rDzXzzvzpRy64N0o"
   }

Servers SHOULD NOT respond to GET requests for account resources as
   these requests are not authenticated.  If a client wishes to query
   the server for information about its account (e.g., to examine the
   "contact" or "certificates" fields), then it SHOULD do so by sending
   a POST request with an empty update.  That is, it should send a JWS
   whose payload is an empty object ({}).
```

/cc @cpu