### PR TITLE
Remove unauthenticated GET in -strict.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1884,19 +1884,17 @@ func (wfe *WebFrontEndImpl) Certificate(
 	response http.ResponseWriter,
 	request *http.Request) {
 
-	var account *core.Account
 	if request.Method == "POST" {
 		postData, prob := wfe.verifyPOST(ctx, logEvent, request, wfe.lookupJWK)
 		if prob != nil {
 			wfe.sendError(prob, response)
 			return
 		}
-		acct, prob := wfe.validPOSTAsGET(postData)
+		_, prob = wfe.validPOSTAsGET(postData)
 		if prob != nil {
 			wfe.sendError(prob, response)
 			return
 		}
-		account = acct
 	}
 
 	serial := strings.TrimPrefix(request.URL.Path, certPath)
@@ -1904,15 +1902,6 @@ func (wfe *WebFrontEndImpl) Certificate(
 	if cert == nil {
 		response.WriteHeader(http.StatusNotFound)
 		return
-	}
-
-	// if the account that authenticated the request is not empty ensure that the
-	// certificate specified is owned by that account
-	if account != nil {
-		if cert.AccountID != account.ID {
-			response.WriteHeader(http.StatusNotFound)
-			return
-		}
 	}
 
 	response.Header().Set("Content-Type", "application/pem-certificate-chain; charset=utf-8")

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -641,7 +641,7 @@ func (wfe *WebFrontEndImpl) verifyJWS(
 	}
 
 	return &authenticatedPOST{
-		postAsGet: string(payload) == "",
+		postAsGet: len(payload) == 0 && payload != nil,
 		body:      payload,
 		url:       headerURL,
 		jwk:       pubKey}, nil

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -641,7 +641,7 @@ func (wfe *WebFrontEndImpl) verifyJWS(
 	}
 
 	return &authenticatedPOST{
-		postAsGet: payload == nil,
+		postAsGet: string(payload) == "",
 		body:      payload,
 		url:       headerURL,
 		jwk:       pubKey}, nil


### PR DESCRIPTION
This is an experimental implementation of the acme draft protocol change
proposed in ACME PR 445[0]. When Pebble is run with `-strict` it will no
longer allow unauthenticated GET requests to Orders, Authorizations or
Challenges. Support is added for "POST-as-GET" requests as an
authenticated alternative.

[0] - https://github.com/ietf-wg-acme/acme/pull/445