### PR TITLE
Use pre-build release versions of pebble and pebble-challtestsrv in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Pebble includes a [docker-compose](https://docs.docker.com/compose/) file that
 will create a `pebble` instance that uses a `pebble-challtestsrv` instance for
 DNS resolution.
 
-To build and start the containers run:
+To download and start the containers run:
 
 ```
 docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
 version: '3'
 services:
   pebble:
-    build:
-      context: .
-      dockerfile: docker/pebble/Dockerfile
+    image: letsencrypt/pebble:v2.0.0
     command: pebble -config /test/config/pebble-config.json -strict -dnsserver 10.30.50.3:8053
     ports:
       # HTTPS ACME API
@@ -12,9 +10,7 @@ services:
       acmenet:
         ipv4_address: 10.30.50.2
   challtestsrv:
-    build:
-      context: .
-      dockerfile: docker/pebble-challtestsrv/Dockerfile
+    image: letsencrypt/pebble-challtestsrv:v2.0.0
     command: pebble-challtestsrv -defaultIPv6 "" -defaultIPv4 10.30.50.3
     ports:
       # HTTP Management Interface


### PR DESCRIPTION
During the PR certbot/certbot#6578, a request emerged from the work we are doing on Certbot to use integration tests with pebble.

Indeed, current `docker-compose.yml` file, on the contrary of the Boulder one, compile Pebble and Pebble-ChallTestSrv from the GIT repository current branch.

This PR modifies this file to use the latest released version in Docker Hub, like it is done for Boulder. This allows to use a fully tested and released version of Pebble, that will be a benefit for the Certbot CI workflow, and for any user that would like to use the `docker-compose.yml` file in the GIT repo as a fast and reliable setup.