### PR TITLE
Connect AppVeyor to Pebble project

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,4 @@
+build: off
+
+test_script:
+  - ps: Write-Host "Hello, world!"


### PR DESCRIPTION
This PR is the prerequisite to #208, it is about activating a Windows pipeline for Pebble. This PR contains only a dummy pipeline that is here to confirm that everything is wired. The actual logic for this pipeline will be in the next PR.

AppVeyor is a CI provider that uses Windows VMs to execute specific pipelines for this platform. We use it in the Certbot project. Everything is configured through an `appveyor.yml` file, similar to `.travis.yml`.

I put here a link to the equivalent PR that I did for Certbot when we connected AppVeyor for it: certbot/certbot#6361. It contains the detailed instructions for the steps I am about to enumerate here:

Basically, activating AppVeyor consists in:
* creating a `letsencrypt` account on https://www.appveyor.com/,
* associating the `letsencrypt` GitHub account using OAuth,
* create an AppVeyor project for the `letsencrypt/pebble` GitHub project
* merging this PR

Once done, I will check that the dummy pipeline is correctly triggered for the `master` branch. Then I will update my PR against `master` to trigger the first full pipeline logic for a PR push.