### PR TITLE
Move to Go 1.10, add `go vet` to CI, fix vet errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
     - elpmaxe.letsencrypt.org
 
 go:
-  - 1.8
+  - "1.10"
 
 before_install:
   # The acme-v2 branch of certbot has some tweaks required for using chisel2
@@ -25,4 +25,5 @@ before_script:
   - until </dev/tcp/localhost/14000 ; do sleep 0.1 ; done
 
 script:
+  - go vet ./...
   - REQUESTS_CA_BUNDLE=./test/certs/pebble.minica.pem python ./test/chisel2.py example.letsencrypt.org elpmaxe.letsencrypt.org

--- a/cmd/pebble-client/main.go
+++ b/cmd/pebble-client/main.go
@@ -381,7 +381,7 @@ func main() {
 		fmt.Sprintf("Failed to make new pebble client with email %q", *email))
 
 	fmt.Printf("Your account ID is %q\n", c.acctID)
-	fmt.Println("Starting REPL environment...\n\n")
+	fmt.Println("Starting REPL environment...")
 	err = c.repl()
 	cmd.FailOnError(err, "REPL error")
 }

--- a/core/types.go
+++ b/core/types.go
@@ -49,7 +49,7 @@ type Challenge struct {
 	ValidatedDate time.Time
 }
 
-func (ch Challenge) ExpectedKeyAuthorization(key *jose.JSONWebKey) string {
+func (ch *Challenge) ExpectedKeyAuthorization(key *jose.JSONWebKey) string {
 	if key == nil {
 		panic("ExpectedKeyAuthorization called with nil key")
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1413,7 +1413,7 @@ func (wfe *WebFrontEndImpl) updateChallenge(
 	now := wfe.clk.Now()
 	if now.After(existingOrder.ExpiresDate) {
 		wfe.sendError(
-			acme.MalformedProblem(fmt.Sprintf("order expired %s %s",
+			acme.MalformedProblem(fmt.Sprintf("order expired %s",
 				existingOrder.ExpiresDate.Format(time.RFC3339))), response)
 		return
 	}


### PR DESCRIPTION
This commit updates the `.travis.yml` to move to Go 1.10 to match Boulder's Go version. Some `go vet` errors were fixed (thanks to @shred for pointing those out initially!). To keep these minor mistakes from piling up again over time this commit also adds an explicit `go vet` step to the CI tasks.