### PR TITLE
WFE: Always send the "index" Link header.

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -202,6 +202,14 @@ func (wfe *WebFrontEndImpl) HandleFunc(
 					response.Header().Set("Replay-Nonce", wfe.nonce.createNonce())
 				}
 
+				// Per section 7.1 "Resources":
+				//   The "index" link relation is present on all resources other than the
+				//   directory and indicates the URL of the directory.
+				if pattern != DirectoryPath {
+					directoryURL := wfe.relativeEndpoint(request, DirectoryPath)
+					response.Header().Add("Link", link(directoryURL, "index"))
+				}
+
 				logEvent.Endpoint = pattern
 				if request.URL != nil {
 					logEvent.Endpoint = path.Join(logEvent.Endpoint, request.URL.Path)


### PR DESCRIPTION
All HTTP responses for requests to resources (other than the directory resource) should get a `Link` header with the `"index"` relation that points to the ACME directory URL. See https://tools.ietf.org/html/draft-ietf-acme-acme-18#section-7.1