### PR TITLE
wfe: lock authz before use (#228)

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1556,6 +1556,10 @@ func (wfe *WebFrontEndImpl) Authz(
 		response.WriteHeader(http.StatusNotFound)
 		return
 	}
+	authz.Lock()
+	defer authz.Unlock()
+	authz.Order.Lock()
+	defer authz.Order.Unlock()
 
 	// If the postData is not a POST-as-GET, treat this as case A) and update
 	// the authorization based on the postData


### PR DESCRIPTION
Without this there is a race that the valid state can be updated while
the response to the client is being constructed.

Since JSON encoding of objects follow all pointers this requires quite a
lot of not so nice locking.

Fixes #228 