### PR TITLE
#154: Forgot to update all account references on update

### DIFF
--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -77,7 +77,12 @@ func (m *MemoryStore) UpdateAccountByID(id string, acct *core.Account) error {
 	if m.accountsByID[id] == nil {
 		return fmt.Errorf("account with ID %q does not exist", id)
 	}
+	keyID, err := keyToID(acct.Key)
+	if err != nil {
+		return err
+	}
 	m.accountsByID[id] = acct
+	m.accountsByKeyID[keyID] = acct
 	return nil
 }
 


### PR DESCRIPTION
@cpu I noticed one bug in #154: on account update, only `m.accountsByID[id]` was updated, but not `m.accountsByKeyID[keyID]` (with corresponding `keyID`). This leads to strange update behavior, with changes suddenly disappearing (depending on how you look at them, i.e. either via account public key or via account URI).

(I noticed that my test for #149 stopped working, resp. started to behave really strange.)