### PR TITLE
Enforce JWS Content-Type header per ACME draft-10.

### DIFF
--- a/acme/problems.go
+++ b/acme/problems.go
@@ -123,3 +123,11 @@ func AccountDoesNotExistProblem(detail string) *ProblemDetails {
 		HTTPStatus: http.StatusBadRequest,
 	}
 }
+
+func UnsupportedMediaTypeProblem(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       malformedErr,
+		Detail:     detail,
+		HTTPStatus: http.StatusUnsupportedMediaType,
+	}
+}


### PR DESCRIPTION
This commit updates the WFE `verifyPOST` function to enforce that POSTs
with JWS bodies include the correct Content-Type header. If the header
is missing, or incorrect, an HTTP 415 response with a malformed problem
is returned.