### PR TITLE
dep: update challtestsrv to 1.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/letsencrypt/pebble
 
 require (
 	github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
-	github.com/letsencrypt/challtestsrv v1.0.1
+	github.com/letsencrypt/challtestsrv v1.0.2
 	golang.org/x/net v0.0.0-20181207154023-610586996380 // indirect
 	golang.org/x/sys v0.0.0-20181206074257-70b957f3b65e // indirect
 	gopkg.in/square/go-jose.v2 v2.1.9

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/letsencrypt/challtestsrv v1.0.1-0.20181214212536-8d77fe6e69cc h1:XKu0
 github.com/letsencrypt/challtestsrv v1.0.1-0.20181214212536-8d77fe6e69cc/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/letsencrypt/challtestsrv v1.0.1 h1:9K3DJleJxOnP3YlFPWeNydca61Lwj4vySqP4W9hi8vE=
 github.com/letsencrypt/challtestsrv v1.0.1/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
+github.com/letsencrypt/challtestsrv v1.0.2 h1:nBAQjKvVMLhpj4cg2Px6jMyvMbQNdJrCEd6gdcmEuOU=
+github.com/letsencrypt/challtestsrv v1.0.2/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/miekg/dns v1.1.1 h1:DVkblRdiScEnEr0LR9nTnEQqHYycjkXW9bOjd+2EL2o=
 github.com/miekg/dns v1.1.1/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=

--- a/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go
@@ -60,7 +60,7 @@ type ChallSrv struct {
 	redirects map[string]string
 }
 
-// mockDNSData holds mock respones for DNS A, AAAA, and CAA lookups.
+// mockDNSData holds mock responses for DNS A, AAAA, and CAA lookups.
 type mockDNSData struct {
 	// The IPv4 address used for all A record responses that don't match a host in
 	// aRecords.
@@ -68,7 +68,7 @@ type mockDNSData struct {
 	// The IPv6 address used for all AAAA record responses that don't match a host
 	// in aaaaRecords.
 	defaultIPv6 string
-	// A map of host to IPv4 addressess in string form for A record responses.
+	// A map of host to IPv4 addresses in string form for A record responses.
 	aRecords map[string][]string
 	// A map of host to IPv6 addresses in string form for AAAA record responses.
 	aaaaRecords map[string][]string

--- a/vendor/github.com/letsencrypt/challtestsrv/dns.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/dns.go
@@ -145,6 +145,7 @@ func (s *ChallSrv) dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 		s.AddRequestEvent(DNSRequestEvent{
 			Question: q,
 		})
+
 		var answerFunc dnsAnswerFunc
 		switch q.Qtype {
 		case dns.TypeTXT:
@@ -155,7 +156,14 @@ func (s *ChallSrv) dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 			answerFunc = s.aaaaAnswers
 		case dns.TypeCAA:
 			answerFunc = s.caaAnswers
+		default:
+			m.SetRcode(r, dns.RcodeNotImplemented)
 		}
+
+		if answerFunc == nil {
+			break
+		}
+
 		if records := answerFunc(q); len(records) > 0 {
 			m.Answer = append(m.Answer, records...)
 		}

--- a/vendor/github.com/letsencrypt/challtestsrv/httpone.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/httpone.go
@@ -95,7 +95,7 @@ func (s *ChallSrv) AddHTTPRedirect(path, targetURL string) {
 	s.redirects[path] = targetURL
 }
 
-// DeletedHTTPRedirect deletes a redirect for the given path.
+// DeleteHTTPRedirect deletes a redirect for the given path.
 func (s *ChallSrv) DeleteHTTPRedirect(path string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()

--- a/vendor/github.com/letsencrypt/challtestsrv/mockdns.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/mockdns.go
@@ -1,7 +1,7 @@
 package challtestsrv
 
 import (
-	"strings"
+	"github.com/miekg/dns"
 )
 
 // SetDefaultDNSIPv4 sets the default IPv4 address used for A query responses
@@ -43,9 +43,7 @@ func (s *ChallSrv) GetDefaultDNSIPv6() string {
 func (s *ChallSrv) AddDNSARecord(host string, addresses []string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	s.dnsMocks.aRecords[host] = append(s.dnsMocks.aRecords[host], addresses...)
 }
 
@@ -54,9 +52,7 @@ func (s *ChallSrv) AddDNSARecord(host string, addresses []string) {
 func (s *ChallSrv) DeleteDNSARecord(host string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	delete(s.dnsMocks.aRecords, host)
 }
 
@@ -64,9 +60,7 @@ func (s *ChallSrv) DeleteDNSARecord(host string) {
 // returned when querying for A records for the given host.
 func (s *ChallSrv) GetDNSARecord(host string) []string {
 	s.challMu.RLock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	defer s.challMu.RUnlock()
 	return s.dnsMocks.aRecords[host]
 }
@@ -76,9 +70,7 @@ func (s *ChallSrv) GetDNSARecord(host string) []string {
 func (s *ChallSrv) AddDNSAAAARecord(host string, addresses []string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	s.dnsMocks.aaaaRecords[host] = append(s.dnsMocks.aaaaRecords[host], addresses...)
 }
 
@@ -87,9 +79,7 @@ func (s *ChallSrv) AddDNSAAAARecord(host string, addresses []string) {
 func (s *ChallSrv) DeleteDNSAAAARecord(host string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	delete(s.dnsMocks.aaaaRecords, host)
 }
 
@@ -98,9 +88,7 @@ func (s *ChallSrv) DeleteDNSAAAARecord(host string) {
 func (s *ChallSrv) GetDNSAAAARecord(host string) []string {
 	s.challMu.RLock()
 	defer s.challMu.RUnlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	return s.dnsMocks.aaaaRecords[host]
 }
 
@@ -109,9 +97,7 @@ func (s *ChallSrv) GetDNSAAAARecord(host string) []string {
 func (s *ChallSrv) AddDNSCAARecord(host string, policies []MockCAAPolicy) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	s.dnsMocks.caaRecords[host] = append(s.dnsMocks.caaRecords[host], policies...)
 }
 
@@ -120,9 +106,7 @@ func (s *ChallSrv) AddDNSCAARecord(host string, policies []MockCAAPolicy) {
 func (s *ChallSrv) DeleteDNSCAARecord(host string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	delete(s.dnsMocks.caaRecords, host)
 }
 
@@ -131,8 +115,6 @@ func (s *ChallSrv) DeleteDNSCAARecord(host string) {
 func (s *ChallSrv) GetDNSCAARecord(host string) []MockCAAPolicy {
 	s.challMu.RLock()
 	defer s.challMu.RUnlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	return s.dnsMocks.caaRecords[host]
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
 github.com/jmhodges/clock
-# github.com/letsencrypt/challtestsrv v1.0.1
+# github.com/letsencrypt/challtestsrv v1.0.2
 github.com/letsencrypt/challtestsrv
 # github.com/miekg/dns v1.1.1
 github.com/miekg/dns


### PR DESCRIPTION
Challtestsrv 1.0.2 fixes a panic from unsupported DNS query types.