### PR TITLE
Remove `KeyAuthorization` from challenge updates.

### DIFF
--- a/acme/common.go
+++ b/acme/common.go
@@ -57,11 +57,10 @@ type Authorization struct {
 
 // A Challenge is used to validate an Authorization
 type Challenge struct {
-	Type             string          `json:"type"`
-	URL              string          `json:"url"`
-	Token            string          `json:"token"`
-	Status           string          `json:"status"`
-	Validated        string          `json:"validated,omitempty"`
-	KeyAuthorization string          `json:"keyAuthorization,omitempty"`
-	Error            *ProblemDetails `json:"error,omitempty"`
+	Type      string          `json:"type"`
+	URL       string          `json:"url"`
+	Token     string          `json:"token"`
+	Status    string          `json:"status"`
+	Validated string          `json:"validated,omitempty"`
+	Error     *ProblemDetails `json:"error,omitempty"`
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1346,7 +1346,7 @@ func (wfe *WebFrontEndImpl) updateChallenge(
 	}
 
 	var chalResp struct {
-		KeyAuthorization string
+		KeyAuthorization *string
 	}
 	err := json.Unmarshal(body, &chalResp)
 	if err != nil {
@@ -1360,7 +1360,7 @@ func (wfe *WebFrontEndImpl) updateChallenge(
 	// sent (and that's what Boulder will do) but for Pebble we'd like to be more
 	// aggressive about pushing clients implementations in the right direction, so
 	// we treat this as a malformed request.
-	if chalResp.KeyAuthorization != "" {
+	if chalResp.KeyAuthorization != nil {
 		wfe.sendError(
 			acme.MalformedProblem(
 				"Challenge response body contained legacy KeyAuthorzation field, "+

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1279,7 +1279,6 @@ func (wfe *WebFrontEndImpl) getAcctByKey(key crypto.PublicKey) (*core.Account, *
 
 func (wfe *WebFrontEndImpl) validateChallengeUpdate(
 	chal *core.Challenge,
-	update *acme.Challenge,
 	acct *core.Account) (*core.Authorization, *acme.ProblemDetails) {
 	// Lock the challenge for reading to do validation
 	chal.RLock()
@@ -1290,16 +1289,6 @@ func (wfe *WebFrontEndImpl) validateChallengeUpdate(
 		return nil, acme.MalformedProblem(
 			fmt.Sprintf("Cannot update challenge with status %s, only status %s",
 				chal.Status, acme.StatusPending))
-	}
-
-	// Calculate the expected key authorization for the owning account's key
-	expectedKeyAuth := chal.ExpectedKeyAuthorization(acct.Key)
-
-	// Validate the expected key auth matches the provided key auth
-	if expectedKeyAuth != update.KeyAuthorization {
-		return nil, acme.MalformedProblem(
-			fmt.Sprintf("Incorrect key authorization: %q",
-				update.KeyAuthorization))
 	}
 
 	return chal.Authz, nil
@@ -1356,11 +1345,26 @@ func (wfe *WebFrontEndImpl) updateChallenge(
 		return
 	}
 
-	var chalResp acme.Challenge
+	var chalResp struct {
+		KeyAuthorization string
+	}
 	err := json.Unmarshal(body, &chalResp)
 	if err != nil {
 		wfe.sendError(
 			acme.MalformedProblem("Error unmarshaling body JSON"), response)
+		return
+	}
+
+	// Historically challenges were updated by POSTing a KeyAuthorization. This is
+	// unnecessary, the server can calculate this itself. We could ignore this if
+	// sent (and that's what Boulder will do) but for Pebble we'd like to be more
+	// aggressive about pushing clients implementations in the right direction, so
+	// we treat this as a malformed request.
+	if chalResp.KeyAuthorization != "" {
+		wfe.sendError(
+			acme.MalformedProblem(
+				"Challenge response body contained legacy KeyAuthorzation field, "+
+					"POST body should be `{}`"), response)
 		return
 	}
 
@@ -1371,7 +1375,7 @@ func (wfe *WebFrontEndImpl) updateChallenge(
 		return
 	}
 
-	authz, prob := wfe.validateChallengeUpdate(existingChal, &chalResp, existingAcct)
+	authz, prob := wfe.validateChallengeUpdate(existingChal, existingAcct)
 	if prob != nil {
 		wfe.sendError(prob, response)
 		return


### PR DESCRIPTION
Per ACME draft-10 challenge update POST bodies [should no longer include
the `KeyAuthorization` field](https://github.com/ietf-wg-acme/acme/commit/4bdfe043058874080aca94cdcc9a47980012715c), the server can calculate this on its own.
Similarly, it shouldn't be returned in challenge bodies sent to the
client because the client can calculate it themselves.

This commit updates Pebble to *reject* challenge updates with
a `KeyAuthorization` field. This is fairly aggressive: We could simply
ignore this field, but Pebble is meant to encourage good client
behaviour so we'll be more aggressive than Boulder will.