### PR TITLE
Publish automatically Docker images.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ go:
 env:
   - GO111MODULE=on
 
+services:
+  - docker
+
 before_install:
   - git clone https://github.com/certbot/certbot
   - cd certbot
@@ -33,3 +36,10 @@ before_script:
 script:
   - go vet ./...
   - REQUESTS_CA_BUNDLE=./test/certs/pebble.minica.pem python ./test/chisel2.py example.letsencrypt.org elpmaxe.letsencrypt.org
+
+deploy:
+  - provider: script
+    script: sh .travis/publish.sh
+    skip_cleanup: true
+    on:
+      repo: letsencrypt/pebble

--- a/.travis/publish.sh
+++ b/.travis/publish.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+
+if [[ "${TRAVIS_PULL_REQUEST}" = "false" ]]; then
+    echo "Publishing..."
+else
+    echo "Skipping publishing"
+    exit 0
+fi
+
+docker login -u $DOCKER_USER -p $DOCKER_PASS
+
+BASE_NAMES=(pebble pebble-challtestsrv)
+for BASE_NAME in ${BASE_NAMES[@]}; do
+    IMAGE_NAME="letsencrypt/${BASE_NAME}"
+
+    echo "Updating docker ${IMAGE_NAME} image..."
+
+    # create docker image
+    docker build -t ${IMAGE_NAME}:latest -f docker/${BASE_NAME}/Dockerfile .
+
+    # push images
+    echo "Try to publish image: ${IMAGE_NAME}:latest"
+    docker push ${IMAGE_NAME}:latest
+
+    if [[ -n "$TRAVIS_COMMIT" ]]; then
+        echo "Try to publish image: ${IMAGE_NAME}:${TRAVIS_COMMIT}"
+        docker tag ${IMAGE_NAME}:latest ${IMAGE_NAME}:${TRAVIS_COMMIT}
+        docker push ${IMAGE_NAME}:${TRAVIS_COMMIT}
+    fi
+
+    if [[ -n "${TRAVIS_TAG}" ]]; then
+        echo "Try to publish image: ${IMAGE_NAME}:${TRAVIS_TAG}"
+        docker tag ${IMAGE_NAME}:latest ${IMAGE_NAME}:${TRAVIS_TAG}
+        docker push ${IMAGE_NAME}:${TRAVIS_TAG}
+    fi
+done
+
+echo "Published"

--- a/.travis/publish.sh
+++ b/.travis/publish.sh
@@ -17,22 +17,17 @@ for BASE_NAME in ${BASE_NAMES[@]}; do
     echo "Updating docker ${IMAGE_NAME} image..."
 
     # create docker image
-    docker build -t ${IMAGE_NAME}:latest -f docker/${BASE_NAME}/Dockerfile .
+    docker build -t ${IMAGE_NAME}:temp -f docker/${BASE_NAME}/Dockerfile .
 
     # push images
-    echo "Try to publish image: ${IMAGE_NAME}:latest"
-    docker push ${IMAGE_NAME}:latest
-
-    if [[ -n "$TRAVIS_COMMIT" ]]; then
-        echo "Try to publish image: ${IMAGE_NAME}:${TRAVIS_COMMIT}"
-        docker tag ${IMAGE_NAME}:latest ${IMAGE_NAME}:${TRAVIS_COMMIT}
-        docker push ${IMAGE_NAME}:${TRAVIS_COMMIT}
-    fi
-
     if [[ -n "${TRAVIS_TAG}" ]]; then
         echo "Try to publish image: ${IMAGE_NAME}:${TRAVIS_TAG}"
-        docker tag ${IMAGE_NAME}:latest ${IMAGE_NAME}:${TRAVIS_TAG}
+        docker tag ${IMAGE_NAME}:temp ${IMAGE_NAME}:${TRAVIS_TAG}
         docker push ${IMAGE_NAME}:${TRAVIS_TAG}
+
+        echo "Try to publish image: ${IMAGE_NAME}:latest"
+        docker tag ${IMAGE_NAME}:${TRAVIS_TAG} ${IMAGE_NAME}:latest
+        docker push ${IMAGE_NAME}:latest
     fi
 done
 


### PR DESCRIPTION
Publishes images for:
- pebble
- pebble-challtestsrv

Publishes image tags:
- `latest`: the latest build
- commit hash: each commit have an image
- tag: each tag have an image

I'm not sure about the commit hash, maybe it's not a good idea.

Also, I can sync latest and the tag if needed.

The PR require that you add env vars in Travis: `DOCKER_USER` and `DOCKER_PASS`.

Fixes #146 

ping @shred :wink: 