### PR TITLE
Add a Dockerfile.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+pebble.exe
+pebble
+vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.10-alpine as builder
+
+RUN apk --update upgrade \
+&& apk --no-cache --no-progress add git mercurial bash gcc musl-dev curl tar \
+&& rm -rf /var/cache/apk/*
+
+WORKDIR /go/src/github.com/letsencrypt/pebble
+COPY . .
+
+RUN go get -u github.com/jmhodges/clock \
+&& go get -u gopkg.in/square/go-jose.v2
+
+RUN go install ./...
+
+## main
+FROM alpine:3.7
+
+RUN apk update && apk add --no-cache --virtual ca-certificates
+
+COPY --from=builder /go/bin/pebble /usr/bin/pebble
+COPY --from=builder /go/src/github.com/letsencrypt/pebble/test/ /test/
+
+ENTRYPOINT [ "/usr/bin/pebble" ]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Pebble
 
+[![Build Status](https://travis-ci.org/letsencrypt/pebble.svg?branch=master)](https://travis-ci.org/letsencrypt/pebble)
+[![Docker Build Status](https://img.shields.io/docker/build/letsencrypt/pebble.svg)](https://hub.docker.com/r/letsencrypt/pebble/builds/)
+
 A miniature version of [Boulder](https://github.com/letsencrypt/boulder), Pebble
 is a small [ACME-12](https://tools.ietf.org/html/draft-ietf-acme-acme-12) test
 server not suited for use as a production CA.
@@ -70,7 +73,38 @@ correctly.
 
 ## Usage
 
-`pebble -config ./test/config/pebble-config.json`
+### Binary
+
+```bash
+pebble -config ./test/config/pebble-config.json
+```
+
+### Docker Image
+
+With a docker-compose file:
+
+```yaml
+version: '3'
+
+services:
+ pebble:
+  image: letsencrypt/pebble
+  command: -config ./test/my-pebble-config.json
+  ports:
+    - 14000:14000
+  environment:
+    - PEBBLE_VA_NOSLEEP=1
+  volumes:
+    - ./my-pebble-config.json:/test/my-pebble-config.json
+```
+
+With a Docker command:
+
+```bash
+docker run -e "PEBBLE_VA_NOSLEEP=1" letsencrypt/pebble
+# or
+docker run -e "PEBBLE_VA_NOSLEEP=1" --mount src=$(pwd)/my-pebble-config.json,target=/test/my-pebble-config.json,type=bind letsencrypt/pebble -config /test/my-pebble-config.json
+```
 
 ### Strict Mode
 

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -62,7 +62,7 @@ const (
 	// To have the WFE not reject any good nonces, run Pebble like:
 	//   PEBBLE_WFE_NONCEREJECT=0 pebble
 	// To have the WFE reject 15% of good nonces, run Pebble like:
-	//   PEBBLE_WFE_NONCEREJECT=15
+	//   PEBBLE_WFE_NONCEREJECT=15 pebble
 	badNonceEnvVar = "PEBBLE_WFE_NONCEREJECT"
 
 	// By default when no PEBBLE_WFE_NONCEREJECT is set, what percentage of good


### PR DESCRIPTION
This PR adds a simple Dockerfile.

In the case of running tests for a client with Docker, it avoids having to build the image during the execution of the tests or maintain a fork to build an image for the Docker Hub.

If this PR interests you, could you activate the automatic builds from the Docker Hub so that the image is built automatically? (this would allow to easily run the tests with a Pebble always up to date)