### PR TITLE
Fix wildcard name rejection in issue #126

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -769,7 +769,7 @@ func isDNSCharacter(ch byte) bool {
 	return ('a' <= ch && ch <= 'z') ||
 		('A' <= ch && ch <= 'Z') ||
 		('0' <= ch && ch <= '9') ||
-		ch == '.' || ch == '-'
+		ch == '.' || ch == '-' || ch == '*'
 }
 
 /* TODO(@cpu): Pebble's validation of domain names is still pretty weak


### PR DESCRIPTION
This is a quick fix for the but introduced in PR #122. I realize `*` is not technically a valid DNS character despite being allowed in the `isDNSCharacter` method, but it seemed ok given its purpose.