### PR TITLE
Set Order status field to invalid/valid based on authz status

### DIFF
--- a/acme/common.go
+++ b/acme/common.go
@@ -7,6 +7,7 @@ const (
 	StatusPending    = "pending"
 	StatusInvalid    = "invalid"
 	StatusValid      = "valid"
+	StatusReady      = "ready"
 	StatusProcessing = "processing"
 
 	IdentifierDNS = "dns"

--- a/va/va.go
+++ b/va/va.go
@@ -197,7 +197,7 @@ func (va VAImpl) process(task *vaTask) {
 			}
 		}
 		if !anyNotValid {
-			order.Status = acme.StatusValid
+			order.Status = acme.StatusReady
 		}
 		order.Unlock()
 

--- a/va/va.go
+++ b/va/va.go
@@ -141,6 +141,7 @@ func (va VAImpl) process(task *vaTask) {
 	chal.ValidatedDate = now
 	chal.Validated = chal.ValidatedDate.Format(time.RFC3339)
 	authz := chal.Authz
+	order := authz.Order
 	chal.Unlock()
 
 	results := make(chan *core.ValidationRecord, concurrentValidations)
@@ -166,6 +167,11 @@ func (va VAImpl) process(task *vaTask) {
 		authz.Status = acme.StatusInvalid
 		authz.Unlock()
 
+		// Lock the order to update the order status
+		order.Lock()
+		order.Status = acme.StatusInvalid
+		order.Unlock()
+
 		va.log.Printf("authz %s set INVALID by completed challenge %s", authz.ID, chal.ID)
 		// Return immediately - there's no need to check for order issuance
 		return
@@ -182,6 +188,18 @@ func (va VAImpl) process(task *vaTask) {
 		chal.Lock()
 		chal.Status = acme.StatusValid
 		chal.Unlock()
+
+		order.Lock()
+		anyNotValid := false
+		for _, a := range order.AuthorizationObjects {
+			if a.Status != acme.StatusValid {
+				anyNotValid = true
+			}
+		}
+		if !anyNotValid {
+			order.Status = acme.StatusValid
+		}
+		order.Unlock()
 
 		va.log.Printf("authz %s set VALID by completed challenge %s", authz.ID, chal.ID)
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -999,10 +999,10 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(
 		return
 	}
 
-	// The existing order must be in a pending status to finalize it
-	if orderStatus != acme.StatusPending {
+	// The existing order must be in a ready status to finalize it
+	if orderStatus != acme.StatusReady {
 		wfe.sendError(acme.MalformedProblem(fmt.Sprintf(
-			"Order's status (%q) was not pending", orderStatus)), response)
+			"Order's status (%q) was not 'ready'", orderStatus)), response)
 		return
 	}
 


### PR DESCRIPTION
This is an attempt to fix #110 and #98 

I did contemplate not ever setting the order field and always computing it in the memory store in GetOrderByID, but without a 'DeepCopy' function to create copies of orders, it would mean the orders status in the memory store could be updated in memory when a Get is performed. This seemed a bit perverse in my mind, but perhaps we should just do that instead.

/cc @cpu 