### PR TITLE
Add certificate revocation call to the WFE.

### DIFF
--- a/acme/problems.go
+++ b/acme/problems.go
@@ -16,6 +16,7 @@ const (
 	invalidContactErr      = errNS + "invalidContact"
 	unsupportedContactErr  = errNS + "unsupportedContact"
 	accountDoesNotExistErr = errNS + "accountDoesNotExist"
+	badRevocationReasonErr = errNS + "badRevocationReason"
 )
 
 type ProblemDetails struct {
@@ -129,5 +130,13 @@ func UnsupportedMediaTypeProblem(detail string) *ProblemDetails {
 		Type:       malformedErr,
 		Detail:     detail,
 		HTTPStatus: http.StatusUnsupportedMediaType,
+	}
+}
+
+func BadRevocationReasonProblem(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       badRevocationReasonErr,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
 	}
 }

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/letsencrypt/pebble/core"
@@ -169,4 +170,24 @@ func (m *MemoryStore) GetCertificateByID(id string) *core.Certificate {
 	m.RLock()
 	defer m.RUnlock()
 	return m.certificatesByID[id]
+}
+
+// GetCertificateByDER loops over all certificates to find the one that matches the provided DER bytes.
+// This method is linear and it's not optimized to give you a quick response.
+func (m *MemoryStore) GetCertificateByDER(der []byte) *core.Certificate {
+	m.RLock()
+	defer m.RUnlock()
+	for _, c := range m.certificatesByID {
+		if reflect.DeepEqual(c.DER, der) {
+			return c
+		}
+	}
+
+	return nil
+}
+
+func (m *MemoryStore) RevokeCertificate(cert *core.Certificate) {
+	m.Lock()
+	defer m.Unlock()
+	delete(m.certificatesByID, cert.ID)
 }


### PR DESCRIPTION
Adds an endpoint to the API to revoke certificates.
There are some caveats to consider:

1. It doesn't verify account ownership.
2. It doesn't verify the certificate issuer.
3. It validates the reason, but it doesn't do anything with it after.

See https://tools.ietf.org/html/draft-ietf-acme-acme-11#section-7.6

Signed-off-by: David Calavera <david.calavera@gmail.com>