### PR TITLE
CI: Use bash not sh for .travis/deploy.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
 
 deploy:
   - provider: script
-    script: sh .travis/publish.sh
+    script: bash .travis/publish.sh
     skip_cleanup: true
     on:
       repo: letsencrypt/pebble


### PR DESCRIPTION
We use bashisms in the `deploy.sh` script and need to invoke with with
`bash` not `sh`, despite the shebang at the top of the deploy script.