### PR TITLE
Allow to retrieve root certificate by GET /root

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,6 @@ correctly.
 pebble -config ./test/config/pebble-config.json
 ```
 
-Note that the CA's root certificate is regenerated on every launch. It can be
-retrieved via `https://localhost:14000/root`.
-
 ### Docker Image
 
 With a docker-compose file:
@@ -209,3 +206,18 @@ should offer a runtime option to specify a list of trusted root CAs.
 store or to any production systems/codebases. The private key for this CA is
 intentionally made [publicly available in this
 repo](test/certs/pebble.minica.key.pem).**
+
+### CA Root Certificate
+
+Note that the CA's root certificate is regenerated on every launch. It can be
+retrieved by a `GET` request to `https://localhost:14000/root`.
+
+You might need the root certificate to verify the complete trust chain of
+generated certificates, for example in end-to-end tests.
+
+**IMPORTANT: Do not add Pebble's root or intermediate certificate to a trust
+store that you use for ordinary browsing or that is used for non-testing
+purposes, since Pebble and its generated keys are not audited or held to the
+same standards as the Let's Encrypt production CA and their keys, and so are
+not safe to use for anything other than testing. Also, their private keys
+will be lost as soon as the Pebble process terminates.**

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ correctly.
 pebble -config ./test/config/pebble-config.json
 ```
 
+Note that the CA's root certificate is regenerated on every launch. It can be
+retrieved via `https://localhost:14000/root`.
+
 ### Docker Image
 
 With a docker-compose file:

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -262,3 +262,7 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 	order.CertificateObject = cert
 	order.Unlock()
 }
+
+func (ca *CAImpl) GetRootCert() *core.Certificate {
+	return ca.root.cert
+}

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -264,5 +264,8 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 }
 
 func (ca *CAImpl) GetRootCert() *core.Certificate {
+	if ca.root == nil {
+		return nil
+	}
 	return ca.root.cert
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -49,6 +49,7 @@ const (
 	challengePath     = "/chalZ/"
 	certPath          = "/certZ/"
 	revokeCertPath    = "/revoke-cert"
+	rootCertPath      = "/root"
 
 	// How long do pending authorizations last before expiring?
 	pendingAuthzExpire = time.Hour
@@ -232,6 +233,17 @@ func (wfe *WebFrontEndImpl) sendError(prob *acme.ProblemDetails, response http.R
 	response.Write(problemDoc)
 }
 
+func (wfe *WebFrontEndImpl) RootCert(
+	ctx context.Context,
+	logEvent *requestEvent,
+	response http.ResponseWriter,
+	request *http.Request) {
+
+	response.Header().Set("Content-Type", "application/pem-certificate-chain; charset=utf-8")
+	response.WriteHeader(http.StatusOK)
+	_, _ = response.Write(wfe.ca.GetRootCert().PEM())
+}
+
 func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	m := http.NewServeMux()
 	wfe.HandleFunc(m, directoryPath, wfe.Directory, "GET")
@@ -246,6 +258,7 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	wfe.HandleFunc(m, certPath, wfe.Certificate, "GET")
 	wfe.HandleFunc(m, acctPath, wfe.UpdateAccount, "POST")
 	wfe.HandleFunc(m, revokeCertPath, wfe.RevokeCert, "POST")
+	wfe.HandleFunc(m, rootCertPath, wfe.RootCert, "GET")
 
 	return m
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -239,9 +239,15 @@ func (wfe *WebFrontEndImpl) RootCert(
 	response http.ResponseWriter,
 	request *http.Request) {
 
+	root := wfe.ca.GetRootCert()
+	if root == nil {
+		response.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
 	response.Header().Set("Content-Type", "application/pem-certificate-chain; charset=utf-8")
 	response.WriteHeader(http.StatusOK)
-	_, _ = response.Write(wfe.ca.GetRootCert().PEM())
+	_, _ = response.Write(root.PEM())
 }
 
 func (wfe *WebFrontEndImpl) Handler() http.Handler {


### PR DESCRIPTION
Provides a `GET` endpoint to retrieve the CA's root certificate. Fixes #152.