### PR TITLE
pebble-challtestsrv: add request history API.

### DIFF
--- a/cmd/pebble-challtestsrv/README.md
+++ b/cmd/pebble-challtestsrv/README.md
@@ -159,6 +159,9 @@ Each HTTP request event is an object of the form:
       "ServerName": "example-sni.com"
    }
 ```
+If the HTTP request was over the HTTPS interface then HTTPS will be true and the
+ServerName field will be populated with the SNI value sent by the client in the
+initial TLS hello.
 
 To get the history of DNS requests run:
 
@@ -190,7 +193,18 @@ Each TLS-ALPN-01 request event is an object of the form:
       ]
    }
 ```
+The ServerName field is populated with the SNI value sent by the client in the
+initial TLS hello. The SupportedProtos field is set with the advertised
+supported next protocols from the initial TLS hello.
 
-To clear all request history run:
+To clear HTTP request history run:
 
-    curl -X POST -d '{}' http://localhost:8055/clear-request-history
+    curl -X POST -d '{"type":"http"}' http://localhost:8055/clear-request-history
+
+Similarly, to clear DNS request history run:
+
+    curl -X POST -d '{"type":"dns"}' http://localhost:8055/clear-request-history
+
+And to clear TLS-ALPN-01 request history run:
+
+    curl -X POST -d '{"type":"tlsalpn"}' http://localhost:8055/clear-request-history

--- a/cmd/pebble-challtestsrv/README.md
+++ b/cmd/pebble-challtestsrv/README.md
@@ -36,7 +36,7 @@ To disable a challenge type, set the bind address to `""`. E.g.:
 
 ### Management Interface
 
-_Note: These examples assume the default `-management` interface address, `:8056`._
+_Note: These examples assume the default `-management` interface address, `:8055`._
 
 #### Mock DNS
 
@@ -45,12 +45,12 @@ _Note: These examples assume the default `-management` interface address, `:8056
 To set the default IPv4 address used for responses to `A` queries that do not
 match explicit mocks run:
 
-    curl -X POST -d '{"ip":"10.10.10.2"}' http://localhost:8056/set-default-ipv4
+    curl -X POST -d '{"ip":"10.10.10.2"}' http://localhost:8055/set-default-ipv4
 
 Similarly to set the default IPv6 address used for responses to `AAAA` queries
 that do not match explicit mocks run:
 
-    curl -X POST -d '{"ip":"::1"}' http://localhost:8056/set-default-ipv6
+    curl -X POST -d '{"ip":"::1"}' http://localhost:8055/set-default-ipv6
 
 To clear the default IPv4 or IPv6 address POST the same endpoints with an empty
 (`""`) IP.
@@ -60,20 +60,20 @@ To clear the default IPv4 or IPv6 address POST the same endpoints with an empty
 To add IPv4 addresses to be returned for `A` queries for
 `test-host.letsencrypt.org` run:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org", "addresses":["12.12.12.12", "13.13.13.13"]}' http://localhost:8056/add-a
+    curl -X POST -d '{"host":"test-host.letsencrypt.org", "addresses":["12.12.12.12", "13.13.13.13"]}' http://localhost:8055/add-a
 
 The mocked `A` responses can be removed by running:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8056/clear-a
+    curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/clear-a
 
 To add IPv6 addresses to be returned for `AAAA` queries for
 `test-host.letsencrypt.org` run:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org", "addresses":["2001:4860:4860::8888", "2001:4860:4860::8844"]}' http://localhost:8056/add-aaaa
+    curl -X POST -d '{"host":"test-host.letsencrypt.org", "addresses":["2001:4860:4860::8888", "2001:4860:4860::8844"]}' http://localhost:8055/add-aaaa
 
 The mocked `AAAA` responses can be removed by running:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8056/clear-aaaa
+    curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/clear-aaaa
 
 ##### Mocked CAA Responses
 
@@ -90,7 +90,7 @@ To remove the mocked CAA policy for `test-host.letsencrypt.org` run:
 
 To add an HTTP-01 challenge response for the token `"aaaa"` with the content `"bbbb"` run:
 
-    curl -X POST -d '{"token":"aaaa", "content":"bbbb"}' http://localhost:8056/add-http01
+    curl -X POST -d '{"token":"aaaa", "content":"bbbb"}' http://localhost:8055/add-http01
 
 Afterwards the challenge response will be available over HTTP at
 `http://localhost:5002/.well-known/acme-challenge/aaaa`, and HTTPS at
@@ -98,14 +98,14 @@ Afterwards the challenge response will be available over HTTP at
 
 The HTTP-01 challenge response for the `"aaaa"` token can be deleted by running:
 
-    curl -X POST -d '{"token":"aaaa"}' http://localhost:8056/del-http01
+    curl -X POST -d '{"token":"aaaa"}' http://localhost:8055/del-http01
 
 ##### Redirects
 
 To add a redirect from `/.well-known/acme-challenge/whatever` to
 `https://localhost:5003/ok` run:
 
-    curl -X POST -d '{"path":"/.well-known/whatever", "targetURL": "https://localhost:5003/ok"}' http://localhost:8056/add-redirect
+    curl -X POST -d '{"path":"/.well-known/whatever", "targetURL": "https://localhost:5003/ok"}' http://localhost:8055/add-redirect
 
 Afterwards HTTP requests to `http://localhost:5002/.well-known/whatever/` will
 be redirected to `https://localhost:5003/ok`. HTTPS requests that match the
@@ -114,26 +114,82 @@ path from HTTP to HTTPS.
 
 To remove the redirect run:
 
-    curl -X POST -d '{"path":"/.well-known/whatever"}' http://localhost:8056/del-redirect
+    curl -X POST -d '{"path":"/.well-known/whatever"}' http://localhost:8055/del-redirect
 
 #### DNS-01
 
 To add a DNS-01 challenge response for `_acme-challenge.test-host.letsencrypt.org` with
 the value `"foo"` run:
 
-    curl -X POST -d '{"host":"_acme-challenge.test-host.letsencrypt.org", "value": "foo"}' http://localhost:8056/add-txt
+    curl -X POST -d '{"host":"_acme-challenge.test-host.letsencrypt.org", "value": "foo"}' http://localhost:8055/add-txt
 
 To remove the mocked DNS-01 challenge response run:
 
