### PR TITLE
WFE: Fix POST-as-GET

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -643,7 +643,7 @@ func (wfe *WebFrontEndImpl) verifyJWS(
 	}
 
 	return &authenticatedPOST{
-		postAsGet: len(payload) == 0 && payload != nil,
+		postAsGet: string(payload) == "",
 		body:      payload,
 		url:       headerURL,
 		jwk:       pubKey}, nil


### PR DESCRIPTION
Like I [described on-list](https://mailarchive.ietf.org/arch/msg/acme/HWXOB39xv0TqW6tbILlBnCgMFCQ) this POST-as-GET empty body check is difficult to implement correctly and I messed it up during the implementation PR based on review feedback. This reverts that review feedback and puts the code back into a state that inter-operates with clients.

Resolves https://github.com/letsencrypt/pebble/issues/167