### PR TITLE
WFE: Return Status 200 for HEAD to new-nonce endpoint.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -360,11 +360,13 @@ func (wfe *WebFrontEndImpl) Nonce(
 	logEvent *requestEvent,
 	response http.ResponseWriter,
 	request *http.Request) {
-	statusCode := http.StatusOK
+	statusCode := http.StatusNoContent
 	// The ACME specification says GET requets should receive http.StatusNoContent
-	// 	// and HEAD requests should receive http.StatusOK.
-	if request.Method == "GET" {
-		statusCode = http.StatusNoContent
+	// and HEAD requests should receive http.StatusOK. We only return StatusOK for
+	// HEAD requests in strict mode because this was the legacy behaviour and it
+	// may break clients to change.
+	if wfe.strict && request.Method == "HEAD" {
+		statusCode = http.StatusOK
 	}
 	response.WriteHeader(statusCode)
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -360,7 +360,13 @@ func (wfe *WebFrontEndImpl) Nonce(
 	logEvent *requestEvent,
 	response http.ResponseWriter,
 	request *http.Request) {
-	response.WriteHeader(http.StatusNoContent)
+	statusCode := http.StatusOK
+	// The ACME specification says GET requets should receive http.StatusNoContent
+	// 	// and HEAD requests should receive http.StatusOK.
+	if request.Method == "GET" {
+		statusCode = http.StatusNoContent
+	}
+	response.WriteHeader(statusCode)
 }
 
 func (wfe *WebFrontEndImpl) parseJWS(body string) (*jose.JSONWebSignature, error) {


### PR DESCRIPTION
Previously we mistakenly returned status 204 (no content) for all
requests to new-nonce, including HEAD. This status should only be used
for GET requests.

This is the same problem & fix as was reported on the Boulder repo:
https://github.com/letsencrypt/boulder/issues/3989

Similar to https://github.com/letsencrypt/boulder/issues/3989 because this
may be a breaking API change HTTP status 200 (OK) is only returned for
HEAD requests when Pebble is running in `-strict` mode.