### PR TITLE
Distinguish between empty contact list and not specified contact list

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -669,7 +669,7 @@ func (wfe *WebFrontEndImpl) UpdateAccount(
 
 	// if this update contains no contacts or deactivated status,
 	// simply return the existing account and return early.
-	if len(updateAcctReq.Contact) == 0 && updateAcctReq.Status != acme.StatusDeactivated {
+	if updateAcctReq.Contact == nil && updateAcctReq.Status != acme.StatusDeactivated {
 		err = wfe.writeJsonResponse(response, http.StatusOK, existingAcct)
 		if err != nil {
 			wfe.sendError(acme.InternalErrorProblem("Error marshalling account"), response)
@@ -697,7 +697,7 @@ func (wfe *WebFrontEndImpl) UpdateAccount(
 			acme.MalformedProblem(fmt.Sprintf(
 				"Invalid account status: %q", updateAcctReq.Status)), response)
 		return
-	case len(updateAcctReq.Contact) > 0:
+	case updateAcctReq.Contact != nil:
 		newAcct.Contact = updateAcctReq.Contact
 		// Verify that the contact information provided is supported & valid
 		prob = wfe.verifyContacts(newAcct.Account)


### PR DESCRIPTION
When updating an account, this PR changes the behavior such that an empty contact list is treated differently than a not specified one (or one which is set to `null`, which cannot be distinguished easily from a not specified one). This allows clients to actually delete the contacts list.

Fixes #114.

I haven't got around to properly test this, so please either test this before merging, or wait for me to do proper testing ;-)