### PR TITLE
WFE: Fix revocation authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ clients are not hardcoding URLs.)
 
 ## Limitations
 
-Pebble is missing some ACME features. It does not presently
+Pebble is missing some ACME features (PRs are welcome!). It does not presently
 support account key rollover, the "orders" field of account objects,
-subproblems, pre-authorization or external account binding. Pebble only supports
-authenticating revocation requests with a signature from the private key
-corresponding to the public key in the certificate. PRs are welcome!
+subproblems, pre-authorization or external account binding. Pebble does not
+support revoking a certificate issued by a different ACME account by proving
+authorization of all of the certificate's domains.
 
 Pebble does not perform all of the same input validation as Boulder. Some domain
 names that would be rejected by Boulder/Let's Encrypt may work with Pebble.

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -153,7 +153,7 @@ func (ca *CAImpl) newIntermediateIssuer() error {
 	return nil
 }
 
-func (ca *CAImpl) newCertificate(domains []string, key crypto.PublicKey) (*core.Certificate, error) {
+func (ca *CAImpl) newCertificate(domains []string, key crypto.PublicKey, accountID string) (*core.Certificate, error) {
 	var cn string
 	if len(domains) > 0 {
 		cn = domains[0]
@@ -192,10 +192,11 @@ func (ca *CAImpl) newCertificate(domains []string, key crypto.PublicKey) (*core.
 
 	hexSerial := hex.EncodeToString(cert.SerialNumber.Bytes())
 	newCert := &core.Certificate{
-		ID:     hexSerial,
-		Cert:   cert,
-		DER:    der,
-		Issuer: issuer.cert,
+		ID:        hexSerial,
+		AccountID: accountID,
+		Cert:      cert,
+		DER:       der,
+		Issuer:    issuer.cert,
 	}
 	_, err = ca.db.AddCertificate(newCert)
 	if err != nil {
@@ -246,7 +247,7 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 
 	// issue a certificate for the csr
 	csr := order.ParsedCSR
-	cert, err := ca.newCertificate(csr.DNSNames, csr.PublicKey)
+	cert, err := ca.newCertificate(csr.DNSNames, csr.PublicKey, order.AccountID)
 	if err != nil {
 		ca.log.Printf("Error: unable to issue order: %s", err.Error())
 		return

--- a/core/types.go
+++ b/core/types.go
@@ -145,10 +145,11 @@ func (ch *Challenge) ExpectedKeyAuthorization(key *jose.JSONWebKey) string {
 }
 
 type Certificate struct {
-	ID     string
-	Cert   *x509.Certificate
-	DER    []byte
-	Issuer *Certificate
+	ID        string
+	Cert      *x509.Certificate
+	DER       []byte
+	Issuer    *Certificate
+	AccountID string
 }
 
 func (c Certificate) PEM() []byte {

--- a/wfe/jose.go
+++ b/wfe/jose.go
@@ -1,8 +1,12 @@
 package wfe
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
 	"fmt"
 
 	"gopkg.in/square/go-jose.v2"
@@ -54,4 +58,38 @@ func checkAlgorithm(key *jose.JSONWebKey, parsedJws *jose.JSONWebSignature) (str
 				"algorithm '%s' on JWK is unacceptable", key.Algorithm)
 	}
 	return "", nil
+}
+
+// keyDigest produces a padded, standard Base64-encoded SHA256 digest of a
+// provided public key. See the original Boulder implementation for more details:
+// https://github.com/letsencrypt/boulder/blob/9c2859c87b70059a2082fc1f28e3f8a033c66d43/core/util.go#L92
+func keyDigest(key crypto.PublicKey) (string, error) {
+	switch t := key.(type) {
+	case *jose.JSONWebKey:
+		if t == nil {
+			return "", fmt.Errorf("Cannot compute digest of nil key")
+		}
+		return keyDigest(t.Key)
+	case jose.JSONWebKey:
+		return keyDigest(t.Key)
+	default:
+		keyDER, err := x509.MarshalPKIXPublicKey(key)
+		if err != nil {
+			return "", err
+		}
+		spkiDigest := sha256.Sum256(keyDER)
+		return base64.StdEncoding.EncodeToString(spkiDigest[0:32]), nil
+	}
+}
+
+// keyDigestEquals determines whether two public keys have the same digest.
+func keyDigestEquals(j, k crypto.PublicKey) bool {
+	digestJ, errJ := keyDigest(j)
+	digestK, errK := keyDigest(k)
+	// Keys that don't have a valid digest (due to marshalling problems)
+	// are never equal. So, e.g. nil keys are not equal.
+	if errJ != nil || errK != nil {
+		return false
+	}
+	return digestJ == digestK
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1747,7 +1747,9 @@ func (wfe *WebFrontEndImpl) revokeCertByKeyID(
 			return nil
 		}
 		return acme.UnauthorizedProblem(
-			fmt.Sprintf("Account %q did not request issuance of the to-be-revoked certificate"))
+			fmt.Sprintf(
+				"Account %q did not request issuance of the to-be-revoked certificate",
+				existingAcct.ID))
 	}
 	return wfe.processRevocation(ctx, body, authorizedToRevoke, request, logEvent)
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1748,7 +1748,7 @@ func (wfe *WebFrontEndImpl) revokeCertByKeyID(
 		}
 		return acme.UnauthorizedProblem(
 			fmt.Sprintf(
-				"Account %q did not request issuance of the to-be-revoked certificate",
+				"The certificate being revoked is not associated with account %q",
 				existingAcct.ID))
 	}
 	return wfe.processRevocation(ctx, body, authorizedToRevoke, request, logEvent)


### PR DESCRIPTION
This commit brings over more of Boulder's WFE2 revocation handling to
Pebble and supports **both** authenticating revocation requests with:
* a JWS with a KeyID specifing the account that previously issued the certificate
* a JWS carrying an embedded JWK containing the certificate to be revoked's public key.

Previously the revocation implementation specified it only
supported authenticating the request with the certificate's key and an
embedded JWK. In practice the revocation logic was still expecting a key
ID and authentication from the ACME account. It also did not verify that 
the certificate to be revoked was originally issued by the account that
authenticates the revocation request.


Resolves https://github.com/letsencrypt/pebble/issues/134