### PR TITLE
Reuse certbot master branch since keyAuthorization has been fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ services:
   - docker
 
 before_install:
-  # TODO(#204): Change back to cloning master once Certbot omits keyAuthorization.
-  - git clone --depth=1 -b no-keyauthorization https://github.com/certbot/certbot
+  - git clone --single-branch --depth=1 -b master https://github.com/certbot/certbot
   - cd certbot
   - ./certbot-auto --os-packages-only -n
   - ./tools/venv.py


### PR DESCRIPTION
Thanks to certbot/certbot#6758 that has been merged, Certbot on master branch is able again to communicate with Pebble with the strict requirements enabled. This PR change Travis configuration to reuse the master branch again.

Fixes #204 