### PR TITLE
Lower default nonce reject & VA sleep time.

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -55,7 +55,7 @@ const (
 	// defaultSleepTime defines the default sleep time (in seconds) between
 	// validation attempts. Can be disabled or modified by the environment
 	// variables PEBBLE_VA_NOSLEEP resp. PEBBLE_VA_SLEEPTIME (see above).
-	defaultSleepTime = 15
+	defaultSleepTime = 5
 
 	// noValidateEnvVar defines the environment variable name used to signal that
 	// the VA should *not* actually validate challenges. Set this to 1 when you
@@ -398,7 +398,7 @@ func (va VAImpl) validateTLSALPN01(task *vaTask) *core.ValidationRecord {
 				var extValue []byte
 				if _, err := asn1.Unmarshal(ext.Value, &extValue); err != nil {
 					errText := fmt.Sprintf("Incorrect validation certificate for %s challenge. "+
-						"Malformed acmeValidation extension value.", acme.ChallengeTLSALPN01)	
+						"Malformed acmeValidation extension value.", acme.ChallengeTLSALPN01)
 					result.Error = acme.UnauthorizedProblem(errText)
 					return result
 				}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -68,7 +68,7 @@ const (
 
 	// By default when no PEBBLE_WFE_NONCEREJECT is set, what percentage of good
 	// nonces are rejected?
-	defaultNonceReject = 15
+	defaultNonceReject = 5
 
 	// POST requests with a JWS body must have the following Content-Type header
 	expectedJWSContentType = "application/jose+json"


### PR DESCRIPTION
In a POST-as-GET world there are a lot more POST requests which means a lot more chances for bad nonces. The existing default rejection rate of 15% is now too high in practice. 

Similarly, a longer default VA sleep time means clients poll resources waiting for status changes longer, which means more POST-as-GET requests, which means more POSTs which means more chance for nonce rejections again.

The upstream `acme` module gaining support for POST-as-GET but only retrying requests a maximum of **one** time for badNonce errors means without these changes our CI consistently fails after bad luck & many requests ensures two or more concurrent badNonce errors (See: https://github.com/certbot/certbot/issues/6542)