-    curl -X POST -d '{"host":"_acme-challenge.test-host.letsencrypt.org"}' http://localhost:8056/clear-txt
+    curl -X POST -d '{"host":"_acme-challenge.test-host.letsencrypt.org"}' http://localhost:8055/clear-txt
 
 #### TLS-ALPN-01
 
 To add a TLS-ALPN-01 challenge response certificate for the host
 `test-host.letsencrypt.org` with the key authorization `"foo"` run:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org", "content":"foo"}' http://localhost:8056/add-tlsalpn01
+    curl -X POST -d '{"host":"test-host.letsencrypt.org", "content":"foo"}' http://localhost:8055/add-tlsalpn01
 
 To remove the mocked TLS-ALPN-01 challenge response run:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8056/clear-tlsalpn01
+    curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/clear-tlsalpn01
+
+#### Request History
+
+`pebble-challtestsrv` keeps track of the requests processed by each of the
+challenge servers and exposes this information via JSON.
+
+To get the history of HTTP requests run:
+
+    curl http://localhost:8055/http-request-history
+
+Each HTTP request event is an object of the form:
+```
+   {
+      "Time": "2018-12-12T16:42:20.667521441-05:00",
+      "URL": "/test-whatever/dude?token=blah",
+      "Host": "localhost:5002",
+      "Method": "GET",
+      "Path": "/test-whatever/dude",
+      "HTTPS": false
+   }
+```
+
+To get the history of DNS requests run:
+
+    curl http://localhost:8055/dns-request-history
+
+Each DNS request event is an object of the form:
+```
+   {
+      "Time": "2018-12-12T16:42:34.465299005-05:00",
+      "Question": {
+         "Name": "bogdog.cog.",
+         "Qtype": 257,
+         "Qclass": 1
+      }
+   }
+```
+
+To get the history of TLS-ALPN-01 requests run:
+
+    curl http://localhost:8055/tlsalpn01-request-history
+
+Each TLS-ALPN-01 request event is an object of the form:
+```
+   {
+      "Time": "2018-12-12T16:42:50.654684756-05:00",
+      "ServerName": "heydudez.watup",
+      "SupportedProtos": [
+         "dogzrule"
+      ]
+   }
+```
+
+To clear all request history run:
+
+    curl -X POST -d '{}' http://localhost:8055/clear-request-history

--- a/cmd/pebble-challtestsrv/README.md
+++ b/cmd/pebble-challtestsrv/README.md
@@ -167,9 +167,9 @@ If the HTTP request was over the HTTPS interface then HTTPS will be true and the
 ServerName field will be populated with the SNI value sent by the client in the
 initial TLS hello.
 
-To get the history of DNS requests for `example.com.` run:
+To get the history of DNS requests for `example.com` run:
 
-    curl -X POST -d '{"host":"example.com."}' http://localhost:8055/dns-request-history
+    curl -X POST -d '{"host":"example.com"}' http://localhost:8055/dns-request-history
 
 Each DNS request event is an object of the form:
 ```
@@ -182,7 +182,7 @@ Each DNS request event is an object of the form:
    }
 ```
 
-To get the history of TLS-ALPN-01 requests run:
+To get the history of TLS-ALPN-01 requests for the SNI host `example.com` run:
 
     curl -X POST -d '{"host":"example.com"}' http://localhost:8055/tlsalpn01-request-history
 
@@ -203,9 +203,9 @@ To clear HTTP request history for `example.com` run:
 
     curl -X POST -d '{"host":"example.com", "type":"http"}' http://localhost:8055/clear-request-history
 
-Similarly, to clear DNS request history for `example.com.` run:
+Similarly, to clear DNS request history for `example.com` run:
 
-    curl -X POST -d '{"host":"example.com.", "type":"dns"}' http://localhost:8055/clear-request-history
+    curl -X POST -d '{"host":"example.com", "type":"dns"}' http://localhost:8055/clear-request-history
 
 And to clear TLS-ALPN-01 request history for `example.com` run:
 

--- a/cmd/pebble-challtestsrv/README.md
+++ b/cmd/pebble-challtestsrv/README.md
@@ -155,7 +155,8 @@ Each HTTP request event is an object of the form:
       "Host": "localhost:5002",
       "Method": "GET",
       "Path": "/test-whatever/dude",
-      "HTTPS": false
+      "HTTPS": true,
+      "ServerName": "example-sni.com"
    }
 ```
 

--- a/cmd/pebble-challtestsrv/README.md
+++ b/cmd/pebble-challtestsrv/README.md
@@ -150,18 +150,15 @@ To remove the mocked TLS-ALPN-01 challenge response run:
 `pebble-challtestsrv` keeps track of the requests processed by each of the
 challenge servers and exposes this information via JSON.
 
-To get the history of HTTP requests run:
+To get the history of HTTP requests to `example.com` run:
 
-    curl http://localhost:8055/http-request-history
+    curl -X POST -d '{"host":"example.com"}' http://localhost:8055/http-request-history
 
 Each HTTP request event is an object of the form:
 ```
    {
-      "Time": "2018-12-12T16:42:20.667521441-05:00",
       "URL": "/test-whatever/dude?token=blah",
-      "Host": "localhost:5002",
-      "Method": "GET",
-      "Path": "/test-whatever/dude",
+      "Host": "example.com",
       "HTTPS": true,
       "ServerName": "example-sni.com"
    }
@@ -170,16 +167,15 @@ If the HTTP request was over the HTTPS interface then HTTPS will be true and the
 ServerName field will be populated with the SNI value sent by the client in the
 initial TLS hello.
 
-To get the history of DNS requests run:
+To get the history of DNS requests for `example.com.` run:
 
