### PR TITLE
Add challtestsrv mocked CNAMEs

### DIFF
--- a/cmd/pebble-challtestsrv/README.md
+++ b/cmd/pebble-challtestsrv/README.md
@@ -93,6 +93,16 @@ To remove the mocked CAA policy for `test-host.letsencrypt.org` run:
 
     curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/clear-caa
 
+##### Mocked CNAME Responses
+
+To add a mocked CNAME record for `_acme-challenge.test-host.letsencrypt.org` run:
+
+    curl -X POST -d '{"host":"_acme-challenge.test-host.letsencrypt.org", "target": "challenges.letsencrypt.org"}' http://localhost:8055/set-cname
+
+To remove a mocked CNAME record for `_acme-challenge.test-host.letsencrypt.org` run:
+
+    curl -X POST -d '{"host":"_acme-challenge.test-host.letsencrypt.org", "target": "challenges.letsencrypt.org"}' http://localhost:8055/clear-cname
+
 #### HTTP-01
 
 To add an HTTP-01 challenge response for the token `"aaaa"` with the content `"bbbb"` run:

--- a/cmd/pebble-challtestsrv/main.go
+++ b/cmd/pebble-challtestsrv/main.go
@@ -116,6 +116,8 @@ func main() {
 		http.HandleFunc("/clear-aaaa", oobSrv.delDNSAAAARecord)
 		http.HandleFunc("/add-caa", oobSrv.addDNSCAARecord)
 		http.HandleFunc("/clear-caa", oobSrv.delDNSCAARecord)
+		http.HandleFunc("/set-cname", oobSrv.addDNSCNAMERecord)
+		http.HandleFunc("/clear-cname", oobSrv.delDNSCNAMERecord)
 
 		srv.SetDefaultDNSIPv4(*defaultIPv4)
 		srv.SetDefaultDNSIPv6(*defaultIPv6)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/letsencrypt/pebble
 
 require (
 	github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
-	github.com/letsencrypt/challtestsrv v1.0.2
+	github.com/letsencrypt/challtestsrv v1.1.0
 	golang.org/x/net v0.0.0-20181207154023-610586996380 // indirect
 	golang.org/x/sys v0.0.0-20181206074257-70b957f3b65e // indirect
 	gopkg.in/square/go-jose.v2 v2.1.9

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/letsencrypt/challtestsrv v1.0.1 h1:9K3DJleJxOnP3YlFPWeNydca61Lwj4vySq
 github.com/letsencrypt/challtestsrv v1.0.1/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/letsencrypt/challtestsrv v1.0.2 h1:nBAQjKvVMLhpj4cg2Px6jMyvMbQNdJrCEd6gdcmEuOU=
 github.com/letsencrypt/challtestsrv v1.0.2/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
+github.com/letsencrypt/challtestsrv v1.1.0 h1:2r5Wa7LvOqUsM8skGSaRnf3CV6WYPQ/OgLF1U6bCt4I=
+github.com/letsencrypt/challtestsrv v1.1.0/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/miekg/dns v1.1.1 h1:DVkblRdiScEnEr0LR9nTnEQqHYycjkXW9bOjd+2EL2o=
 github.com/miekg/dns v1.1.1/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=

--- a/va/va.go
+++ b/va/va.go
@@ -387,7 +387,7 @@ func (va VAImpl) validateTLSALPN01(task *vaTask) *core.ValidationRecord {
 	h := sha256.Sum256([]byte(expectedKeyAuthorization))
 	for _, ext := range leafCert.Extensions {
 		if ext.Critical {
-			hasAcmeIdentifier := challtestsrv.IdPeAcmeIdentifier.Equal(ext.Id)
+			hasAcmeIdentifier := challtestsrv.IDPeAcmeIdentifier.Equal(ext.Id)
 			if hasAcmeIdentifier {
 				var extValue []byte
 				if _, err := asn1.Unmarshal(ext.Value, &extValue); err != nil {

--- a/vendor/github.com/letsencrypt/challtestsrv/.travis.yml
+++ b/vendor/github.com/letsencrypt/challtestsrv/.travis.yml
@@ -1,14 +1,23 @@
 language: go
 go:
-  - "1.11.x"
+  - "stable"
 env:
   - GO111MODULE=on
 
 # Override the base install phase so that the project can be installed using
 # `-mod=vendor` to use the vendored dependencies
 install:
+  # Install `golangci-lint` using their installer script
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.13.2
+  # Install `cover` and `goveralls` without `GO111MODULE` enabled so that we
+  # don't download project dependencies and just put the tools in $GOPATH/bin
+  - GO111MODULE=off go get golang.org/x/tools/cmd/cover
+  - GO111MODULE=off go get github.com/mattn/goveralls
   - go install -mod=vendor -v -race ./...
 
 script:
-  - go vet -mod=vendor -v ./...
-  - go test -mod=vendor -v -race ./...
+  - set -e
+  - go mod download
+  - golangci-lint run
+  - go test -mod=vendor -v -race -covermode=atomic -coverprofile=coverage.out ./...
+  - goveralls -coverprofile=coverage.out -service=travis-ci

--- a/vendor/github.com/letsencrypt/challtestsrv/README.md
+++ b/vendor/github.com/letsencrypt/challtestsrv/README.md
@@ -1,9 +1,16 @@
 # Challenge Test Server
 
+[![Build Status](https://travis-ci.org/letsencrypt/challtestsrv.svg?branch=master)](https://travis-ci.org/letsencrypt/challtestsrv)
+[![Coverage Status](https://coveralls.io/repos/github/letsencrypt/challtestsrv/badge.svg)](https://coveralls.io/github/letsencrypt/challtestsrv)
+[![Go Report Card](https://goreportcard.com/badge/github.com/letsencrypt/challtestsrv)](https://goreportcard.com/report/github.com/letsencrypt/challtestsrv)
+[![GolangCI](https://golangci.com/badges/github.com/letsencrypt/challtestsrv.svg)](https://golangci.com/r/github.com/letsencrypt/challtestsrv)
+
 The `challtestsrv` package offers a library/command that can be used by test
 code to respond to HTTP-01, DNS-01, and TLS-ALPN-01 ACME challenges. The
 `challtestsrv` package can also be used as a mock DNS server letting
-developers mock `A`, `AAAA`, and `CAA` DNS data for specific hostnames.
+developers mock `A`, `AAAA`, `CNAME`, and `CAA` DNS data for specific hostnames.
+The mock server will resolve up to one level of `CNAME` aliasing for accepted
+DNS request types.
 
 **Important note: The `challtestsrv` command and library are for TEST USAGE
 ONLY. It is trivially insecure, offering no authentication. Only use

--- a/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go
@@ -74,6 +74,8 @@ type mockDNSData struct {
 	aaaaRecords map[string][]string
 	// A map of host to CAA policies for CAA responses.
 	caaRecords map[string][]MockCAAPolicy
+	// A map of host to CNAME records.
+	cnameRecords map[string]string
 }
 
 // MockCAAPolicy holds a tag and a value for a CAA record. See
@@ -131,11 +133,12 @@ func New(config Config) (*ChallSrv, error) {
 		tlsALPNOne:     make(map[string]string),
 		redirects:      make(map[string]string),
 		dnsMocks: mockDNSData{
-			defaultIPv4: defaultIPv4,
-			defaultIPv6: defaultIPv6,
-			aRecords:    make(map[string][]string),
-			aaaaRecords: make(map[string][]string),
-			caaRecords:  make(map[string][]MockCAAPolicy),
+			defaultIPv4:  defaultIPv4,
+			defaultIPv6:  defaultIPv6,
+			aRecords:     make(map[string][]string),
+			aaaaRecords:  make(map[string][]string),
+			caaRecords:   make(map[string][]MockCAAPolicy),
+			cnameRecords: make(map[string]string),
 		},
 	}
 

--- a/vendor/github.com/letsencrypt/challtestsrv/dns.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/dns.go
@@ -28,6 +28,28 @@ func mockSOA() *dns.SOA {
 // more RRs for the response.
 type dnsAnswerFunc func(question dns.Question) []dns.RR
 
+// cnameAnswers is a dnsAnswerFunc that creates CNAME RR's for the given question
+// using the ChallSrv's dns mock data. If there is no mock CNAME data for the
+// given hostname in the question no RR's will be returned.
+func (s *ChallSrv) cnameAnswers(q dns.Question) []dns.RR {
+	var records []dns.RR
+
+	if value := s.GetDNSCNAMERecord(q.Name); value != "" {
+		record := &dns.CNAME{
+			Hdr: dns.RR_Header{
+				Name:   q.Name,
+				Rrtype: dns.TypeCNAME,
+				Class:  dns.ClassINET,
+			},
+			Target: value,
+		}
+
+		records = append(records, record)
+	}
+
+	return records
+}
+
 // txtAnswers is a dnsAnswerFunc that creates TXT RR's for the given question
 // using the ChallSrv's dns mock data. If there is no mock TXT data for the
 // given hostname in the question no RR's will be returned.
@@ -133,8 +155,10 @@ func (s *ChallSrv) caaAnswers(q dns.Question) []dns.RR {
 }
 
 // dnsHandler is a miekg/dns handler that can process a dns.Msg request and
-// write a response to the provided dns.ResponseWriter. TXT, A, AAAA, and CAA
-// queries types are supported and answered using the ChallSrv's mock DNS data.
+// write a response to the provided dns.ResponseWriter. TXT, A, AAAA, CNAME,
+// and CAA queries types are supported and answered using the ChallSrv's mock
+// DNS data. A host that is aliased by a CNAME record will follow that alias
+// one level and return the requested record types for that alias' target
 func (s *ChallSrv) dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 	m := new(dns.Msg)
 	m.SetReply(r)
@@ -146,8 +170,19 @@ func (s *ChallSrv) dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 			Question: q,
 		})
 
+		// If a CNAME exists for the question include the CNAME record and modify
+		// the question to instead lookup based on that CNAME's target
+		if cname := s.GetDNSCNAMERecord(q.Name); cname != "" {
+			cnameRecords := s.cnameAnswers(q)
+			m.Answer = append(m.Answer, cnameRecords...)
+
+			q = dns.Question{Name: cname, Qtype: q.Qtype}
+		}
+
 		var answerFunc dnsAnswerFunc
 		switch q.Qtype {
+		case dns.TypeCNAME:
+			answerFunc = s.cnameAnswers
 		case dns.TypeTXT:
 			answerFunc = s.txtAnswers
 		case dns.TypeA:

--- a/vendor/github.com/letsencrypt/challtestsrv/mockdns.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/mockdns.go
@@ -38,6 +38,33 @@ func (s *ChallSrv) GetDefaultDNSIPv6() string {
 	return s.dnsMocks.defaultIPv6
 }
 
+// AddDNSCNAMERecord sets a CNAME record that will be used like an alias when
+// querying for other DNS records for the given host.
+func (s *ChallSrv) AddDNSCNAMERecord(host string, value string) {
+	s.challMu.Lock()
+	defer s.challMu.Unlock()
+	host = dns.Fqdn(host)
+	value = dns.Fqdn(value)
+	s.dnsMocks.cnameRecords[host] = value
+}
+
+// GetDNSCNAMERecord returns a target host if a CNAME is set for the querying
+// host and an empty string otherwise.
+func (s *ChallSrv) GetDNSCNAMERecord(host string) string {
+	s.challMu.RLock()
+	host = dns.Fqdn(host)
+	defer s.challMu.RUnlock()
+	return s.dnsMocks.cnameRecords[host]
+}
+
+// DeleteDNSCAMERecord deletes any CNAME alias set for the given host.
+func (s *ChallSrv) DeleteDNSCNAMERecord(host string) {
+	s.challMu.Lock()
+	defer s.challMu.Unlock()
+	host = dns.Fqdn(host)
+	delete(s.dnsMocks.cnameRecords, host)
+}
+
 // AddDNSARecord adds IPv4 addresses that will be returned when querying for
 // A records for the given host.
 func (s *ChallSrv) AddDNSARecord(host string, addresses []string) {

--- a/vendor/github.com/letsencrypt/challtestsrv/tlsalpnone.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/tlsalpnone.go
@@ -20,9 +20,10 @@ import (
 // https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-01#section-5.2
 const ACMETLS1Protocol = "acme-tls/1"
 
-// As defined in https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-04#section-5.1
+// IDPeAcmeIdentifier is the identifier defined in
+// https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-04#section-5.1
 // id-pe OID + 31 (acmeIdentifier)
-var IdPeAcmeIdentifier = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 31}
+var IDPeAcmeIdentifier = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 31}
 
 // AddTLSALPNChallenge adds a new TLS-ALPN-01 key authorization for the given host
 func (s *ChallSrv) AddTLSALPNChallenge(host, content string) {
@@ -75,7 +76,7 @@ func (s *ChallSrv) ServeChallengeCertFunc(k *ecdsa.PrivateKey) func(*tls.ClientH
 			DNSNames:     []string{hello.ServerName},
 			ExtraExtensions: []pkix.Extension{
 				{
-					Id:       IdPeAcmeIdentifier,
+					Id:       IDPeAcmeIdentifier,
 					Critical: true,
 					Value:    extValue,
 				},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
 github.com/jmhodges/clock
-# github.com/letsencrypt/challtestsrv v1.0.2
+# github.com/letsencrypt/challtestsrv v1.1.0
 github.com/letsencrypt/challtestsrv
 # github.com/miekg/dns v1.1.1
 github.com/miekg/dns


### PR DESCRIPTION
Adds challtestsrv endpoints for managing mocked CNAMEs added in https://github.com/letsencrypt/challtestsrv/pull/7. CNAMEs will resolve up to one level for DNS requests for record types accepted by challtestsrv.

This allows testing CNAME-based DNS-01 challenges; where a customer CNAMEs to a platform-controlled domain where the actual TXT records are set up.

Example:
```
$ curl localhost:8055/set-cname -XPOST --data '{"host":"foo.example.com", "target":"foobar.example.com"}'

$ curl localhost:8055/set-txt -XPOST --data '{"host":"foobar.example.com.", "value":"foobar"}'

$ curl localhost:8055/add-a -XPOST --data '{"host":"foobar.example.com", "addresses":["1.2.3.4"]}'

$ dig @localhost -p 8053 foo.example.com +noall +answer
foo.example.com.	0	IN	CNAME	foobar.example.com.
foobar.example.com.	0	IN	A	1.2.3.4

$ dig TXT @localhost -p 8053 foo.example.com +noall +answer
foo.example.com.	0	IN	CNAME	foobar.example.com.
foobar.example.com.	0	IN	TXT	"foobar"

$ dig CNAME @localhost -p 8053 foo.example.com +noall +answer
foo.example.com.	0	IN	CNAME	foobar.example.com.
```