### PR TITLE
CI: Publish script tweaks

### DIFF
--- a/.travis/publish.sh
+++ b/.travis/publish.sh
@@ -8,26 +8,26 @@ else
     exit 0
 fi
 
-docker login -u $DOCKER_USER -p $DOCKER_PASS
+docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
 
 BASE_NAMES=(pebble pebble-challtestsrv)
-for BASE_NAME in ${BASE_NAMES[@]}; do
+for BASE_NAME in "${BASE_NAMES[@]}"; do
     IMAGE_NAME="letsencrypt/${BASE_NAME}"
 
     echo "Updating docker ${IMAGE_NAME} image..."
 
     # create docker image
-    docker build -t ${IMAGE_NAME}:temp -f docker/${BASE_NAME}/Dockerfile .
+    docker build -t "${IMAGE_NAME}:temp" -f "docker/${BASE_NAME}/Dockerfile" .
 
     # push images
     if [[ -n "${TRAVIS_TAG}" ]]; then
         echo "Try to publish image: ${IMAGE_NAME}:${TRAVIS_TAG}"
-        docker tag ${IMAGE_NAME}:temp ${IMAGE_NAME}:${TRAVIS_TAG}
-        docker push ${IMAGE_NAME}:${TRAVIS_TAG}
+        docker tag "${IMAGE_NAME}:temp" "${IMAGE_NAME}:${TRAVIS_TAG}"
+        docker push "${IMAGE_NAME}:${TRAVIS_TAG}"
 
         echo "Try to publish image: ${IMAGE_NAME}:latest"
-        docker tag ${IMAGE_NAME}:${TRAVIS_TAG} ${IMAGE_NAME}:latest
-        docker push ${IMAGE_NAME}:latest
+        docker tag "${IMAGE_NAME}:${TRAVIS_TAG}" "${IMAGE_NAME}:latest"
+        docker push "${IMAGE_NAME}:latest"
     fi
 done
 

--- a/.travis/publish.sh
+++ b/.travis/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-if [[ "${TRAVIS_PULL_REQUEST}" = "false" ]]; then
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
     echo "Publishing..."
 else
     echo "Skipping publishing"
@@ -20,7 +20,7 @@ for BASE_NAME in "${BASE_NAMES[@]}"; do
     docker build -t "${IMAGE_NAME}:temp" -f "docker/${BASE_NAME}/Dockerfile" .
 
     # push images
-    if [[ -n "${TRAVIS_TAG}" ]]; then
+    if [ -n "${TRAVIS_TAG}" ]; then
         echo "Try to publish image: ${IMAGE_NAME}:${TRAVIS_TAG}"
         docker tag "${IMAGE_NAME}:temp" "${IMAGE_NAME}:${TRAVIS_TAG}"
         docker push "${IMAGE_NAME}:${TRAVIS_TAG}"


### PR DESCRIPTION
After merging https://github.com/letsencrypt/pebble/pull/187 the deploy stage failed:

```
Deploying application
.travis/publish.sh: 4: .travis/publish.sh: [[: not found
Skipping publishing
```

7049873 applies the recommended `shellcheck` fixes. f053bc9 switches to the older bash `if` syntax.

I'm not 100% sure that f053bc9 is the right fix (the BASH keyword syntax using `[[ ]]`, _seems_ fine to me) but its my first idea.

cc @ldez 