### PR TITLE
WFE: Return malformed problem for revoke cert 404.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1651,7 +1651,9 @@ func (wfe *WebFrontEndImpl) RevokeCert(
 
 	cert := wfe.db.GetCertificateByDER(derBytes)
 	if cert == nil {
-		response.WriteHeader(http.StatusNotFound)
+		wfe.sendError(
+			acme.MalformedProblem(
+				"Unable to find specified certificate. It may already be revoked"), response)
 		return
 	}
 


### PR DESCRIPTION
Prior to this commit if a revocation request specified a certificate
that Pebble did not have in the memorystore a bare HTTP 404 response was
returned. It would be better to return an ACME problem (like Boulder
does) in this case so this commit updates the WFE to return a malformed
problem with an appropriate message.

Resolves https://github.com/letsencrypt/pebble/issues/135