### PR TITLE
WFE: Implement orderNotReady and badPublicKey err types.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   - until </dev/tcp/localhost/14000 ; do sleep 0.1 ; done
 
 script:
-  - go vet ./...
+  - go vet -mod=vendor ./...
   - REQUESTS_CA_BUNDLE=./test/certs/pebble.minica.pem python ./test/chisel2.py example.letsencrypt.org elpmaxe.letsencrypt.org
 
 deploy:

--- a/acme/problems.go
+++ b/acme/problems.go
@@ -18,6 +18,7 @@ const (
 	accountDoesNotExistErr = errNS + "accountDoesNotExist"
 	badRevocationReasonErr = errNS + "badRevocationReason"
 	alreadyRevokedErr      = errNS + "alreadyRevoked"
+	orderNotReadyErr       = errNS + "orderNotReady"
 )
 
 type ProblemDetails struct {
@@ -147,5 +148,13 @@ func AlreadyRevokedProblem(detail string) *ProblemDetails {
 		Type:       alreadyRevokedErr,
 		Detail:     detail,
 		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+func OrderNotReadyProblem(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       orderNotReadyErr,
+		Detail:     detail,
+		HTTPStatus: http.StatusForbidden,
 	}
 }

--- a/acme/problems.go
+++ b/acme/problems.go
@@ -19,6 +19,7 @@ const (
 	badRevocationReasonErr = errNS + "badRevocationReason"
 	alreadyRevokedErr      = errNS + "alreadyRevoked"
 	orderNotReadyErr       = errNS + "orderNotReady"
+	badPublicKeyErr        = errNS + "badPublicKey"
 )
 
 type ProblemDetails struct {
@@ -156,5 +157,13 @@ func OrderNotReadyProblem(detail string) *ProblemDetails {
 		Type:       orderNotReadyErr,
 		Detail:     detail,
 		HTTPStatus: http.StatusForbidden,
+	}
+}
+
+func BadPublicKeyProblem(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       badPublicKeyErr,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
 	}
 }

--- a/wfe/jose.go
+++ b/wfe/jose.go
@@ -9,6 +9,8 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/letsencrypt/pebble/acme"
+
 	"gopkg.in/square/go-jose.v2"
 )
 
@@ -26,7 +28,7 @@ func algorithmForKey(key *jose.JSONWebKey) (string, error) {
 			return string(jose.ES512), nil
 		}
 	}
-	return "", fmt.Errorf("no signature algorithms suitable for given key type")
+	return "", fmt.Errorf("no signature algorithms suitable for given key type: %T", key.Key)
 }
 
 // Check that (1) there is a suitable algorithm for the provided key based on its
@@ -34,20 +36,20 @@ func algorithmForKey(key *jose.JSONWebKey) (string, error) {
 // that algorithm, and (3) the Algorithm field on the JWK is present and matches
 // that algorithm. Precondition: parsedJws must have exactly one signature on
 // it.
-func checkAlgorithm(key *jose.JSONWebKey, parsedJws *jose.JSONWebSignature) error {
+func checkAlgorithm(key *jose.JSONWebKey, parsedJws *jose.JSONWebSignature) *acme.ProblemDetails {
 	algorithm, err := algorithmForKey(key)
 	if err != nil {
-		return err
+		return acme.BadPublicKeyProblem(err.Error())
 	}
 	jwsAlgorithm := parsedJws.Signatures[0].Header.Algorithm
 	if jwsAlgorithm != algorithm {
-		return fmt.Errorf(
+		return acme.MalformedProblem(fmt.Sprintf(
 			"signature type '%s' in JWS header is not supported, expected one of RS256, ES256, ES384 or ES512",
-			jwsAlgorithm)
+			jwsAlgorithm))
 	}
 	if key.Algorithm != "" && key.Algorithm != algorithm {
-		return fmt.Errorf(
-			"algorithm '%s' on JWK is unacceptable", key.Algorithm)
+		return acme.BadPublicKeyProblem(fmt.Sprintf(
+			"algorithm '%s' on JWK is unacceptable", key.Algorithm))
 	}
 	return nil
 }

--- a/wfe/jose.go
+++ b/wfe/jose.go
@@ -33,7 +33,7 @@ func algorithmForKey(key *jose.JSONWebKey) (string, error) {
 // Golang type, (2) the Algorithm field on the JWK is either absent, or matches
 // that algorithm, and (3) the Algorithm field on the JWK is present and matches
 // that algorithm. Precondition: parsedJws must have exactly one signature on
-// it. Returns stat name to increment if err is non-nil.
+// it.
 func checkAlgorithm(key *jose.JSONWebKey, parsedJws *jose.JSONWebSignature) error {
 	algorithm, err := algorithmForKey(key)
 	if err != nil {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1451,7 +1451,7 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(
 
 	// The existing order must be in a ready status to finalize it
 	if orderStatus != acme.StatusReady {
-		wfe.sendError(acme.MalformedProblem(fmt.Sprintf(
+		wfe.sendError(acme.OrderNotReadyProblem(fmt.Sprintf(
 			"Order's status (%q) was not %s", orderStatus, acme.StatusReady)), response)
 		return
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -583,9 +583,8 @@ func (wfe *WebFrontEndImpl) verifyPOST(
 	return result, nil
 }
 
-// Checks parsed JWS whether it matches the given public key
-// and checks whether the algorithm used is acceptable
-// (the latter is still to be implemented).
+// verifyJWSSignatureAndAlgorithm verifies the pubkey and JWS algorithms are
+// acceptable and that the JWS verifies with the provided pubkey.
 func (wfe *WebFrontEndImpl) verifyJWSSignatureAndAlgorithm(
 	pubKey *jose.JSONWebKey,
 	parsedJWS *jose.JSONWebSignature) ([]byte, error) {


### PR DESCRIPTION
Resolves https://github.com/letsencrypt/pebble/issues/210

I also noticed that CI was running `go vet` without `-mod=vendor` and was downloading deps. d1f3e64 fixes that as part of this PR.