### PR TITLE
Handle order status as a property of assoc. authz status.

### DIFF
--- a/acme/common.go
+++ b/acme/common.go
@@ -7,7 +7,9 @@ const (
 	StatusPending     = "pending"
 	StatusInvalid     = "invalid"
 	StatusValid       = "valid"
+	StatusExpired     = "expired"
 	StatusProcessing  = "processing"
+	StatusReady       = "ready"
 	StatusDeactivated = "deactivated"
 
 	IdentifierDNS = "dns"
@@ -34,14 +36,15 @@ type Account struct {
 
 // An Order is created to request issuance for a CSR
 type Order struct {
-	Status         string       `json:"status"`
-	Expires        string       `json:"expires"`
-	Identifiers    []Identifier `json:"identifiers,omitempty"`
-	Finalize       string       `json:"finalize"`
-	NotBefore      string       `json:"notBefore,omitempty"`
-	NotAfter       string       `json:"notAfter,omitempty"`
-	Authorizations []string     `json:"authorizations"`
-	Certificate    string       `json:"certificate,omitempty"`
+	Status         string          `json:"status"`
+	Error          *ProblemDetails `json:"error,omitempty"`
+	Expires        string          `json:"expires"`
+	Identifiers    []Identifier    `json:"identifiers,omitempty"`
+	Finalize       string          `json:"finalize"`
+	NotBefore      string          `json:"notBefore,omitempty"`
+	NotAfter       string          `json:"notAfter,omitempty"`
+	Authorizations []string        `json:"authorizations"`
+	Certificate    string          `json:"certificate,omitempty"`
 }
 
 // An Authorization is created for each identifier in an order

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -47,7 +47,7 @@ func main() {
 	cmd.FailOnError(err, "Reading JSON config file into config structure")
 
 	clk := clock.Default()
-	db := db.NewMemoryStore()
+	db := db.NewMemoryStore(clk)
 	ca := ca.New(logger, db)
 	va := va.New(logger, clk, c.Pebble.HTTPPort, c.Pebble.TLSPort)
 

--- a/core/types.go
+++ b/core/types.go
@@ -28,7 +28,7 @@ type Order struct {
 	CertificateObject    *Certificate
 }
 
-func (o Order) GetStatus(clk clock.Clock) (string, error) {
+func (o *Order) GetStatus(clk clock.Clock) (string, error) {
 	// Lock the order for reading
 	o.RLock()
 	defer o.RUnlock()

--- a/core/types.go
+++ b/core/types.go
@@ -59,7 +59,7 @@ func (o *Order) GetStatus(clk clock.Clock) (string, error) {
 		return acme.StatusInvalid, nil
 	}
 
-	// An order is invalid if **any** of its authzs are expired
+	// An order is expired if **any** of its authzs are expired
 	if authzStatuses[acme.StatusExpired] > 0 {
 		return acme.StatusInvalid, nil
 	}


### PR DESCRIPTION
This PR updates the way Pebble handles an Order's status field to closer match the way we handle it in Boulder. This means the order's status is considered to be a calculated field derived based on the order's error/beganProcessing/certificate fields and the status/expires/error of the order's associated authorizations. Along the way the new "Ready" status was implemented. This PR also addresses the problem of the order status not being updated when an authorization is failed. Now, an order has a problem details field that is set when an authorization associated with the order has a failed challenge validation.

Resolves #110 and #98