### PR TITLE
Custom DNS Server Address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+vendor/

--- a/README.md
+++ b/README.md
@@ -57,11 +57,6 @@ corresponding to the public key in the certificate. PRs are welcome!
 Pebble does not perform all of the same input validation as Boulder. Some domain
 names that would be rejected by Boulder/Let's Encrypt may work with Pebble.
 
-Pebble uses the system DNS resolver. This may mean that caching causes problems
-with DNS-01 validation. It may also mean that no DNSSEC validation is performed.
-You should configure your system's recursive DNS resolver according to your
-needs.
-
 Pebble does not enforce any rate limits. It is not presently an appropriate tool
 for testing that your client handles Boulder/Let's Encrypt rate limits
 correctly.
@@ -94,6 +89,20 @@ Presently we default `-strict` to false but this **will change in the future**.
 If you are using Pebble for integration tests and favour reliability over
 learning about breaking changes ASAP please explicitly run Pebble with `-strict
 false`.
+
+### DNS Server
+
+By default Pebble uses the system DNS resolver, this may mean that caching causes
+problems with DNS-01 validation. It may also mean that no DNSSEC validation is
+performed.
+You should configure your system's recursive DNS resolver according to your
+needs or use the `-dnsserver` flag to define an address to a DNS server. 
+
+```
+pebble -dnsserver 10.10.10.10:5053
+pebble -dnsserver 8.8.8.8:53
+pebble -dnsserver :5053
+```
 
 ### Testing at full speed
 

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -64,7 +64,7 @@ func main() {
 		setupCustomDNSResolver(dnsServerAddress)
 	}
 
-	clk := clock.Default()
+	clk := clock.New()
 	db := db.NewMemoryStore(clk)
 	ca := ca.New(logger, db)
 	va := va.New(logger, clk, c.Pebble.HTTPPort, c.Pebble.TLSPort)

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -18,12 +18,11 @@ import (
 
 type config struct {
 	Pebble struct {
-		ListenAddress    string
-		HTTPPort         int
-		TLSPort          int
-		Certificate      string
-		PrivateKey       string
-		DNSServerAddress string
+		ListenAddress string
+		HTTPPort      int
+		TLSPort       int
+		Certificate   string
+		PrivateKey    string
 	}
 }
 
@@ -53,15 +52,8 @@ func main() {
 	err := cmd.ReadConfigFile(*configFile, &c)
 	cmd.FailOnError(err, "Reading JSON config file into config structure")
 
-	var dnsServerAddress string
 	if len(*resolverAddress) > 0 {
-		dnsServerAddress = *resolverAddress
-	} else {
-		dnsServerAddress = c.Pebble.DNSServerAddress
-	}
-
-	if len(dnsServerAddress) > 0 {
-		setupCustomDNSResolver(dnsServerAddress)
+		setupCustomDNSResolver(*resolverAddress)
 	}
 
 	clk := clock.New()
@@ -84,7 +76,7 @@ func main() {
 func setupCustomDNSResolver(dnsResolverAddress string) {
 	net.DefaultResolver = &net.Resolver{
 		PreferGo: true,
-		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
 			d := net.Dialer{}
 			return d.DialContext(ctx, "udp", dnsResolverAddress)
 		},

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -38,7 +38,7 @@ func main() {
 	resolverAddress := flag.String(
 		"dnsserver",
 		"",
-		"Define a custom DNS server address (ex: 192.168.0.56:5053 or 8.8.8.8:53). Override the configuration file.")
+		"Define a custom DNS server address (ex: 192.168.0.56:5053 or 8.8.8.8:53).")
 	flag.Parse()
 	if *configFile == "" {
 		flag.Usage()


### PR DESCRIPTION
Add a way to add a custom DNS server address:
- add a flag `dnsserver` 

This allow to use custom port and custom address, ex:
- `192.168.0.56:5053`
- `8.8.8.8:53`

Related to #33