### PR TITLE
Add config flag to enable/disable strict ACME enforcement.

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -29,6 +29,10 @@ func main() {
 		"config",
 		"test/config/pebble-config.json",
 		"File path to the Pebble configuration file")
+	strictMode := flag.Bool(
+		"strict",
+		false,
+		"Enable strict mode to test upcoming API breaking changes")
 	flag.Parse()
 	if *configFile == "" {
 		flag.Usage()
@@ -47,7 +51,7 @@ func main() {
 	ca := ca.New(logger, db)
 	va := va.New(logger, clk, c.Pebble.HTTPPort, c.Pebble.TLSPort)
 
-	wfe := wfe.New(logger, clk, db, va, ca)
+	wfe := wfe.New(logger, clk, db, va, ca, *strictMode)
 	muxHandler := wfe.Handler()
 
 	logger.Printf("Pebble running, listening on: %s\n", c.Pebble.ListenAddress)


### PR DESCRIPTION
Prior to this commit Pebble enforced both that no `keyAuthorization` was
sent in Challenge POST bodies and that all JWS POSTs included the
correct `Content-Type`.

The Let's Encrypt staging/prod V2 environments do not support *not*
sending the `keyAuthorization` (pending an update soon to be deployed),
while Pebble would not support sending it. This leaves clients unable to
support both Pebble and Boulder.

As a compromise this commit introduces a "-strict" flag. When enabled,
breaking changes are enforced by Pebble. This gives client developers an
easy way to check for future API breaking changes. For now we default to
off. After the Boulder updates we should instead default to "on".