### PR TITLE
Making sleep time configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ variable `PEBBLE_VA_NOSLEEP` to `1`. E.g.
 
 `PEBBLE_VA_NOSLEEP=1 pebble -config ./test/config/pebble-config.json`
 
+The maximal number of seconds to sleep can be configured by defining
+`PEBBLE_VA_SLEEPTIME`. It must be set to a positive integer.
+
 ### Skipping Validation
 
 If you want to avoid the hassle of having to stand up a challenge response

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ false`.
 
 ### Testing at full speed
 
-By default Pebble will sleep a random number of seconds (from 1 to 15) between
+By default Pebble will sleep a random number of seconds (from 0 to 15) between
 individual challenge validation attempts. This ensures clients don't make
 assumptions about when the challenge is solved from the CA side by observing
 a single request for a challenge response. Instead clients must poll the

--- a/va/va.go
+++ b/va/va.go
@@ -46,9 +46,9 @@ const (
 	noSleepEnvVar = "PEBBLE_VA_NOSLEEP"
 
 	// sleepTimeEnvVar defines the environment variable name used to set the time
-	// VA should sleep between validation attempts (if not disabled). Set this
-	// e.g. to 5 when you invoke Pebble if you wish the delays to be between 1
-	// and 5 seconds (instead between 1 and 15 seconds):
+	// the VA should sleep between validation attempts (if not disabled). Set this
+	// e.g. to 5 when you invoke Pebble if you wish the delays to be between 0
+	// and 5 seconds (instead between 0 and 15 seconds):
 	//   PEBBLE_VA_SLEEPTIME=5 pebble
 	sleepTimeEnvVar = "PEBBLE_VA_SLEEPTIME"
 
@@ -247,8 +247,7 @@ func (va VAImpl) process(task *vaTask) {
 
 func (va VAImpl) performValidation(task *vaTask, results chan<- *core.ValidationRecord) {
 	if va.sleep {
-		// Sleep for a random amount of time between 1-15s (where 15 can be
-		// changed by modifying va.sleepTime)
+		// Sleep for a random amount of time between 0 and va.sleepTime seconds
 		len := time.Duration(rand.Intn(va.sleepTime))
 		va.log.Printf("Sleeping for %s seconds before validating", time.Second*len)
 		va.clk.Sleep(time.Second * len)

--- a/va/va.go
+++ b/va/va.go
@@ -45,6 +45,13 @@ const (
 	//   PEBBLE_VA_NOSLEEP=1 pebble
 	noSleepEnvVar = "PEBBLE_VA_NOSLEEP"
 
+	// sleepTimeEnvVar defines the environment variable name used to set the time
+	// VA should sleep between validation attempts (if not disabled). Set this
+	// e.g. to 5 when you invoke Pebble if you wish the delays to be between 1
+	// and 5 seconds (instead between 1 and 15 seconds):
+	//   PEBBLE_VA_SLEEPTIME=5 pebble
+	sleepTimeEnvVar = "PEBBLE_VA_SLEEPTIME"
+
 	// noValidateEnvVar defines the environment variable name used to signal that
 	// the VA should *not* actually validate challenges. Set this to 1 when you
 	// invoke Pebble if you wish validation to always succeed without actually
@@ -85,6 +92,7 @@ type VAImpl struct {
 	tlsPort     int
 	tasks       chan *vaTask
 	sleep       bool
+	sleepTime   int
 	alwaysValid bool
 }
 
@@ -93,12 +101,13 @@ func New(
 	clk clock.Clock,
 	httpPort, tlsPort int) *VAImpl {
 	va := &VAImpl{
-		log:      log,
-		clk:      clk,
-		httpPort: httpPort,
-		tlsPort:  tlsPort,
-		tasks:    make(chan *vaTask, taskQueueSize),
-		sleep:    true,
+		log:       log,
+		clk:       clk,
+		httpPort:  httpPort,
+		tlsPort:   tlsPort,
+		tasks:     make(chan *vaTask, taskQueueSize),
+		sleep:     true,
+		sleepTime: 15,
 	}
 
 	// Read the PEBBLE_VA_NOSLEEP environment variable string
@@ -108,6 +117,12 @@ func New(
 	case "1", "true", "True", "TRUE":
 		va.sleep = false
 		va.log.Printf("Disabling random VA sleeps")
+	}
+
+	sleepTime := os.Getenv(sleepTimeEnvVar)
+	sleepTimeInt, err := strconv.Atoi(sleepTime)
+	if err == nil && sleepTimeInt >= 1 {
+		va.sleepTime = sleepTimeInt
 	}
 
 	noValidate := os.Getenv(noValidateEnvVar)
@@ -232,8 +247,9 @@ func (va VAImpl) process(task *vaTask) {
 
 func (va VAImpl) performValidation(task *vaTask, results chan<- *core.ValidationRecord) {
 	if va.sleep {
-		// Sleep for a random amount of time between 1-15s
-		len := time.Duration(rand.Intn(15))
+		// Sleep for a random amount of time between 1-15s (where 15 can be
+		// changed by modifying va.sleepTime)
+		len := time.Duration(rand.Intn(va.sleepTime))
 		va.log.Printf("Sleeping for %s seconds before validating", time.Second*len)
 		va.clk.Sleep(time.Second * len)
 	}

--- a/va/va.go
+++ b/va/va.go
@@ -53,8 +53,8 @@ const (
 	sleepTimeEnvVar = "PEBBLE_VA_SLEEPTIME"
 
 	// defaultSleepTime defines the default sleep time (in seconds) between
-	// validation attempts. Can be disabled resp. modified by the environment
-	// variables PEBBLE_VA_NOSLEEP and PEBBLE_VA_SLEEPTIME (see above).
+	// validation attempts. Can be disabled or modified by the environment
+	// variables PEBBLE_VA_NOSLEEP resp. PEBBLE_VA_SLEEPTIME (see above).
 	defaultSleepTime = 15
 
 	// noValidateEnvVar defines the environment variable name used to signal that
@@ -128,7 +128,7 @@ func New(
 	sleepTimeInt, err := strconv.Atoi(sleepTime)
 	if err == nil && sleepTimeInt >= 1 {
 		va.sleepTime = sleepTimeInt
-		va.log.Printf("Setting maximal random VA sleep time to %d seconds", va.sleepTime)
+		va.log.Printf("Setting maximum random VA sleep time to %d seconds", va.sleepTime)
 	}
 
 	noValidate := os.Getenv(noValidateEnvVar)

--- a/va/va.go
+++ b/va/va.go
@@ -52,6 +52,11 @@ const (
 	//   PEBBLE_VA_SLEEPTIME=5 pebble
 	sleepTimeEnvVar = "PEBBLE_VA_SLEEPTIME"
 
+	// defaultSleepTime defines the default sleep time (in seconds) between
+	// validation attempts. Can be disabled resp. modified by the environment
+	// variables PEBBLE_VA_NOSLEEP and PEBBLE_VA_SLEEPTIME (see above).
+	defaultSleepTime = 15
+
 	// noValidateEnvVar defines the environment variable name used to signal that
 	// the VA should *not* actually validate challenges. Set this to 1 when you
 	// invoke Pebble if you wish validation to always succeed without actually
@@ -107,7 +112,7 @@ func New(
 		tlsPort:   tlsPort,
 		tasks:     make(chan *vaTask, taskQueueSize),
 		sleep:     true,
-		sleepTime: 15,
+		sleepTime: defaultSleepTime,
 	}
 
 	// Read the PEBBLE_VA_NOSLEEP environment variable string

--- a/va/va.go
+++ b/va/va.go
@@ -126,7 +126,7 @@ func New(
 
 	sleepTime := os.Getenv(sleepTimeEnvVar)
 	sleepTimeInt, err := strconv.Atoi(sleepTime)
-	if err == nil && sleepTimeInt >= 1 {
+	if err == nil && !va.sleep && sleepTimeInt >= 1 {
 		va.sleepTime = sleepTimeInt
 		va.log.Printf("Setting maximum random VA sleep time to %d seconds", va.sleepTime)
 	}

--- a/va/va.go
+++ b/va/va.go
@@ -128,6 +128,7 @@ func New(
 	sleepTimeInt, err := strconv.Atoi(sleepTime)
 	if err == nil && sleepTimeInt >= 1 {
 		va.sleepTime = sleepTimeInt
+		va.log.Printf("Setting maximal random VA sleep time to %d seconds", va.sleepTime)
 	}
 
 	noValidate := os.Getenv(noValidateEnvVar)


### PR DESCRIPTION
This introduces a new environment variable `PEBBLE_VA_SLEEPTIME` which allows to set the sleep time to an arbitrary maximum value (instead of just 15). Only positive integers are accepted. (Fixes #140.)

BTW: I noticed that the waiting times were not between 1 and 15 seconds, but between 0 and 14 seconds. My patch doesn't change this, so if you set the maximum to `n`, you will get waits between 0 and `n - 1`. To change this, line 252 in `va.go` should be changed to `len := time.Duration(rand.Intn(va.sleepTime) + 1)`.