-    curl http://localhost:8055/dns-request-history
+    curl -X POST -d '{"host":"example.com."}' http://localhost:8055/dns-request-history
 
 Each DNS request event is an object of the form:
 ```
    {
-      "Time": "2018-12-12T16:42:34.465299005-05:00",
       "Question": {
-         "Name": "bogdog.cog.",
+         "Name": "example.com.",
          "Qtype": 257,
          "Qclass": 1
       }
@@ -188,13 +184,12 @@ Each DNS request event is an object of the form:
 
 To get the history of TLS-ALPN-01 requests run:
 
-    curl http://localhost:8055/tlsalpn01-request-history
+    curl -X POST -d '{"host":"example.com"}' http://localhost:8055/tlsalpn01-request-history
 
 Each TLS-ALPN-01 request event is an object of the form:
 ```
    {
-      "Time": "2018-12-12T16:42:50.654684756-05:00",
-      "ServerName": "heydudez.watup",
+      "ServerName": "example.com",
       "SupportedProtos": [
          "dogzrule"
       ]
@@ -204,14 +199,14 @@ The ServerName field is populated with the SNI value sent by the client in the
 initial TLS hello. The SupportedProtos field is set with the advertised
 supported next protocols from the initial TLS hello.
 
-To clear HTTP request history run:
+To clear HTTP request history for `example.com` run:
 
-    curl -X POST -d '{"type":"http"}' http://localhost:8055/clear-request-history
+    curl -X POST -d '{"host":"example.com", "type":"http"}' http://localhost:8055/clear-request-history
 
-Similarly, to clear DNS request history run:
+Similarly, to clear DNS request history for `example.com.` run:
 
-    curl -X POST -d '{"type":"dns"}' http://localhost:8055/clear-request-history
+    curl -X POST -d '{"host":"example.com.", "type":"dns"}' http://localhost:8055/clear-request-history
 
-And to clear TLS-ALPN-01 request history run:
+And to clear TLS-ALPN-01 request history for `example.com` run:
 
-    curl -X POST -d '{"type":"tlsalpn"}' http://localhost:8055/clear-request-history
+    curl -X POST -d '{"host":"example.com", "type":"tlsalpn"}' http://localhost:8055/clear-request-history

--- a/cmd/pebble-challtestsrv/history.go
+++ b/cmd/pebble-challtestsrv/history.go
@@ -2,77 +2,70 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/letsencrypt/challtestsrv"
 )
 
 // clearHistory handles an HTTP POST request to clear the challenge server
-// request history.
+// request history for a specific type of event.
 //
