### PR TITLE
Improve certificate revocation

### DIFF
--- a/acme/problems.go
+++ b/acme/problems.go
@@ -17,6 +17,7 @@ const (
 	unsupportedContactErr  = errNS + "unsupportedContact"
 	accountDoesNotExistErr = errNS + "accountDoesNotExist"
 	badRevocationReasonErr = errNS + "badRevocationReason"
+	alreadyRevokedErr      = errNS + "alreadyRevoked"
 )
 
 type ProblemDetails struct {
@@ -136,6 +137,14 @@ func UnsupportedMediaTypeProblem(detail string) *ProblemDetails {
 func BadRevocationReasonProblem(detail string) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       badRevocationReasonErr,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+func AlreadyRevokedProblem(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       alreadyRevokedErr,
 		Detail:     detail,
 		HTTPStatus: http.StatusBadRequest,
 	}

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -39,18 +39,20 @@ type MemoryStore struct {
 	challengesByID map[string]*core.Challenge
 
 	certificatesByID map[string]*core.Certificate
+	revokedCertificatesByID map[string]*core.Certificate
 }
 
 func NewMemoryStore(clk clock.Clock) *MemoryStore {
 	return &MemoryStore{
-		clk:                clk,
-		accountIDCounter:   1,
-		accountsByID:       make(map[string]*core.Account),
-		accountsByKeyID:    make(map[string]*core.Account),
-		ordersByID:         make(map[string]*core.Order),
-		authorizationsByID: make(map[string]*core.Authorization),
-		challengesByID:     make(map[string]*core.Challenge),
-		certificatesByID:   make(map[string]*core.Certificate),
+		clk:                    clk,
+		accountIDCounter:       1,
+		accountsByID:           make(map[string]*core.Account),
+		accountsByKeyID:        make(map[string]*core.Account),
+		ordersByID:             make(map[string]*core.Order),
+		authorizationsByID:     make(map[string]*core.Authorization),
+		challengesByID:         make(map[string]*core.Challenge),
+		certificatesByID:        make(map[string]*core.Certificate),
+		revokedCertificatesByID: make(map[string]*core.Certificate),
 	}
 }
 
@@ -214,6 +216,9 @@ func (m *MemoryStore) AddCertificate(cert *core.Certificate) (int, error) {
 	if _, present := m.certificatesByID[certID]; present {
 		return 0, fmt.Errorf("cert %q already exists", certID)
 	}
+	if _, present := m.revokedCertificatesByID[certID]; present {
+		return 0, fmt.Errorf("cert %q already exists (and is revoked)", certID)
+	}
 
 	m.certificatesByID[certID] = cert
 	return len(m.certificatesByID), nil
@@ -239,9 +244,24 @@ func (m *MemoryStore) GetCertificateByDER(der []byte) *core.Certificate {
 	return nil
 }
 
+// GetCertificateByDER loops over all revoked certificates to find the one that matches the provided
+// DER bytes. This method is linear and it's not optimized to give you a quick response.
+func (m *MemoryStore) GetRevokedCertificateByDER(der []byte) *core.Certificate {
+	m.RLock()
+	defer m.RUnlock()
+	for _, c := range m.revokedCertificatesByID {
+		if reflect.DeepEqual(c.DER, der) {
+			return c
+		}
+	}
+
+	return nil
+}
+
 func (m *MemoryStore) RevokeCertificate(cert *core.Certificate) {
 	m.Lock()
 	defer m.Unlock()
+	m.revokedCertificatesByID[cert.ID] = cert
 	delete(m.certificatesByID, cert.ID)
 }
 

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1799,8 +1799,14 @@ func (wfe *WebFrontEndImpl) processRevocation(
 
 	cert := wfe.db.GetCertificateByDER(derBytes)
 	if cert == nil {
-		return acme.MalformedProblem(
-			"Unable to find specified certificate. It may already be revoked")
+		cert := wfe.db.GetRevokedCertificateByDER(derBytes)
+		if cert != nil {
+			return acme.AlreadyRevokedProblem(
+				"Certificate has already been revoked.")
+		} else {
+			return acme.MalformedProblem(
+				"Unable to find specified certificate.")
+		}
 	}
 
 	if prob := authorizedToRevoke(cert); prob != nil {


### PR DESCRIPTION
This PR adds code to store all revoked certificates, so that the new [draft-14 error](https://tools.ietf.org/html/draft-ietf-acme-acme-14#section-6.6) `alreadyRevoked` can be returned (see [page 56](https://tools.ietf.org/html/draft-ietf-acme-acme-14#page-56)) instead of a generic malformed problem if an already revoked certificate is to be revoked again.

Updates #136 to newest draft.
