### PR TITLE
Add goreleaser.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,111 @@
+project_name: pebble
+
+builds:
+  - binary: pebble
+    main: ./cmd/pebble/
+    env:
+    - GO111MODULE=on
+    - CGO_ENABLED=0
+
+    goos:
+    - windows
+    - darwin
+    - linux
+    - freebsd
+    - openbsd
+    goarch:
+    - amd64
+    - 386
+    - arm
+    - arm64
+    goarm:
+    - 7
+
+    ignore:
+    - goos: openbsd
+      goarch: arm
+
+  - binary: pebble-client
+    main: ./cmd/pebble-client/
+    env:
+    - GO111MODULE=on
+    - CGO_ENABLED=0
+
+    goos:
+    - windows
+    - darwin
+    - linux
+    - freebsd
+    - openbsd
+    goarch:
+    - amd64
+    - 386
+    - arm
+    - arm64
+    goarm:
+    - 7
+
+    ignore:
+    - goos: openbsd
+      goarch: arm
+
+  - binary: pebble-challtestsrv
+    main: ./cmd/pebble-challtestsrv/
+    env:
+    - GO111MODULE=on
+    - CGO_ENABLED=0
+
+    goos:
+    - windows
+    - darwin
+    - linux
+    - freebsd
+    - openbsd
+    goarch:
+    - amd64
+    - 386
+    - arm
+    - arm64
+    goarm:
+    - 7
+
+    ignore:
+    - goos: openbsd
+      goarch: arm
+
+archive:
+  name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm}}v{{ .Arm }}{{ end }}'
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  files:
+  - LICENSE
+
+dockers:
+  - image_templates:
+    - "letsencrypt/pebble:latest"
+    - "letsencrypt/pebble:{{ .Tag }}"
+    - "letsencrypt/pebble:v{{ .Major }}"
+    - "letsencrypt/pebble:v{{ .Major }}.{{ .Minor }}"
+    binary: pebble
+    dockerfile: docker/pebble/release.Dockerfile
+#    skip_push: true
+    extra_files:
+    - test/
+
+  - image_templates:
+    - "letsencrypt/pebble-challtestsrv:latest"
+    - "letsencrypt/pebble-challtestsrv:{{ .Tag }}"
+    - "letsencrypt/pebble-challtestsrv:v{{ .Major }}"
+    - "letsencrypt/pebble-challtestsrv:v{{ .Major }}.{{ .Minor }}"
+    binary: pebble-challtestsrv
+    dockerfile: docker/pebble-challtestsrv/release.Dockerfile
+#    skip_push: true
+
+release:
+  disable: true
+
+## To test locally:
+## goreleaser release --skip-publish --skip-validate --rm-dist
+## goreleaser release --skip-publish --skip-validate --snapshot --rm-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ go:
 env:
   - GO111MODULE=on
 
+services:
+  - docker
+
 before_install:
   - git clone https://github.com/certbot/certbot
   - cd certbot
@@ -33,3 +36,21 @@ before_script:
 script:
   - go vet ./...
   - REQUESTS_CA_BUNDLE=./test/certs/pebble.minica.pem python ./test/chisel2.py example.letsencrypt.org elpmaxe.letsencrypt.org
+
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: curl -sL https://git.io/goreleaser | bash
+    on:
+      tags: true
+      condition: $TRAVIS_GO_VERSION =~ ^1\.11\.x$
+
+  - provider: releases
+    api_key: ${GITHUB_TOKEN}
+    file: dist/pebble_*
+    skip_cleanup: true
+    overwrite: true
+    file_glob: true
+    on:
+      tags: true
+      condition: $TRAVIS_GO_VERSION =~ ^1\.11\.x$

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ script:
   - go vet ./...
   - REQUESTS_CA_BUNDLE=./test/certs/pebble.minica.pem python ./test/chisel2.py example.letsencrypt.org elpmaxe.letsencrypt.org
 
+after_success:
+  - test -n "$TRAVIS_TAG" && docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
 deploy:
   - provider: script
     skip_cleanup: true

--- a/docker/pebble-challtestsrv/release.Dockerfile
+++ b/docker/pebble-challtestsrv/release.Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.8
+
+RUN apk update && apk add --no-cache --virtual ca-certificates
+
+COPY pebble-challtestsrv /usr/bin/pebble-challtestsrv
+
+CMD [ "/usr/bin/pebble-challtestsrv" ]

--- a/docker/pebble/release.Dockerfile
+++ b/docker/pebble/release.Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.8
+
+RUN apk update && apk add --no-cache --virtual ca-certificates
+
+COPY pebble /usr/bin/pebble
+COPY /test/ /test/
+
+CMD [ "/usr/bin/pebble" ]


### PR DESCRIPTION
It's a proposal, this PR does the same thing as #187 (with more tags) but also publishes binary files.

Goreleaser is simple to use and configure.

- allow to publish automatically docker images
  - for pebble and pebble-challtestsrv
  - tags: `latest`, `vx.y.z`, `vx.y`, `vx`
- allow to publish archive (tar/zip) for the binaries
    - linux
    - windows
    - darwin
    - freebsd
    - openbsd

Goreleaser can do more, but I think it's a little overkill for pebble :wink: 