### PR TITLE
Pebble cmd: Print directory URL and root CA URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ correctly.
 pebble -config ./test/config/pebble-config.json
 ```
 
+Afterwards you can access the Pebble server's ACME directory
+at `http://localhost:14000/dir`.
+
 ### Docker Image
 
 With a docker-compose file:

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -47,6 +47,7 @@ func main() {
 
 	// Log to stdout
 	logger := log.New(os.Stdout, "Pebble ", log.LstdFlags)
+	logger.Printf("Starting Pebble ACME server")
 
 	var c config
 	err := cmd.ReadConfigFile(*configFile, &c)
@@ -61,10 +62,14 @@ func main() {
 	ca := ca.New(logger, db)
 	va := va.New(logger, clk, c.Pebble.HTTPPort, c.Pebble.TLSPort, *strictMode)
 
-	wfe := wfe.New(logger, clk, db, va, ca, *strictMode)
-	muxHandler := wfe.Handler()
+	wfeImpl := wfe.New(logger, clk, db, va, ca, *strictMode)
+	muxHandler := wfeImpl.Handler()
 
-	logger.Printf("Pebble running, listening on: %s\n", c.Pebble.ListenAddress)
+	logger.Printf("Listening on: %s\n", c.Pebble.ListenAddress)
+	logger.Printf("ACME directory available at: https://%s%s",
+		c.Pebble.ListenAddress, wfe.DirectoryPath)
+	logger.Printf("Root CA certificate available at: https://%s%s",
+		c.Pebble.ListenAddress, wfe.RootCertPath)
 	err = http.ListenAndServeTLS(
 		c.Pebble.ListenAddress,
 		c.Pebble.Certificate,

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -36,7 +36,9 @@ import (
 const (
 	// Note: We deliberately pick endpoint paths that differ from Boulder to
 	// exercise clients processing of the /directory response
-	directoryPath     = "/dir"
+	// We export the DirectoryPath and RootCertPath so that the pebble binary can reference it
+	DirectoryPath     = "/dir"
+	RootCertPath      = "/root"
 	noncePath         = "/nonce-plz"
 	newAccountPath    = "/sign-me-up"
 	acctPath          = "/my-account/"
@@ -47,7 +49,6 @@ const (
 	challengePath     = "/chalZ/"
 	certPath          = "/certZ/"
 	revokeCertPath    = "/revoke-cert"
-	rootCertPath      = "/root"
 	keyRolloverPath   = "/rollover-account-key"
 
 	// How long do pending authorizations last before expiring?
@@ -253,10 +254,10 @@ func (wfe *WebFrontEndImpl) RootCert(
 func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	m := http.NewServeMux()
 	// GET only handlers
-	wfe.HandleFunc(m, directoryPath, wfe.Directory, "GET")
+	wfe.HandleFunc(m, DirectoryPath, wfe.Directory, "GET")
 	// Note for noncePath: "GET" also implies "HEAD"
 	wfe.HandleFunc(m, noncePath, wfe.Nonce, "GET")
-	wfe.HandleFunc(m, rootCertPath, wfe.RootCert, "GET")
+	wfe.HandleFunc(m, RootCertPath, wfe.RootCert, "GET")
 
 	// POST only handlers
 	wfe.HandleFunc(m, newAccountPath, wfe.NewAccount, "POST")


### PR DESCRIPTION
Also update the README instructions to prominently mention the directory URL.

Thanks to @m-adler for the suggestion :clinking_glasses: 

Resolves https://github.com/letsencrypt/pebble/issues/165