### PR TITLE
WFE: Enforce Key ID has expected URL prefix.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -409,6 +409,9 @@ func (wfe *WebFrontEndImpl) lookupJWK(request *http.Request, jws *jose.JSONWebSi
 	header := jws.Signatures[0].Header
 	accountURL := header.KeyID
 	prefix := wfe.relativeEndpoint(request, acctPath)
+	if !strings.HasPrefix(accountURL, prefix) {
+		return nil, acme.MalformedProblem("Key ID (kid) in JWS header missing expected URL prefix")
+	}
 	accountID := strings.TrimPrefix(accountURL, prefix)
 	if accountID == "" {
 		return nil, acme.MalformedProblem("No key ID (kid) in JWS header")


### PR DESCRIPTION
This PR updates the WFE to reject a JWS that has a KeyID that is only the raw account ID (e.g. "1234"), not the full Key ID account URL (e.g. "http://localhost:14000/my-account/xxxxxx").

Resolves https://github.com/letsencrypt/pebble/issues/109 Thanks to @rmbolger for flagging this bug!  :boot: :beetle: