### PR TITLE
WFE: Remove unused challenges for non-pending authz.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1226,6 +1226,21 @@ func prepAuthorizationForDisplay(authz acme.Authorization) *acme.Authorization {
 		authz.Identifier.Value = strings.TrimPrefix(identVal, "*.")
 		authz.Wildcard = true
 	}
+
+	// If the authz isn't pending then we need to filter the challenges displayed
+	// to only those that were used to make the authz valid || invalid.
+	if authz.Status != acme.StatusPending {
+		var chals []*acme.Challenge
+		// Scan each of the authz's challenges
+		for _, c := range authz.Challenges {
+			// Include any that have an associated error, or that are status valid
+			if c.Error != nil || c.Status == acme.StatusValid {
+				chals = append(chals, c)
+			}
+		}
+		// Replace the authz's challenges with the filtered set
+		authz.Challenges = chals
+	}
 	return &authz
 }
 


### PR DESCRIPTION
This PR updates the WFE's `prepAuthorizationForDisplay` function such that if the authorization being prep'd is not status pending then the associated challenges are filtered to only those that were used to
make the authz change status. In effect this means that an invalid or valid authz will only have the challenge that was POSTed included in the authz output.

This better matches what the ACME draft says about the "challenges" field in Section 7.1.4 "Authorization Objects".

Resolves https://github.com/letsencrypt/pebble/issues/88 - Thanks to @sophie-h for flagging this issue initially.