### PR TITLE
fix dataraces, add -race install, add load-gen.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,16 @@ before_install:
 install:
   # Install `golangci-lint` using their installer script
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
-  # Install `cover` and `goveralls` without `GO111MODULE` enabled so that we
-  # don't download ct-woodpecker dependencies and just put the tools in our
+  # Install tools without `GO111MODULE` enabled so that we
+  # don't download Pebble's deps and just put the tools in our
   # gobin.
   - GO111MODULE=off go get golang.org/x/tools/cmd/cover
   - GO111MODULE=off go get github.com/mattn/goveralls
-  - go install -v -mod=vendor ./...
+  - GO111MODULE=off go get github.com/letsencrypt/boulder/test/load-generator
+  - go install -v -race -mod=vendor ./...
 
 before_script:
-  - pebble &
+  - GORACE="halt_on_error=1" pebble &
 
 script:
   - go mod download
@@ -50,6 +51,10 @@ script:
   - goveralls -coverprofile=coverage.out -service=travis-ci
   # Perform a test issuance with chisel2.py
   - REQUESTS_CA_BUNDLE=./test/certs/pebble.minica.pem python ./test/chisel2.py example.letsencrypt.org elpmaxe.letsencrypt.org
+  # Run the load-generator briefly - note, because Pebble isn't using the
+  # load-generator's mock DNS server none of the issuances will succeed. This
+  # step is performed just to shake out data races with concurrent requests.
+  - load-generator -config ./test/config/load-generator-config.json
 
 deploy:
   - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
   # Run the load-generator briefly - note, because Pebble isn't using the
   # load-generator's mock DNS server none of the issuances will succeed. This
   # step is performed just to shake out data races with concurrent requests.
-  - load-generator -config ./test/config/load-generator-config.json
+  - load-generator -config ./test/config/load-generator-config.json > /dev/null
 
 deploy:
   - provider: script

--- a/acme/common.go
+++ b/acme/common.go
@@ -49,10 +49,10 @@ type Order struct {
 
 // An Authorization is created for each identifier in an order
 type Authorization struct {
-	Status     string       `json:"status"`
-	Identifier Identifier   `json:"identifier"`
-	Challenges []*Challenge `json:"challenges"`
-	Expires    string       `json:"expires"`
+	Status     string      `json:"status"`
+	Identifier Identifier  `json:"identifier"`
+	Challenges []Challenge `json:"challenges"`
+	Expires    string      `json:"expires"`
 	// Wildcard is a Let's Encrypt specific Authorization field that indicates the
 	// authorization was created as a result of an order containing a name with
 	// a `*.`wildcard prefix. This will help convey to users that an

--- a/core/types.go
+++ b/core/types.go
@@ -121,6 +121,7 @@ type Authorization struct {
 	URL         string
 	ExpiresDate time.Time
 	Order       *Order
+	Challenges  []*Challenge
 }
 
 type Challenge struct {

--- a/test/config/load-generator-config.json
+++ b/test/config/load-generator-config.json
@@ -1,0 +1,27 @@
+{
+    "plan": {
+        "actions": [
+            "newAccount",
+            "newOrder",
+            "fulfillOrder",
+            "finalizeOrder"
+        ],
+        "rate": 10,
+        "runtime": "30s",
+        "rateDelta": "1/10s"
+    },
+    "directoryURL": "https://localhost:14000/dir",
+    "domainBase": "com",
+    "challengeStrategy": "random",
+    "httpOneAddrs": [":5002"],
+    "tlsAlpnOneAddrs": [":5001"],
+    "dnsAddrs": [":8053"],
+    "fakeDNS": "127.0.0.1",
+    "regKeySize": 2048,
+    "certKeySize": 2048,
+    "regEmail": "loadtesting@letsencrypt.org",
+    "maxRegs": 20,
+    "maxNamesPerCert": 20,
+    "externalState": "state.json",
+    "dontSaveState": false
+}

--- a/test/config/load-generator-config.json
+++ b/test/config/load-generator-config.json
@@ -22,6 +22,5 @@
     "regEmail": "loadtesting@letsencrypt.org",
     "maxRegs": 20,
     "maxNamesPerCert": 20,
-    "externalState": "state.json",
-    "dontSaveState": false
+    "dontSaveState": true
 }

--- a/test/config/load-generator-config.json
+++ b/test/config/load-generator-config.json
@@ -7,7 +7,7 @@
             "finalizeOrder"
         ],
         "rate": 10,
-        "runtime": "30s",
+        "runtime": "10s",
         "rateDelta": "1/10s"
     },
     "directoryURL": "https://localhost:14000/dir",


### PR DESCRIPTION
The `Authz()` method of the WFE was racey. First because it didn't lock the authorizations and orders it was working with. Second because the handling of displaying authorization challenges was working with `acme.Challenge` objects owned by `core.Challenge`'s that should have been locked for reading but were not. This mean the VA would datarace with the WFE when updating a validated challenge status.

To prevent future occurrences `travis.yml` is updated to install Pebble with the race detector enabled, and to run Pebble such that it will exit non-zero if a race is detected.

Since `Chisel2.py` is single threaded the Boulder `load-generator` is used for a short duration to drive concurrent request traffic. In practice before fixing the dataraces I found this would crash Pebble <30s.

Resolves https://github.com/letsencrypt/pebble/issues/230
Resolves https://github.com/letsencrypt/pebble/issues/228