### PR TITLE
VA: Allow skipping real challenge validation requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ variable `PEBBLE_VA_NOSLEEP` to `1`. E.g.
 
 `PEBBLE_VA_NOSLEEP=1 pebble -config ./test/config/pebble-config.json`
 
+### Skipping Validation
+
+If you want to avoid the hassle of having to stand up a challenge response
+server for real HTTP-01, DNS-01 or TLS-ALPN-01 validation requests Pebble
+supports a mode that always treats challenge validation requests as successful.
+By default this mode is disabled and challenge validation is performed.
+
+To have all challenge POST requests succeed without performing any validation
+run:
+
+`PEBBLE_VA_ALWAYS_VALID=1 pebble`
+
 ### Invalid Anti-Replay Nonce Errors
 
 The `urn:ietf:params:acme:error:badNonce` error type is meant to be retry-able.


### PR DESCRIPTION
An ACME client developer requested a way to use Pebble to test ACME interactions without having to go through the complexities of standing up a real challenge response server. This lets the developer focus on 
the baseline ACME issuance flow without needing to actually respond to HTTP-01, DNS-01, or TLS-ALPN-01 challenge requests.

This commit adds a new env var `PEBBLE_VA_ALWAYS_VALID` to accomplish the above. When enabled the VA will not actually perform validation when a challenge is POSTed and instead will assume the challenge is valid.

Resolves https://github.com/letsencrypt/pebble/issues/106