### PR TITLE
VA: Don't unlock mutex twice

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -185,7 +185,6 @@ func (va VAImpl) setAuthzInvalid(
 	chal.Error = err
 	// Update the challenge status
 	chal.Status = acme.StatusInvalid
-	chal.Unlock()
 }
 
 func (va VAImpl) process(task *vaTask) {


### PR DESCRIPTION
In `VA.setAuthzInvalid` we `defer` the `Unlock()` of a challenge's `sync.RWMutex`: https://github.com/letsencrypt/pebble/blob/43f6c387dc6278772c54da74f3eb7fb0c1703256/va/va.go#L183

Unfortunately, we also explicitly call `Unlock()` at the end of the function: https://github.com/letsencrypt/pebble/blob/43f6c387dc6278772c54da74f3eb7fb0c1703256/va/va.go#L188

The combination of doing both would panic the `pebble` binary when a challenge validation failed with an error like: `fatal error: sync: Unlock of unlocked RWMutex`

This commit removes the superfluous explicit `Unlock()`, fixes the panic, and resolves https://github.com/letsencrypt/pebble/issues/119.

Thanks to @BenjaminSchubert for reporting this bug! :trophy: 

