### PR TITLE
Leave out port on HTTP request host header if it's the standard one

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -488,6 +488,14 @@ func (va VAImpl) fetchHTTP(identifier string, token string) ([]byte, string, *ac
 		return nil, url.String(), acme.MalformedProblem(
 			fmt.Sprintf("Invalid URL %q\n", url.String()))
 	}
+	// trim the :80 port of the url off the host header
+	// if we're using the standard port.
+	// Certain HTTP routers (notably kubernetes nginx-ingress)
+	// gets confused by it
+	if va.httpPort == 80 {
+		httpRequest.Host = identifier
+	}
+
 	httpRequest.Header.Set("User-Agent", userAgent())
 	httpRequest.Header.Set("Accept", "*/*")
 


### PR DESCRIPTION
During testing with nginx-ingress and http->https redirects, an issue
was discovered. Pebble does its http requests with the Host header
set to Host: domain:httpPort. This would confuse nginx-ingress into
redirecting to https://domain:httpPort/.wellknown if mandatory TLS
upgrade was enabled, causing failures once pebble tried to do a TLS
handshake on port 80.

Fix by trimming the port off the Host header if it is port 80.