### PR TITLE
Implement account deactivation.

### DIFF
--- a/acme/common.go
+++ b/acme/common.go
@@ -4,10 +4,11 @@ package acme
 type Resource string
 
 const (
-	StatusPending    = "pending"
-	StatusInvalid    = "invalid"
-	StatusValid      = "valid"
-	StatusProcessing = "processing"
+	StatusPending     = "pending"
+	StatusInvalid     = "invalid"
+	StatusValid       = "valid"
+	StatusProcessing  = "processing"
+	StatusDeactivated = "deactivated"
 
 	IdentifierDNS = "dns"
 


### PR DESCRIPTION
ACME v11 is not very clear about the problem returned after the account
has been deactivated:

> Once an account is deactivated, the server MUST NOT accept further
> requests authorized by that account's key.

This change assumes that any further request that requires to check the
account will return an unauthorized error. That might be something to
ammend in the ACME spec.

Fixes #108

Signed-off-by: David Calavera <david.calavera@gmail.com>