### PR TITLE
Promote -strict behaviors to the default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
   - docker
 
 before_install:
-  - git clone https://github.com/certbot/certbot
+  - git checkout -b no-keyauthorization https://github.com/certbot/certbot
   - cd certbot
   - ./certbot-auto --os-packages-only -n
   - ./tools/venv.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ services:
   - docker
 
 before_install:
+  # TODO(#204): Change back to cloning master once Certbot omits # keyAuthorization.
   - git clone --depth=1 -b no-keyauthorization https://github.com/certbot/certbot
   - cd certbot
   - ./certbot-auto --os-packages-only -n

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
   - docker
 
 before_install:
-  # TODO(#204): Change back to cloning master once Certbot omits # keyAuthorization.
+  # TODO(#204): Change back to cloning master once Certbot omits keyAuthorization.
   - git clone --depth=1 -b no-keyauthorization https://github.com/certbot/certbot
   - cd certbot
   - ./certbot-auto --os-packages-only -n

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
   - docker
 
 before_install:
-  - git checkout -b no-keyauthorization https://github.com/certbot/certbot
+  - git clone --depth=1 -b no-keyauthorization https://github.com/certbot/certbot
   - cd certbot
   - ./certbot-auto --os-packages-only -n
   - ./tools/venv.py

--- a/va/va.go
+++ b/va/va.go
@@ -396,11 +396,6 @@ func (va VAImpl) validateTLSALPN01(task *vaTask) *core.ValidationRecord {
 	for _, ext := range leafCert.Extensions {
 		if ext.Critical {
 			hasAcmeIdentifier := IdPeAcmeIdentifier.Equal(ext.Id)
-			// For backwards compatibility, check old identifier
-			// as well if strict mode is not enabled
-			if !va.strict && IdPeAcmeIdentifierV1Obsolete.Equal(ext.Id) {
-				hasAcmeIdentifier = true
-			}
 			if hasAcmeIdentifier {
 				var extValue []byte
 				if _, err := asn1.Unmarshal(ext.Value, &extValue); err != nil {

--- a/va/va.go
+++ b/va/va.go
@@ -73,11 +73,6 @@ const (
 // (https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-04#page-4)
 var IdPeAcmeIdentifier = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 31}
 
-// This is the identifier defined in draft-01. This is only supported for backwards
-// compatibility.
-// (https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-01#page-4)
-var IdPeAcmeIdentifierV1Obsolete = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 30, 1}
-
 func userAgent() string {
 	return fmt.Sprintf(
 		"%s (%s; %s)",

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1352,19 +1352,16 @@ func (wfe *WebFrontEndImpl) Order(
 	logEvent *requestEvent,
 	response http.ResponseWriter,
 	request *http.Request) {
-
-	var account *core.Account
 	postData, prob := wfe.verifyPOST(ctx, logEvent, request, wfe.lookupJWK)
 	if prob != nil {
 		wfe.sendError(prob, response)
 		return
 	}
-	acct, prob := wfe.validPOSTAsGET(postData)
+	account, prob := wfe.validPOSTAsGET(postData)
 	if prob != nil {
 		wfe.sendError(prob, response)
 		return
 	}
-	account = acct
 
 	orderID := strings.TrimPrefix(request.URL.Path, orderPath)
 	order := wfe.db.GetOrderByID(orderID)
@@ -1655,7 +1652,6 @@ func (wfe *WebFrontEndImpl) Challenge(
 	// There are two possibilities:
 	// A) request is a POST to begin a challenge
 	// B) request is a POST-as-GET to poll a challenge
-	var account *core.Account
 	postData, prob := wfe.verifyPOST(ctx, logEvent, request, wfe.lookupJWK)
 	if prob != nil {
 		wfe.sendError(prob, response)
@@ -1670,17 +1666,17 @@ func (wfe *WebFrontEndImpl) Challenge(
 	}
 
 	// If the post isn't a POST-as-GET its case A)
+	var account *core.Account
 	if !postData.postAsGet {
 		wfe.updateChallenge(ctx, postData, response, request)
 		return
 	} else {
 		// Otherwise it is case B)
-		acct, prob := wfe.validPOSTAsGET(postData)
+		account, prob = wfe.validPOSTAsGET(postData)
 		if prob != nil {
 			wfe.sendError(prob, response)
 			return
 		}
-		account = acct
 	}
 
 	// Lock the challenge for reading in order to write the response


### PR DESCRIPTION
This change keeps the -strict flag and related plumbing, in case we need it again in the future.

Since this rejects challenge POSTs with `keyAuthorization`, and Certbot master still sends that,
I've updated the Travis config to check out a branch of Certbot that is tweaked to not send it.

Resolves https://github.com/letsencrypt/pebble/issues/192
Resolves #206