### PR TITLE
Fix issue where intermediate CA was self signed

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -77,13 +77,16 @@ func (ca *CAImpl) makeRootCert(
 	}
 
 	var signerKey crypto.Signer
-	if signer != nil && signer.key != nil {
+	var parent *x509.Certificate
+	if signer != nil && signer.key != nil && signer.cert != nil && signer.cert.Cert != nil {
 		signerKey = signer.key
+		parent = signer.cert.Cert
 	} else {
 		signerKey = subjectKey
+		parent = template
 	}
 
-	der, err := x509.CreateCertificate(rand.Reader, template, template, subjectKey.Public(), signerKey)
+	der, err := x509.CreateCertificate(rand.Reader, template, parent, subjectKey.Public(), signerKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Issuer Certificate was being issued as self signed, rather than signed by the root CA, causing issues with Google Chrome and MS Edge to determine that the certificate was invalid. 

Fix to ensure that the signer's certificate is passed to x509.CreateCertificate as per docs https://golang.org/pkg/crypto/x509/#CreateCertificate