### PR TITLE
Allow POST-as-GET for account retrieval

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -746,6 +746,10 @@ func (wfe *WebFrontEndImpl) UpdateAccount(
 	// if this update contains no contacts or deactivated status,
 	// simply return the existing account and return early.
 	if updateAcctReq.Contact == nil && updateAcctReq.Status != acme.StatusDeactivated {
+		if wfe.strict == true && postData.postAsGet == false {
+			wfe.sendError(acme.MalformedProblem("Use POST-as-GET to retrieve account data instead of doing an empty update"), response)
+			return
+		}
 		err := wfe.writeJsonResponse(response, http.StatusOK, existingAcct)
 		if err != nil {
 			wfe.sendError(acme.InternalErrorProblem("Error marshalling account"), response)

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -746,7 +746,7 @@ func (wfe *WebFrontEndImpl) UpdateAccount(
 	// if this update contains no contacts or deactivated status,
 	// simply return the existing account and return early.
 	if updateAcctReq.Contact == nil && updateAcctReq.Status != acme.StatusDeactivated {
-		if wfe.strict == true && postData.postAsGet == false {
+		if wfe.strict && !postData.postAsGet {
 			wfe.sendError(acme.MalformedProblem("Use POST-as-GET to retrieve account data instead of doing an empty update"), response)
 			return
 		}


### PR DESCRIPTION
If I understand [draft-15](https://tools.ietf.org/html/draft-ietf-acme-acme-15) correctly, the account URL also must allow POST-as-GET (for account information retrieval). The current Pebble version does not support that yet, i.e. you need to pass `{}` as the JWT payload (that isn't anymore mentioned explicitly in the draft, as I assume POST-as-GET is the new preferred method).

This is an attempt to allow POST-as-GET also for account URLs.