-// The POST body is expected to be the trivial JSON payload `{}`
+// The POST body is expected to have one parameter:
+// "type" - the type of event to clear. May be "http", "dns", or "tlsalpn"
 //
 // A successful POST will write http.StatusOK to the client.
 func (srv *managementServer) clearHistory(w http.ResponseWriter, r *http.Request) {
-	var request struct{}
+	var request struct {
+		Typ string `json:"type"`
+	}
 	if err := mustParsePOST(&request, r); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	srv.challSrv.ClearRequestHistory()
-	srv.log.Print("Cleared challenge server request history\n")
-	w.WriteHeader(http.StatusOK)
+	typeMap := map[string]challtestsrv.RequestEventType{
+		"http":    challtestsrv.HTTPRequestEventType,
+		"dns":     challtestsrv.DNSRequestEventType,
+		"tlsalpn": challtestsrv.TLSALPNRequestEventType,
+	}
+	if code, ok := typeMap[request.Typ]; ok {
+		srv.challSrv.ClearRequestHistory(code)
+		srv.log.Printf("Cleared challenge server request history for %q events\n",
+			request.Typ)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	http.Error(w, fmt.Sprintf("%q event type unknown", request.Typ), http.StatusBadRequest)
+	return
 }
 
 // getHTTPHistory returns only the HTTPRequestEvent's from the challenge
 // server's request history in JSON form.
 func (srv *managementServer) getHTTPHistory(w http.ResponseWriter, r *http.Request) {
-	history := srv.challSrv.RequestHistory()
-
-	var filteredHistory []challtestsrv.RequestEvent
-	for _, event := range history {
-		if httpEvent, ok := event.(challtestsrv.HTTPRequestEvent); ok {
-			filteredHistory = append(filteredHistory, httpEvent)
-		}
-	}
-
-	srv.writeHistory(filteredHistory, w)
+	srv.writeHistory(srv.challSrv.RequestHistory(challtestsrv.HTTPRequestEventType), w)
 }
 
 // getDNSHistory returns only the DNSRequestEvent's from the challenge
 // server's request history in JSON form.
 func (srv *managementServer) getDNSHistory(w http.ResponseWriter, r *http.Request) {
-	history := srv.challSrv.RequestHistory()
-
-	var filteredHistory []challtestsrv.RequestEvent
-	for _, event := range history {
-		if dnsEvent, ok := event.(challtestsrv.DNSRequestEvent); ok {
-			filteredHistory = append(filteredHistory, dnsEvent)
-		}
-	}
-
-	srv.writeHistory(filteredHistory, w)
+	srv.writeHistory(srv.challSrv.RequestHistory(challtestsrv.DNSRequestEventType), w)
 }
 
 // getTLSALPNHistory returns only the TLSALPNRequestEvent's from the challenge
 // server's request history in JSON form.
 func (srv *managementServer) getTLSALPNHistory(w http.ResponseWriter, r *http.Request) {
-	history := srv.challSrv.RequestHistory()
-
-	var filteredHistory []challtestsrv.RequestEvent
-	for _, event := range history {
-		if alpnEvent, ok := event.(challtestsrv.TLSALPNRequestEvent); ok {
-			filteredHistory = append(filteredHistory, alpnEvent)
-		}
-	}
-
-	srv.writeHistory(filteredHistory, w)
+	srv.writeHistory(srv.challSrv.RequestHistory(challtestsrv.TLSALPNRequestEventType), w)
 }
 
 // writeHistory writes the provided list of challtestsrv.RequestEvents to the
 // provided http.ResponseWriter in JSON form.
 func (srv *managementServer) writeHistory(
 	history []challtestsrv.RequestEvent, w http.ResponseWriter) {
+	// Always write an empty JSON list instead of `null`
+	if history == nil {
+		history = []challtestsrv.RequestEvent{}
+	}
 	jsonHistory, err := json.MarshalIndent(history, "", "   ")
 	if err != nil {
 		srv.log.Printf("Error marshaling history: %v\n", err)

--- a/cmd/pebble-challtestsrv/history.go
+++ b/cmd/pebble-challtestsrv/history.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/letsencrypt/challtestsrv"
+)
+
+// clearHistory handles an HTTP POST request to clear the challenge server
+// request history.
+//
+// The POST body is expected to be the trivial JSON payload `{}`
+//
+// A successful POST will write http.StatusOK to the client.
+func (srv *managementServer) clearHistory(w http.ResponseWriter, r *http.Request) {
+	var request struct{}
+	if err := mustParsePOST(&request, r); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	srv.challSrv.ClearRequestHistory()
+	srv.log.Print("Cleared challenge server request history\n")
+	w.WriteHeader(http.StatusOK)
+}
+
+// getHTTPHistory returns only the HTTPRequestEvent's from the challenge
+// server's request history in JSON form.
+func (srv *managementServer) getHTTPHistory(w http.ResponseWriter, r *http.Request) {
+	history := srv.challSrv.RequestHistory()
+
+	var filteredHistory []challtestsrv.RequestEvent
+	for _, event := range history {
+		if httpEvent, ok := event.(challtestsrv.HTTPRequestEvent); ok {
+			filteredHistory = append(filteredHistory, httpEvent)
+		}
+	}
+
+	srv.writeHistory(filteredHistory, w)
+}
+
+// getDNSHistory returns only the DNSRequestEvent's from the challenge
+// server's request history in JSON form.
+func (srv *managementServer) getDNSHistory(w http.ResponseWriter, r *http.Request) {
+	history := srv.challSrv.RequestHistory()
+
+	var filteredHistory []challtestsrv.RequestEvent
+	for _, event := range history {
+		if dnsEvent, ok := event.(challtestsrv.DNSRequestEvent); ok {
+			filteredHistory = append(filteredHistory, dnsEvent)
+		}
+	}
+
+	srv.writeHistory(filteredHistory, w)
+}
+
+// getTLSALPNHistory returns only the TLSALPNRequestEvent's from the challenge
+// server's request history in JSON form.
+func (srv *managementServer) getTLSALPNHistory(w http.ResponseWriter, r *http.Request) {
+	history := srv.challSrv.RequestHistory()
+
+	var filteredHistory []challtestsrv.RequestEvent
+	for _, event := range history {
+		if alpnEvent, ok := event.(challtestsrv.TLSALPNRequestEvent); ok {
+			filteredHistory = append(filteredHistory, alpnEvent)
+		}
+	}
+
+	srv.writeHistory(filteredHistory, w)
+}
+
+// writeHistory writes the provided list of challtestsrv.RequestEvents to the
+// provided http.ResponseWriter in JSON form.
+func (srv *managementServer) writeHistory(
+	history []challtestsrv.RequestEvent, w http.ResponseWriter) {
+	jsonHistory, err := json.MarshalIndent(history, "", "   ")
+	if err != nil {
+		srv.log.Printf("Error marshaling history: %v\n", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(jsonHistory)
+}

--- a/cmd/pebble-challtestsrv/history.go
+++ b/cmd/pebble-challtestsrv/history.go
@@ -37,7 +37,6 @@ func (srv *managementServer) clearHistory(w http.ResponseWriter, r *http.Request
 	}
 
 	http.Error(w, fmt.Sprintf("%q event type unknown", request.Typ), http.StatusBadRequest)
-	return
 }
 
 // getHTTPHistory returns only the HTTPRequestEvent's from the challenge

--- a/cmd/pebble-challtestsrv/main.go
+++ b/cmd/pebble-challtestsrv/main.go
@@ -118,6 +118,11 @@ func main() {
 		http.HandleFunc("/del-tlsalpn01", oobSrv.delTLSALPN01)
 	}
 
+	http.HandleFunc("/clear-request-history", oobSrv.clearHistory)
+	http.HandleFunc("/http-request-history", oobSrv.getHTTPHistory)
+	http.HandleFunc("/dns-request-history", oobSrv.getDNSHistory)
+	http.HandleFunc("/tlsalpn01-request-history", oobSrv.getTLSALPNHistory)
+
 	// Start all of the sub-servers in their own Go routines so that the main Go
 	// routine can spin forever looking for signals to catch.
 	go srv.Run()

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/letsencrypt/pebble
 
 require (
 	github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
-	github.com/letsencrypt/challtestsrv v1.0.0
+	github.com/letsencrypt/challtestsrv v1.0.1-0.20181212222758-e1173e47e167
 	golang.org/x/net v0.0.0-20181207154023-610586996380 // indirect
 	golang.org/x/sys v0.0.0-20181206074257-70b957f3b65e // indirect
 	gopkg.in/square/go-jose.v2 v2.1.9

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/letsencrypt/pebble
 
 require (
 	github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
-	github.com/letsencrypt/challtestsrv v1.0.1-0.20181212222758-e1173e47e167
+	github.com/letsencrypt/challtestsrv v1.0.1-0.20181213164708-7ac06f2c48ad
 	golang.org/x/net v0.0.0-20181207154023-610586996380 // indirect
 	golang.org/x/sys v0.0.0-20181206074257-70b957f3b65e // indirect
 	gopkg.in/square/go-jose.v2 v2.1.9

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/letsencrypt/pebble
 
 require (
 	github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
-	github.com/letsencrypt/challtestsrv v1.0.1-0.20181213164708-7ac06f2c48ad
+	github.com/letsencrypt/challtestsrv v1.0.1-0.20181214141602-e2eba9b59bf7
 	golang.org/x/net v0.0.0-20181207154023-610586996380 // indirect
 	golang.org/x/sys v0.0.0-20181206074257-70b957f3b65e // indirect
 	gopkg.in/square/go-jose.v2 v2.1.9

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/letsencrypt/pebble
 
 require (
 	github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
-	github.com/letsencrypt/challtestsrv v1.0.1-0.20181214212536-8d77fe6e69cc
+	github.com/letsencrypt/challtestsrv v1.0.1
 	golang.org/x/net v0.0.0-20181207154023-610586996380 // indirect
 	golang.org/x/sys v0.0.0-20181206074257-70b957f3b65e // indirect
 	gopkg.in/square/go-jose.v2 v2.1.9

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/letsencrypt/pebble
 
 require (
 	github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
-	github.com/letsencrypt/challtestsrv v1.0.1-0.20181214141602-e2eba9b59bf7
+	github.com/letsencrypt/challtestsrv v1.0.1-0.20181214212536-8d77fe6e69cc
 	golang.org/x/net v0.0.0-20181207154023-610586996380 // indirect
 	golang.org/x/sys v0.0.0-20181206074257-70b957f3b65e // indirect
 	gopkg.in/square/go-jose.v2 v2.1.9

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/letsencrypt/challtestsrv v1.0.1-0.20181212222758-e1173e47e167 h1:QH2b
 github.com/letsencrypt/challtestsrv v1.0.1-0.20181212222758-e1173e47e167/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/letsencrypt/challtestsrv v1.0.1-0.20181213164708-7ac06f2c48ad h1:WKfASZKhpfYh+wggJWPtKWDiRSN93GOnGHfTdCGCqU8=
 github.com/letsencrypt/challtestsrv v1.0.1-0.20181213164708-7ac06f2c48ad/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181214141602-e2eba9b59bf7 h1:/Kl45ZozvwLA7sl7sikILYS0orc6bRrd++qP8tNqjf0=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181214141602-e2eba9b59bf7/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/miekg/dns v1.1.1 h1:DVkblRdiScEnEr0LR9nTnEQqHYycjkXW9bOjd+2EL2o=
 github.com/miekg/dns v1.1.1/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/letsencrypt/challtestsrv v1.0.1-0.20181212211825-6441a6a4faad h1:GAhf
 github.com/letsencrypt/challtestsrv v1.0.1-0.20181212211825-6441a6a4faad/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/letsencrypt/challtestsrv v1.0.1-0.20181212222758-e1173e47e167 h1:QH2bqxMbHIrpX+s/+z5Z/dlfWrJJVtOAHmZobt8ztDQ=
 github.com/letsencrypt/challtestsrv v1.0.1-0.20181212222758-e1173e47e167/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181213164708-7ac06f2c48ad h1:WKfASZKhpfYh+wggJWPtKWDiRSN93GOnGHfTdCGCqU8=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181213164708-7ac06f2c48ad/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/miekg/dns v1.1.1 h1:DVkblRdiScEnEr0LR9nTnEQqHYycjkXW9bOjd+2EL2o=
 github.com/miekg/dns v1.1.1/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,14 @@ github.com/letsencrypt/challtestsrv v1.0.1-0.20181213164708-7ac06f2c48ad h1:WKfA
 github.com/letsencrypt/challtestsrv v1.0.1-0.20181213164708-7ac06f2c48ad/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/letsencrypt/challtestsrv v1.0.1-0.20181214141602-e2eba9b59bf7 h1:/Kl45ZozvwLA7sl7sikILYS0orc6bRrd++qP8tNqjf0=
 github.com/letsencrypt/challtestsrv v1.0.1-0.20181214141602-e2eba9b59bf7/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181214205357-9a3b55451bba h1:cZjwNzTr4ZukBk6/cfqwBQsvZuhme8gELXR2Upzbv1U=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181214205357-9a3b55451bba/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181214211236-91d66851530d h1:fViNBP77AG+QEWUNPKLLOmUtX/shnfljrfVtNRK7fVE=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181214211236-91d66851530d/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181214212133-97213d51de4b h1:skXVfdU3xp5ULyjjY4rRBLeFNZAtvYpTZ7dEvge8fvc=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181214212133-97213d51de4b/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181214212536-8d77fe6e69cc h1:XKu0K6+XznHIJXP0gv+jkHZUleFBqWPw3HT/RSdS9FY=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181214212536-8d77fe6e69cc/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/miekg/dns v1.1.1 h1:DVkblRdiScEnEr0LR9nTnEQqHYycjkXW9bOjd+2EL2o=
 github.com/miekg/dns v1.1.1/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/letsencrypt/challtestsrv v1.0.1-0.20181214212133-97213d51de4b h1:skXV
 github.com/letsencrypt/challtestsrv v1.0.1-0.20181214212133-97213d51de4b/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/letsencrypt/challtestsrv v1.0.1-0.20181214212536-8d77fe6e69cc h1:XKu0K6+XznHIJXP0gv+jkHZUleFBqWPw3HT/RSdS9FY=
 github.com/letsencrypt/challtestsrv v1.0.1-0.20181214212536-8d77fe6e69cc/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
+github.com/letsencrypt/challtestsrv v1.0.1 h1:9K3DJleJxOnP3YlFPWeNydca61Lwj4vySqP4W9hi8vE=
+github.com/letsencrypt/challtestsrv v1.0.1/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/miekg/dns v1.1.1 h1:DVkblRdiScEnEr0LR9nTnEQqHYycjkXW9bOjd+2EL2o=
 github.com/miekg/dns v1.1.1/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,12 @@ github.com/letsencrypt/challtestsrv v0.0.0-20181206200831-495441a88800 h1:lLMZpQ
 github.com/letsencrypt/challtestsrv v0.0.0-20181206200831-495441a88800/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/letsencrypt/challtestsrv v1.0.0 h1:qWZX81YKt+ke5U4jJePbO3hDtdEbKC93aHYxgJNFvTI=
 github.com/letsencrypt/challtestsrv v1.0.0/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181212211153-921078ce7fc4 h1:NgzUgTJ5BbPt13D7T7Is+dyzZ4KW0Ognc6oT9WT5aJI=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181212211153-921078ce7fc4/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181212211825-6441a6a4faad h1:GAhfHjMmok/3SXsygak5o3RI0OPP+0/cGs0UXR0SJDE=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181212211825-6441a6a4faad/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181212222758-e1173e47e167 h1:QH2bqxMbHIrpX+s/+z5Z/dlfWrJJVtOAHmZobt8ztDQ=
+github.com/letsencrypt/challtestsrv v1.0.1-0.20181212222758-e1173e47e167/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/miekg/dns v1.1.1 h1:DVkblRdiScEnEr0LR9nTnEQqHYycjkXW9bOjd+2EL2o=
 github.com/miekg/dns v1.1.1/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=

--- a/vendor/github.com/letsencrypt/challtestsrv/README.md
+++ b/vendor/github.com/letsencrypt/challtestsrv/README.md
@@ -50,6 +50,16 @@ value `"bbb"`, defer cleaning it up again:
   defer challSrv.DeleteHTTPOneChallenge("_acme-challenge.example.com.")
 ```
 
+Get the history of requests processed by the challenge server:
+```
+requestHistory := challSrv.RequestHistory()
+```
+
+Clear the history of requests:
+```
+challSrv.ClearRequestHistory()
+```
+
 Stop the Challenge server and subservers:
 ```
   // Shutdown the Challenge server

--- a/vendor/github.com/letsencrypt/challtestsrv/README.md
+++ b/vendor/github.com/letsencrypt/challtestsrv/README.md
@@ -50,14 +50,14 @@ value `"bbb"`, defer cleaning it up again:
   defer challSrv.DeleteHTTPOneChallenge("_acme-challenge.example.com.")
 ```
 
-Get the history of requests processed by the challenge server:
+Get the history of HTTP requests processed by the challenge server:
 ```
-requestHistory := challSrv.RequestHistory()
+requestHistory := challSrv.RequestHistory(challtestsrv.HTTPRequestEventType)
 ```
 
-Clear the history of requests:
+Clear the history of HTTP requests processed by the challenge server:
 ```
-challSrv.ClearRequestHistory()
+challSrv.ClearRequestHistory(challtestsrv.HTTPRequestEventType)
 ```
 
 Stop the Challenge server and subservers:

--- a/vendor/github.com/letsencrypt/challtestsrv/README.md
+++ b/vendor/github.com/letsencrypt/challtestsrv/README.md
@@ -50,14 +50,16 @@ value `"bbb"`, defer cleaning it up again:
   defer challSrv.DeleteHTTPOneChallenge("_acme-challenge.example.com.")
 ```
 
-Get the history of HTTP requests processed by the challenge server:
+Get the history of HTTP requests processed by the challenge server for the host
+"example.com":
 ```
-requestHistory := challSrv.RequestHistory(challtestsrv.HTTPRequestEventType)
+requestHistory := challSrv.RequestHistory("example.com", challtestsrv.HTTPRequestEventType)
 ```
 
-Clear the history of HTTP requests processed by the challenge server:
+Clear the history of HTTP requests processed by the challenge server for the
+host "example.com":
 ```
-challSrv.ClearRequestHistory(challtestsrv.HTTPRequestEventType)
+challSrv.ClearRequestHistory("example.com", challtestsrv.HTTPRequestEventType)
 ```
 
 Stop the Challenge server and subservers:

--- a/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go
@@ -35,9 +35,9 @@ type ChallSrv struct {
 	// response data maps below.
 	challMu sync.RWMutex
 
-	// requestHistory is a map from event type to a list of sequential request
-	// events
-	requestHistory map[RequestEventType][]RequestEvent
+	// requestHistory is a map from hostname to a map of event type to a list of
+	// sequential request events
+	requestHistory map[string]map[RequestEventType][]RequestEvent
 
 	// httpOne is a map of token values to key authorizations used for HTTP-01
 	// responses.
@@ -125,7 +125,7 @@ func New(config Config) (*ChallSrv, error) {
 
 	challSrv := &ChallSrv{
 		log:            config.Log,
-		requestHistory: make(map[RequestEventType][]RequestEvent),
+		requestHistory: make(map[string]map[RequestEventType][]RequestEvent),
 		httpOne:        make(map[string]string),
 		dnsOne:         make(map[string][]string),
 		tlsALPNOne:     make(map[string]string),

--- a/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go
@@ -35,10 +35,9 @@ type ChallSrv struct {
 	// response data maps below.
 	challMu sync.RWMutex
 
-	// requestHistory is a sequential list of request events processed by
-	// challenge servers. It can be cleared with the
-	// `ChallSrv.ClearRequestHistory` function.
-	requestHistory []RequestEvent
+	// requestHistory is a map from event type to a list of sequential request
+	// events
+	requestHistory map[RequestEventType][]RequestEvent
 
 	// httpOne is a map of token values to key authorizations used for HTTP-01
 	// responses.
@@ -126,7 +125,7 @@ func New(config Config) (*ChallSrv, error) {
 
 	challSrv := &ChallSrv{
 		log:            config.Log,
-		requestHistory: []RequestEvent{},
+		requestHistory: make(map[RequestEventType][]RequestEvent),
 		httpOne:        make(map[string]string),
 		dnsOne:         make(map[string][]string),
 		tlsALPNOne:     make(map[string]string),

--- a/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go
@@ -35,6 +35,11 @@ type ChallSrv struct {
 	// response data maps below.
 	challMu sync.RWMutex
 
+	// requestHistory is a sequential list of request events processed by
+	// challenge servers. It can be cleared with the
+	// `ChallSrv.ClearRequestHistory` function.
+	requestHistory []RequestEvent
+
 	// httpOne is a map of token values to key authorizations used for HTTP-01
 	// responses.
 	httpOne map[string]string
@@ -120,11 +125,12 @@ func New(config Config) (*ChallSrv, error) {
 	}
 
 	challSrv := &ChallSrv{
-		log:        config.Log,
-		httpOne:    make(map[string]string),
-		dnsOne:     make(map[string][]string),
-		tlsALPNOne: make(map[string]string),
-		redirects:  make(map[string]string),
+		log:            config.Log,
+		requestHistory: []RequestEvent{},
+		httpOne:        make(map[string]string),
+		dnsOne:         make(map[string][]string),
+		tlsALPNOne:     make(map[string]string),
+		redirects:      make(map[string]string),
 		dnsMocks: mockDNSData{
 			defaultIPv4: defaultIPv4,
 			defaultIPv6: defaultIPv6,

--- a/vendor/github.com/letsencrypt/challtestsrv/dns.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/dns.go
@@ -2,7 +2,6 @@ package challtestsrv
 
 import (
 	"net"
-	"time"
 
 	"github.com/miekg/dns"
 )
@@ -144,7 +143,6 @@ func (s *ChallSrv) dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 	// For each question, add answers based on the type of question
 	for _, q := range r.Question {
 		s.AddRequestEvent(DNSRequestEvent{
-			Time:     time.Now(),
 			Question: q,
 		})
 		var answerFunc dnsAnswerFunc

--- a/vendor/github.com/letsencrypt/challtestsrv/dns.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/dns.go
@@ -2,6 +2,7 @@ package challtestsrv
 
 import (
 	"net"
+	"time"
 
 	"github.com/miekg/dns"
 )
@@ -142,6 +143,10 @@ func (s *ChallSrv) dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 
 	// For each question, add answers based on the type of question
 	for _, q := range r.Question {
+		s.AddRequestEvent(DNSRequestEvent{
+			Time:     time.Now(),
+			Question: q,
+		})
 		var answerFunc dnsAnswerFunc
 		switch q.Qtype {
 		case dns.TypeTXT:

--- a/vendor/github.com/letsencrypt/challtestsrv/event.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/event.go
@@ -1,7 +1,8 @@
 package challtestsrv
 
 import (
-	"time"
+	"net"
+	"strings"
 
 	"github.com/miekg/dns"
 )
@@ -18,24 +19,20 @@ const (
 	TLSALPNRequestEventType
 )
 
-// A RequestEvent is anything that can identify its RequestEventType
+// A RequestEvent is anything that can identify its RequestEventType and a key
+// for storing the request event in the history.
 type RequestEvent interface {
 	Type() RequestEventType
+	Key() string
 }
 
 // HTTPRequestEvent corresponds to an HTTP request received by a httpOneServer.
 // It implements the RequestEvent interface.
 type HTTPRequestEvent struct {
-	// Time the request was received
-	Time time.Time
 	// The full request URL (path and query arguments)
 	URL string
 	// The Host header from the request
 	Host string
-	// The request Method (POST, GET, HEAD, etc)
-	Method string
-	// The request path
-	Path string
 	// Whether the request was received over HTTPS or HTTP
 	HTTPS bool
 	// The ServerName from the ClientHello. May be empty if there was no SNI or if
@@ -48,11 +45,18 @@ func (e HTTPRequestEvent) Type() RequestEventType {
 	return HTTPRequestEventType
 }
 
+// HTTPRequestEvents use the HTTP Host as the storage key. Any explicit port
+// will be removed.
+func (e HTTPRequestEvent) Key() string {
+	if h, _, err := net.SplitHostPort(e.Host); err == nil {
+		return h
+	}
+	return e.Host
+}
+
 // DNSRequestEvent corresponds to a DNS request received by a dnsOneServer. It
 // implements the RequestEvent interface.
 type DNSRequestEvent struct {
-	// Time request was received.
-	Time time.Time
 	// The DNS question received.
 	Question dns.Question
 }
@@ -62,11 +66,19 @@ func (e DNSRequestEvent) Type() RequestEventType {
 	return DNSRequestEventType
 }
 
+// DNSRequestEvents use the Question Name as the storage key. Any trailing `.`
+// in the question name is removed.
+func (e DNSRequestEvent) Key() string {
+	key := e.Question.Name
+	if strings.HasSuffix(key, ".") {
+		key = strings.TrimSuffix(key, ".")
+	}
+	return key
+}
+
 // TLSALPNRequestEvent corresponds to a TLS request received by
 // a tlsALPNOneServer. It implements the RequestEvent interface.
 type TLSALPNRequestEvent struct {
-	// Time request was received.
-	Time time.Time
 	// ServerName from the TLS Client Hello.
 	ServerName string
 	// SupportedProtos from the TLS Client Hello.
@@ -78,6 +90,11 @@ func (e TLSALPNRequestEvent) Type() RequestEventType {
 	return TLSALPNRequestEventType
 }
 
+// TLSALPNRequestEvents use the SNI value as the storage key
+func (e TLSALPNRequestEvent) Key() string {
+	return e.ServerName
+}
+
 // AddRequestEvent adds a RequestEvent to the server's request history. It is
 // appeneded to a list of RequestEvents indexed by the event's Type().
 func (s *ChallSrv) AddRequestEvent(event RequestEvent) {
@@ -85,20 +102,32 @@ func (s *ChallSrv) AddRequestEvent(event RequestEvent) {
 	defer s.challMu.Unlock()
 
 	typ := event.Type()
-	s.requestHistory[typ] = append(s.requestHistory[typ], event)
+	host := event.Key()
+	if s.requestHistory[host] == nil {
+		s.requestHistory[host] = make(map[RequestEventType][]RequestEvent)
+	}
+	s.requestHistory[host][typ] = append(s.requestHistory[host][typ], event)
 }
 
-// RequestHistory returns the server's request history for the given event type.
-func (s *ChallSrv) RequestHistory(typ RequestEventType) []RequestEvent {
+// RequestHistory returns the server's request history for the given hostname
+// and event type.
+func (s *ChallSrv) RequestHistory(hostname string, typ RequestEventType) []RequestEvent {
 	s.challMu.RLock()
 	defer s.challMu.RUnlock()
-	return s.requestHistory[typ]
+
+	if hostEvents, ok := s.requestHistory[hostname]; ok {
+		return hostEvents[typ]
+	}
+	return []RequestEvent{}
 }
 
-// ClearRequestHistory clears the server's request history for the given event
-// type.
-func (s *ChallSrv) ClearRequestHistory(typ RequestEventType) {
+// ClearRequestHistory clears the server's request history for the given
+// hostname and event type.
+func (s *ChallSrv) ClearRequestHistory(hostname string, typ RequestEventType) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	s.requestHistory[typ] = []RequestEvent{}
+
+	if hostEvents, ok := s.requestHistory[hostname]; ok {
+		hostEvents[typ] = []RequestEvent{}
+	}
 }

--- a/vendor/github.com/letsencrypt/challtestsrv/event.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/event.go
@@ -28,6 +28,9 @@ type HTTPRequestEvent struct {
 	Path string
 	// Whether the request was received over HTTPS or HTTP
 	HTTPS bool
+	// The ServerName from the ClientHello. May be empty if there was no SNI or if
+	// the request was not HTTPS
+	ServerName string
 }
 
 // An HTTPRequestEvent is String formatted as:

--- a/vendor/github.com/letsencrypt/challtestsrv/event.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/event.go
@@ -1,0 +1,97 @@
+package challtestsrv
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// RequestEvent is an interface used to handle disparate request event types in
+// a uniform list.
+type RequestEvent interface {
+	String() string
+}
+
+// HTTPRequestEvent corresponds to an HTTP request received by a httpOneServer.
+type HTTPRequestEvent struct {
+	// Time the request was received
+	Time time.Time
+	// The full request URL (path and query arguments)
+	URL string
+	// The Host header from the request
+	Host string
+	// The request Method (POST, GET, HEAD, etc)
+	Method string
+	// The request path
+	Path string
+	// Whether the request was received over HTTPS or HTTP
+	HTTPS bool
+}
+
+// An HTTPRequestEvent is String formatted as:
+// <timestamp> - HTTP|HTTPS - <Method> - <Host> - <URL>
+func (e HTTPRequestEvent) String() string {
+	timeStamp := e.Time.Format(time.RFC3339)
+	protocol := "HTTP"
+	if e.HTTPS {
+		protocol = "HTTPS"
+	}
+	return fmt.Sprintf("%s - %s - %s - %s - %s", timeStamp, protocol, e.Method, e.Host, e.URL)
+}
+
+// DNSRequestEvent corresponds to a DNS request received by a dnsOneServer.
+type DNSRequestEvent struct {
+	// Time request was received.
+	Time time.Time
+	// The DNS question received.
+	Question dns.Question
+}
+
+// A DNSRequestEvent is String formatted as:
+// <timestamp> - DNS - "<query>"
+func (e DNSRequestEvent) String() string {
+	timeStamp := e.Time.Format(time.RFC3339)
+	return fmt.Sprintf("%s - DNS - %q", timeStamp, e.Question.String())
+}
+
+// TLSALPNRequestEvent corresponds to a TLS request received by
+// a tlsALPNOneServer.
+type TLSALPNRequestEvent struct {
+	// Time request was received.
+	Time time.Time
+	// ServerName from the TLS Client Hello.
+	ServerName string
+	// SupportedProtos from the TLS Client Hello.
+	SupportedProtos []string
+}
+
+// A TLSALPNRequestEvent is String formatted as:
+// <timestamp> - TLS-ALPN-01 - <servername> - <comma separated supported protos>
+func (e TLSALPNRequestEvent) String() string {
+	timeStamp := e.Time.Format(time.RFC3339)
+	return fmt.Sprintf("%s - TLS-ALPN-01 - %s - %s",
+		timeStamp, e.ServerName, strings.Join(e.SupportedProtos, ","))
+}
+
+// AddRequestEvent appends a RequestEvent to the server's request history.
+func (s *ChallSrv) AddRequestEvent(event RequestEvent) {
+	s.challMu.Lock()
+	defer s.challMu.Unlock()
+	s.requestHistory = append(s.requestHistory, event)
+}
+
+// RequestHistory returns the server's request history.
+func (s *ChallSrv) RequestHistory() []RequestEvent {
+	s.challMu.RLock()
+	defer s.challMu.RUnlock()
+	return s.requestHistory
+}
+
+// ClearRequestHistory clears the server's request history.
+func (s *ChallSrv) ClearRequestHistory() {
+	s.challMu.Lock()
+	defer s.challMu.Unlock()
+	s.requestHistory = []RequestEvent{}
+}

--- a/vendor/github.com/letsencrypt/challtestsrv/httpone.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/httpone.go
@@ -124,11 +124,8 @@ func (s *ChallSrv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.AddRequestEvent(HTTPRequestEvent{
-		Time:       time.Now(),
 		URL:        r.URL.String(),
 		Host:       r.Host,
-		Method:     r.Method,
-		Path:       requestPath,
 		HTTPS:      r.TLS != nil,
 		ServerName: serverName,
 	})

--- a/vendor/github.com/letsencrypt/challtestsrv/httpone.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/httpone.go
@@ -118,13 +118,19 @@ func (s *ChallSrv) GetHTTPRedirect(path string) (string, bool) {
 func (s *ChallSrv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	requestPath := r.URL.Path
 
+	serverName := ""
+	if r.TLS != nil {
+		serverName = r.TLS.ServerName
+	}
+
 	s.AddRequestEvent(HTTPRequestEvent{
-		Time:   time.Now(),
-		URL:    r.URL.String(),
-		Host:   r.Host,
-		Method: r.Method,
-		Path:   requestPath,
-		HTTPS:  r.TLS != nil,
+		Time:       time.Now(),
+		URL:        r.URL.String(),
+		Host:       r.Host,
+		Method:     r.Method,
+		Path:       requestPath,
+		HTTPS:      r.TLS != nil,
+		ServerName: serverName,
 	})
 
 	// If the request was not over HTTPS and we have a redirect, serve it.

--- a/vendor/github.com/letsencrypt/challtestsrv/httpone.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/httpone.go
@@ -49,7 +49,7 @@ func selfSignedCert() tls.Certificate {
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 	}
 
 	der, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
@@ -117,6 +117,15 @@ func (s *ChallSrv) GetHTTPRedirect(path string) (string, bool) {
 // then the challenge response contents are returned.
 func (s *ChallSrv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	requestPath := r.URL.Path
+
+	s.AddRequestEvent(HTTPRequestEvent{
+		Time:   time.Now(),
+		URL:    r.URL.String(),
+		Host:   r.Host,
+		Method: r.Method,
+		Path:   requestPath,
+		HTTPS:  r.TLS != nil,
+	})
 
 	// If the request was not over HTTPS and we have a redirect, serve it.
 	// Redirects are ignored over HTTPS so we can easily do an HTTP->HTTPS

--- a/vendor/github.com/letsencrypt/challtestsrv/tlsalpnone.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/tlsalpnone.go
@@ -51,7 +51,6 @@ func (s *ChallSrv) GetTLSALPNChallenge(host string) (string, bool) {
 func (s *ChallSrv) ServeChallengeCertFunc(k *ecdsa.PrivateKey) func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 	return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		s.AddRequestEvent(TLSALPNRequestEvent{
-			Time:            time.Now(),
 			ServerName:      hello.ServerName,
 			SupportedProtos: hello.SupportedProtos,
 		})

--- a/vendor/github.com/letsencrypt/challtestsrv/tlsalpnone.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/tlsalpnone.go
@@ -50,6 +50,11 @@ func (s *ChallSrv) GetTLSALPNChallenge(host string) (string, bool) {
 
 func (s *ChallSrv) ServeChallengeCertFunc(k *ecdsa.PrivateKey) func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 	return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		s.AddRequestEvent(TLSALPNRequestEvent{
+			Time:            time.Now(),
+			ServerName:      hello.ServerName,
+			SupportedProtos: hello.SupportedProtos,
+		})
 		if len(hello.SupportedProtos) != 1 || hello.SupportedProtos[0] != ACMETLS1Protocol {
 			return nil, fmt.Errorf(
 				"ALPN failed, ClientHelloInfo.SupportedProtos: %s",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
 github.com/jmhodges/clock
-# github.com/letsencrypt/challtestsrv v1.0.0
+# github.com/letsencrypt/challtestsrv v1.0.1-0.20181212222758-e1173e47e167
 github.com/letsencrypt/challtestsrv
 # github.com/miekg/dns v1.1.1
 github.com/miekg/dns

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
 github.com/jmhodges/clock
-# github.com/letsencrypt/challtestsrv v1.0.1-0.20181213164708-7ac06f2c48ad
+# github.com/letsencrypt/challtestsrv v1.0.1-0.20181214141602-e2eba9b59bf7
 github.com/letsencrypt/challtestsrv
 # github.com/miekg/dns v1.1.1
 github.com/miekg/dns

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
 github.com/jmhodges/clock
-# github.com/letsencrypt/challtestsrv v1.0.1-0.20181214212536-8d77fe6e69cc
+# github.com/letsencrypt/challtestsrv v1.0.1
 github.com/letsencrypt/challtestsrv
 # github.com/miekg/dns v1.1.1
 github.com/miekg/dns

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
 github.com/jmhodges/clock
-# github.com/letsencrypt/challtestsrv v1.0.1-0.20181214141602-e2eba9b59bf7
+# github.com/letsencrypt/challtestsrv v1.0.1-0.20181214212536-8d77fe6e69cc
 github.com/letsencrypt/challtestsrv
 # github.com/miekg/dns v1.1.1
 github.com/miekg/dns

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
 github.com/jmhodges/clock
-# github.com/letsencrypt/challtestsrv v1.0.1-0.20181212222758-e1173e47e167
+# github.com/letsencrypt/challtestsrv v1.0.1-0.20181213164708-7ac06f2c48ad
 github.com/letsencrypt/challtestsrv
 # github.com/miekg/dns v1.1.1
 github.com/miekg/dns


### PR DESCRIPTION
In testing contexts its useful to be able to ask the `pebble-challtestsrv` about what DNS, HTTP(s), and TLS-ALPN-01 requests it has received.

I also fixed an error with the default management server port in the `pebble-challtestsrv` README.