### PR TITLE
TLS-ALPN-01: Adjust IdPeAcmeIdentifier to value in draft-05

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -59,7 +59,7 @@ func main() {
 	clk := clock.New()
 	db := db.NewMemoryStore(clk)
 	ca := ca.New(logger, db)
-	va := va.New(logger, clk, c.Pebble.HTTPPort, c.Pebble.TLSPort)
+	va := va.New(logger, clk, c.Pebble.HTTPPort, c.Pebble.TLSPort, *strictMode)
 
 	wfe := wfe.New(logger, clk, db, va, ca, *strictMode)
 	muxHandler := wfe.Handler()

--- a/va/va.go
+++ b/va/va.go
@@ -65,7 +65,7 @@ const (
 	noValidateEnvVar = "PEBBLE_VA_ALWAYS_VALID"
 )
 
-var IdPeAcmeIdentifierV1 = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 30, 1}
+var IdPeAcmeIdentifier = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 31}
 
 func userAgent() string {
 	return fmt.Sprintf(
@@ -377,7 +377,7 @@ func (va VAImpl) validateTLSALPN01(task *vaTask) *core.ValidationRecord {
 	expectedKeyAuthorization := task.Challenge.ExpectedKeyAuthorization(task.Account.Key)
 	h := sha256.Sum256([]byte(expectedKeyAuthorization))
 	for _, ext := range leafCert.Extensions {
-		if IdPeAcmeIdentifierV1.Equal(ext.Id) && ext.Critical {
+		if IdPeAcmeIdentifier.Equal(ext.Id) && ext.Critical {
 			var extValue []byte
 			if _, err := asn1.Unmarshal(ext.Value, &extValue); err != nil {
 				errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+

--- a/va/va.go
+++ b/va/va.go
@@ -72,7 +72,7 @@ var IdPeAcmeIdentifier = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 31}
 // This is the identifier defined in draft-01. This is only supported for backwards
 // compatibility.
 // (https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-01#page-4)
-var IdPeAcmeIdentifierV1 = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 30, 1}
+var IdPeAcmeIdentifierV1Obsolete = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 30, 1}
 
 func userAgent() string {
 	return fmt.Sprintf(
@@ -391,14 +391,14 @@ func (va VAImpl) validateTLSALPN01(task *vaTask) *core.ValidationRecord {
 			hasAcmeIdentifier := IdPeAcmeIdentifier.Equal(ext.Id)
 			// For backwards compatibility, check old identifier
 			// as well if strict mode is not enabled
-			if !va.strict && IdPeAcmeIdentifierV1.Equal(ext.Id) {
+			if !va.strict && IdPeAcmeIdentifierV1Obsolete.Equal(ext.Id) {
 				hasAcmeIdentifier = true
 			}
 			if hasAcmeIdentifier {
 				var extValue []byte
 				if _, err := asn1.Unmarshal(ext.Value, &extValue); err != nil {
 					errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+
-						"Malformed acmeValidationV1 extension value.", acme.ChallengeTLSALPN01)	
+						"Malformed acmeValidation extension value.", acme.ChallengeTLSALPN01)	
 					result.Error = acme.UnauthorizedProblem(errText)
 					return result
 				}
@@ -406,7 +406,7 @@ func (va VAImpl) validateTLSALPN01(task *vaTask) *core.ValidationRecord {
 					return result
 				}
 				errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+
-					"Invalid acmeValidationV1 extension value.", acme.ChallengeTLSALPN01)
+					"Invalid acmeValidation extension value.", acme.ChallengeTLSALPN01)
 				result.Error = acme.UnauthorizedProblem(errText)
 				return result
 			}


### PR DESCRIPTION
This updates `id-pe-acmeIdentifier-v1` with OID `1.3.6.1.5.5.7.1.30.1` ([draft-01](https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-01#page-4)) to `id-pe-acmeIdentifier` with OID `1.3.6.1.5.5.7.1.31` ([draft-05](https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-05#page-4)).

CC @rolandshoemaker