### PR TITLE
allow to offer alternate chains (RFC8555 7.4.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,14 +265,14 @@ repo](test/certs/pebble.minica.key.pem).**
 ### CA Root and Intermediate Certificates
 
 Note that the CA's root and intermediate certificates are regenerated on every
-launch. It can be retrieved by a `GET` request to `https://localhost:14000/root`
-and `https://localhost:14000/intermediate` respectively.
+launch. It can be retrieved by a `GET` request to `https://localhost:14000/roots/`
+and `https://localhost:14000/intermediates/` respectively.
 
 You might need the root certificate to verify the complete trust chain of
 generated certificates, for example in end-to-end tests.
 
 The private keys of these certificates can also be retrieved by a `GET` request
-to `https://localhost:14000/root-key` and `https://localhost:14000/intermediate-key`
+to `https://localhost:14000/root-keys/` and `https://localhost:14000/intermediate-keys/`
 respectively.
 
 **IMPORTANT: Do not add Pebble's root or intermediate certificate to a trust

--- a/README.md
+++ b/README.md
@@ -265,14 +265,14 @@ repo](test/certs/pebble.minica.key.pem).**
 ### CA Root and Intermediate Certificates
 
 Note that the CA's root and intermediate certificates are regenerated on every
-launch. It can be retrieved by a `GET` request to `https://localhost:14000/roots/`
-and `https://localhost:14000/intermediates/` respectively.
+launch. It can be retrieved by a `GET` request to `https://localhost:14000/root`
+and `https://localhost:14000/intermediate` respectively.
 
 You might need the root certificate to verify the complete trust chain of
 generated certificates, for example in end-to-end tests.
 
 The private keys of these certificates can also be retrieved by a `GET` request
-to `https://localhost:14000/root-keys/` and `https://localhost:14000/intermediate-keys/`
+to `https://localhost:14000/root-key` and `https://localhost:14000/intermediate-key`
 respectively.
 
 **IMPORTANT: Do not add Pebble's root or intermediate certificate to a trust
@@ -284,9 +284,10 @@ terminates: so they are not safe to use for anything other than testing.**
 
 In case alternative root chains are enabled by setting `PEBBLE_ALTERNATE_ROOTS` to a
 positive integer, the root certificates for these can be retrieved by doing a `GET`
-request to `https://localhost:14000/roots/0`,
-`https://localhost:14000/intermediate-keys/1` etc. These endpoints also
-send `Link` HTTP headers for all alternative root and intermediate certificates and keys.
+request to `https://localhost:14000/roots/0`, `https://localhost:14000/root-keys/1`
+`https://localhost:14000/intermediates/2`, `https://localhost:14000/intermediate-keys/3`
+etc. These endpoints also send `Link` HTTP headers for all alternative root and
+intermediate certificates and keys.
 
 ### OCSP Responder URL
 

--- a/README.md
+++ b/README.md
@@ -284,8 +284,8 @@ terminates: so they are not safe to use for anything other than testing.**
 
 In case alternative root chains are enabled by setting `PEBBLE_ALTERNATE_ROOTS` to a
 positive integer, the root certificates for these can be retrieved by doing a `GET`
-request to `https://localhost:14000/roots/alternate/1`,
-`https://localhost:14000/intermediate-keys/alternate/2` etc. These endpoints also
+request to `https://localhost:14000/roots/0`,
+`https://localhost:14000/intermediate-keys/1` etc. These endpoints also
 send `Link` HTTP headers for all alternative root and intermediate certificates and keys.
 
 ### OCSP Responder URL

--- a/README.md
+++ b/README.md
@@ -282,6 +282,12 @@ same standards as the Let's Encrypt production CA and their keys. Moreover
 these keys are exposed by Pebble and will be lost as soon as the process
 terminates: so they are not safe to use for anything other than testing.**
 
+In case alternative root chains are enabled by setting `PEBBLE_ALTERNATE_ROOTS` to a
+positive integer, the root certificates for these can be retrieved by doing a `GET`
+request to `https://localhost:14000/roots/alternate/1`,
+`https://localhost:14000/intermediate-keys/alternate/2` etc. These endpoints also
+send `Link` HTTP headers for all alternative root and intermediate certificates and keys.
+
 ### OCSP Responder URL
 
 Pebble does not support the OCSP protocol as a responder and so does not set

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -304,9 +304,8 @@ func (ca *CAImpl) GetNumberOfRootCerts() int {
 func (ca *CAImpl) getChain(no int) *chain {
 	if 0 <= no && no < len(ca.chains) {
 		return ca.chains[no]
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func (ca *CAImpl) GetRootCert(no int) *core.Certificate {

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -157,18 +157,18 @@ func newIntermediateIssuer(root *issuer, ca *CAImpl, ik crypto.Signer) (*issuer,
 }
 
 func newChain(ca *CAImpl, ik crypto.Signer) *chain {
-	chain := &chain{}
 	root, err := newRootIssuer(ca)
 	if err != nil {
 		panic(fmt.Sprintf("Error creating new root issuer: %s", err.Error()))
 	}
-	chain.root = root
-	intermediate, err := newIntermediateIssuer(chain.root, ca, ik)
+	intermediate, err := newIntermediateIssuer(root, ca, ik)
 	if err != nil {
 		panic(fmt.Sprintf("Error creating new intermediate issuer: %s", err.Error()))
 	}
-	chain.intermediate = intermediate
-	return chain
+	return &chain{
+		root:         root,
+		intermediate: intermediate,
+	}
 }
 
 func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.PublicKey, accountID string) (*core.Certificate, error) {

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -141,7 +141,7 @@ func newRootIssuer(ca *CAImpl) (*issuer, error) {
 
 func newIntermediateIssuer(root *issuer, ca *CAImpl, ik crypto.Signer) (*issuer, error) {
 	if root == nil {
-		return nil, fmt.Errorf("newIntermediateIssuer() called before newRootIssuer()")
+		return nil, fmt.Errorf("Internal error: root must not be nil")
 	}
 
 	// Make an intermediate certificate with the root issuer

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/letsencrypt/pebble/ca"
 	"github.com/letsencrypt/pebble/cmd"
@@ -57,8 +58,14 @@ func main() {
 		setupCustomDNSResolver(*resolverAddress)
 	}
 
+	alternateRoots := 0
+	alternateRootsVal := os.Getenv("PEBBLE_ALTERNATE_ROOTS")
+	if val, err := strconv.ParseInt(alternateRootsVal, 10, 0); err == nil && val >= 0 {
+		alternateRoots = int(val)
+	}
+
 	db := db.NewMemoryStore()
-	ca := ca.New(logger, db, c.Pebble.OCSPResponderURL)
+	ca := ca.New(logger, db, c.Pebble.OCSPResponderURL, alternateRoots)
 	va := va.New(logger, c.Pebble.HTTPPort, c.Pebble.TLSPort, *strictMode)
 
 	wfeImpl := wfe.New(logger, db, va, ca, *strictMode)

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -74,7 +74,7 @@ func main() {
 	logger.Printf("Listening on: %s\n", c.Pebble.ListenAddress)
 	logger.Printf("ACME directory available at: https://%s%s",
 		c.Pebble.ListenAddress, wfe.DirectoryPath)
-	logger.Printf("Root CA certificate available at: https://%s%s",
+	logger.Printf("Root CA certificate(s) available at: https://%s%s",
 		c.Pebble.ListenAddress, wfe.RootCertPath)
 	err = http.ListenAndServeTLS(
 		c.Pebble.ListenAddress,

--- a/core/types.go
+++ b/core/types.go
@@ -145,12 +145,11 @@ func (ch *Challenge) ExpectedKeyAuthorization(key *jose.JSONWebKey) string {
 }
 
 type Certificate struct {
-	ID                 string
-	Cert               *x509.Certificate
-	DER                []byte
-	Issuer             *Certificate
-	AlternativeIssuers []*Certificate
-	AccountID          string
+	ID        string
+	Cert      *x509.Certificate
+	DER       []byte
+	Issuers   []*Certificate
+	AccountID string
 }
 
 func (c Certificate) PEM() []byte {
@@ -175,18 +174,18 @@ func (c Certificate) Chain(no int) []byte {
 	chain = append(chain, c.PEM())
 
 	// Add zero or more issuers
-	issuer := c.Issuer
-	if no != 0 && 0 < no && no <= len(c.AlternativeIssuers) {
-		issuer = c.AlternativeIssuers[no-1]
+	var issuer *Certificate
+	if 0 <= no && no < len(c.Issuers) {
+		issuer = c.Issuers[no]
 	}
 	for {
 		// if the issuer is nil, or the issuer's issuer is nil then we've reached
 		// the root of the chain and can break
-		if issuer == nil || issuer.Issuer == nil {
+		if issuer == nil || len(issuer.Issuers) == 0 {
 			break
 		}
 		chain = append(chain, issuer.PEM())
-		issuer = issuer.Issuer
+		issuer = issuer.Issuers[0]
 	}
 
 	// Return the chain, leaf cert first

--- a/core/types.go
+++ b/core/types.go
@@ -145,11 +145,12 @@ func (ch *Challenge) ExpectedKeyAuthorization(key *jose.JSONWebKey) string {
 }
 
 type Certificate struct {
-	ID        string
-	Cert      *x509.Certificate
-	DER       []byte
-	Issuer    *Certificate
-	AccountID string
+	ID                 string
+	Cert               *x509.Certificate
+	DER                []byte
+	Issuer             *Certificate
+	AlternativeIssuers []*Certificate
+	AccountID          string
 }
 
 func (c Certificate) PEM() []byte {
@@ -167,7 +168,7 @@ func (c Certificate) PEM() []byte {
 	return buf.Bytes()
 }
 
-func (c Certificate) Chain() []byte {
+func (c Certificate) Chain(no int) []byte {
 	chain := make([][]byte, 0)
 
 	// Add the leaf certificate
@@ -175,6 +176,9 @@ func (c Certificate) Chain() []byte {
 
 	// Add zero or more issuers
 	issuer := c.Issuer
+	if no != 0 && 0 < no && no <= len(c.AlternativeIssuers) {
+		issuer = c.AlternativeIssuers[no-1]
+	}
 	for {
 		// if the issuer is nil, or the issuer's issuer is nil then we've reached
 		// the root of the chain and can break

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -245,7 +245,7 @@ func getAlternateNo(url string) (string, int, int) {
 	if len(urlSplit) == 1 {
 		if strings.HasPrefix(url, "alternate/") {
 			urlTrunc = ""
-			noStr = url[len("alternate/"):len(url)]
+			noStr = url[len("alternate/"):]
 		} else {
 			return url, 0, 0
 		}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -235,17 +235,15 @@ func (wfe *WebFrontEndImpl) sendError(prob *acme.ProblemDetails, response http.R
 	_, _ = response.Write(problemDoc)
 }
 
+// Parse the URL to extract alternate number (if available, default 0). Returns the
+// remaining URL, the number (0 or larger), and a HTTP error code (or 0 for success).
+//
+// If the URL contains "/alternate/" or begins with "alternate/", everything following
+// that will be interpreted as the number. If it cannot be parsed as an integer, or
+// the number is negative, a HTTP error (404 Not Found) will be returned. The remaining
+// URL is everything before "/alternate/", respectively the empty string if the URL
+// begins with "alternate/".
 func getAlternateNo(url string) (string, int, int) {
-	// Parse the URL to extract alternate number (if available, default 0).
-	// Returns the remaining URL, the number (0 or larger), and a HTTP
-	// error code (or 0 for success).
-	//
-	// If the URL contains "/alternate/" or begins with "alternate/", everything
-	// following that will be interpreted as the number. If it cannot be
-	// parsed as an integer, or the number is negative, a HTTP error
-	// (404 Not Found) will be returned. The remaining URL is everything
-	// before "/alternate/", respectively the empty string if the URL begins
-	// with "alternate/".
 	urlSplit := strings.SplitN(url, "/alternate/", 2)
 	if len(urlSplit) == 0 {
 		// URL is the empty string: return
@@ -276,11 +274,10 @@ func getAlternateNo(url string) (string, int, int) {
 	return urlTrunc, no + 1, 0
 }
 
+// Adds HTTP Link headers for alternate versions of the resource. To the given
+// URL, "/alternate/<no>" will be added as the address of the alternative. Will
+// add links to all alternatives from 0 up to number-1 except for no.
 func addAlternateLinks(response http.ResponseWriter, url string, no int, number int) {
-	// Adds HTTP Link headers for alternate versions of the resource.
-	// To the given URL, "/alternate/<no>" will be added as the address
-	// of the alternative. Will add links to all alternatives from 0
-	// up to number-1 except for no.
 	if no != 0 {
 		response.Header().Add("Link", link(url, "alternate"))
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -363,26 +363,10 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	wfe.HandleFunc(m, DirectoryPath, wfe.Directory, false, "GET")
 	// Note for noncePath: "GET" also implies "HEAD"
 	wfe.HandleFunc(m, noncePath, wfe.Nonce, false, "GET")
-	wfe.HandleFunc(m, RootCertPath, wfe.handleCert(
-		func(no int) *core.Certificate {
-			return wfe.ca.GetRootCert(no)
-		},
-		wfe.ca.GetNumberOfRootCerts(), RootCertPath), true, "GET")
-	wfe.HandleFunc(m, rootKeyPath, wfe.handleKey(
-		func(no int) *rsa.PrivateKey {
-			return wfe.ca.GetRootKey(no)
-		},
-		wfe.ca.GetNumberOfRootCerts(), rootKeyPath), true, "GET")
-	wfe.HandleFunc(m, intermediateCertPath, wfe.handleCert(
-		func(no int) *core.Certificate {
-			return wfe.ca.GetIntermediateCert(no)
-		},
-		wfe.ca.GetNumberOfRootCerts(), intermediateCertPath), true, "GET")
-	wfe.HandleFunc(m, intermediateKeyPath, wfe.handleKey(
-		func(no int) *rsa.PrivateKey {
-			return wfe.ca.GetIntermediateKey(no)
-		},
-		wfe.ca.GetNumberOfRootCerts(), intermediateKeyPath), true, "GET")
+	wfe.HandleFunc(m, RootCertPath, wfe.handleCert(wfe.ca.GetRootCert, wfe.ca.GetNumberOfRootCerts(), RootCertPath), true, "GET")
+	wfe.HandleFunc(m, rootKeyPath, wfe.handleKey(wfe.ca.GetRootKey, wfe.ca.GetNumberOfRootCerts(), rootKeyPath), true, "GET")
+	wfe.HandleFunc(m, intermediateCertPath, wfe.handleCert(wfe.ca.GetIntermediateCert, wfe.ca.GetNumberOfRootCerts(), intermediateCertPath), true, "GET")
+	wfe.HandleFunc(m, intermediateKeyPath, wfe.handleKey(wfe.ca.GetIntermediateKey, wfe.ca.GetNumberOfRootCerts(), intermediateKeyPath), true, "GET")
 
 	// POST only handlers
 	wfe.HandleFunc(m, newAccountPath, wfe.NewAccount, false, "POST")

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -255,7 +255,7 @@ func getAlternateNo(url string) (string, int, error) {
 	if no < 0 {
 		return url, 0, fmt.Errorf("number is negative")
 	}
-	return urlSplit[0], no + 1, nil
+	return urlSplit[0], no, nil
 }
 
 // Adds HTTP Link headers for alternate versions of the resource. To the given

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -352,6 +352,18 @@ func (wfe *WebFrontEndImpl) handleKey(
 	}
 }
 
+func (wfe *WebFrontEndImpl) handleRedirect(
+	relPath string) func(
+	ctx context.Context,
+	response http.ResponseWriter,
+	request *http.Request) {
+	return func(ctx context.Context, response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("Location", wfe.relativeEndpoint(request, relPath))
+		response.WriteHeader(http.StatusMovedPermanently)
+		_, _ = response.Write([]byte("Please update your URLs!\n"))
+	}
+}
+
 func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	m := http.NewServeMux()
 	// GET only handlers
@@ -362,6 +374,10 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	wfe.HandleFunc(m, rootKeyPath, wfe.handleKey(wfe.ca.GetRootKey, rootKeyPath), "GET")
 	wfe.HandleFunc(m, intermediateCertPath, wfe.handleCert(wfe.ca.GetIntermediateCert, intermediateCertPath), "GET")
 	wfe.HandleFunc(m, intermediateKeyPath, wfe.handleKey(wfe.ca.GetIntermediateKey, intermediateKeyPath), "GET")
+	wfe.HandleFunc(m, "/root", wfe.handleRedirect(RootCertPath), "GET")
+	wfe.HandleFunc(m, "/root-key", wfe.handleRedirect(rootKeyPath), "GET")
+	wfe.HandleFunc(m, "/intermediate", wfe.handleRedirect(intermediateCertPath), "GET")
+	wfe.HandleFunc(m, "/intermediate-key", wfe.handleRedirect(intermediateKeyPath), "GET")
 
 	// POST only handlers
 	wfe.HandleFunc(m, newAccountPath, wfe.NewAccount, "POST")

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -232,8 +232,8 @@ func (wfe *WebFrontEndImpl) sendError(prob *acme.ProblemDetails, response http.R
 	_, _ = response.Write(problemDoc)
 }
 
-type certGetter func(no int) *core.Certificate;
-type keyGetter func(no int) *rsa.PrivateKey;
+type certGetter func(no int) *core.Certificate
+type keyGetter func(no int) *rsa.PrivateKey
 
 func (wfe *WebFrontEndImpl) handleCert(
 	certGet certGetter,
@@ -248,7 +248,7 @@ func (wfe *WebFrontEndImpl) handleCert(
 		noStr := request.URL.Query().Get("no")
 		if noStr != "" {
 			noInt, err := strconv.Atoi(noStr)
-			if err != nil || noInt < 0 || noInt >= wfe.ca.GetNumberOfAlternativeRootCerts() {
+			if err != nil || noInt < 0 || noInt >= numberOfAlternativeRootCerts {
 				response.WriteHeader(http.StatusNotFound)
 				return
 			}
@@ -256,7 +256,7 @@ func (wfe *WebFrontEndImpl) handleCert(
 		}
 
 		// Get hold of root certificate
-		cert := certGet(no);
+		cert := certGet(no)
 		if cert == nil {
 			response.WriteHeader(http.StatusServiceUnavailable)
 			return
@@ -266,7 +266,7 @@ func (wfe *WebFrontEndImpl) handleCert(
 		if no != 0 {
 			response.Header().Add("Link", link(wfe.relativeEndpoint(request, relPath), "alternate"))
 		}
-		for i := 0; i < wfe.ca.GetNumberOfAlternativeRootCerts(); i++ {
+		for i := 0; i < numberOfAlternativeRootCerts; i++ {
 			if no == i+1 {
 				continue
 			}
@@ -294,7 +294,7 @@ func (wfe *WebFrontEndImpl) handleKey(
 		noStr := request.URL.Query().Get("no")
 		if noStr != "" {
 			noInt, err := strconv.Atoi(noStr)
-			if err != nil || noInt < 0 || noInt >= wfe.ca.GetNumberOfAlternativeRootCerts() {
+			if err != nil || noInt < 0 || noInt >= numberOfAlternativeRootCerts {
 				response.WriteHeader(http.StatusNotFound)
 				return
 			}
@@ -302,7 +302,7 @@ func (wfe *WebFrontEndImpl) handleKey(
 		}
 
 		// Get hold of root certificate's key
-		key := keyGet(no);
+		key := keyGet(no)
 		if key == nil {
 			response.WriteHeader(http.StatusServiceUnavailable)
 			return
@@ -312,7 +312,7 @@ func (wfe *WebFrontEndImpl) handleKey(
 		if no != 0 {
 			response.Header().Add("Link", link(wfe.relativeEndpoint(request, relPath), "alternate"))
 		}
-		for i := 0; i < wfe.ca.GetNumberOfAlternativeRootCerts(); i++ {
+		for i := 0; i < numberOfAlternativeRootCerts; i++ {
 			if no == i+1 {
 				continue
 			}
@@ -346,22 +346,22 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	wfe.HandleFunc(m, noncePath, wfe.Nonce, "GET")
 	wfe.HandleFunc(m, RootCertPath, wfe.handleCert(
 		func(no int) *core.Certificate {
-			return wfe.ca.GetRootCert(no);
+			return wfe.ca.GetRootCert(no)
 		},
 		wfe.ca.GetNumberOfAlternativeRootCerts(), RootCertPath), "GET")
 	wfe.HandleFunc(m, rootKeyPath, wfe.handleKey(
 		func(no int) *rsa.PrivateKey {
-			return wfe.ca.GetRootKey(no);
+			return wfe.ca.GetRootKey(no)
 		},
 		wfe.ca.GetNumberOfAlternativeRootCerts(), rootKeyPath), "GET")
 	wfe.HandleFunc(m, intermediateCertPath, wfe.handleCert(
 		func(no int) *core.Certificate {
-			return wfe.ca.GetIntermediateCert(no);
+			return wfe.ca.GetIntermediateCert(no)
 		},
 		wfe.ca.GetNumberOfAlternativeRootCerts(), intermediateCertPath), "GET")
 	wfe.HandleFunc(m, intermediateKeyPath, wfe.handleKey(
 		func(no int) *rsa.PrivateKey {
-			return wfe.ca.GetIntermediateKey(no);
+			return wfe.ca.GetIntermediateKey(no)
 		},
 		wfe.ca.GetNumberOfAlternativeRootCerts(), intermediateKeyPath), "GET")
 

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -232,48 +232,6 @@ func (wfe *WebFrontEndImpl) sendError(prob *acme.ProblemDetails, response http.R
 	_, _ = response.Write(problemDoc)
 }
 
-// Parse the URL to extract alternate number (if available, default 0). Returns the
-// remaining URL, the number (0 or larger), and an error (or nil for success).
-//
-// If the URL contains "/alternate/", everything following that will be interpreted as
-// the number. If it cannot be parsed as an integer, or the number is negative, an error
-// will be returned. The remaining URL is everything before "/alternate/".
-func getAlternateNo(url string) (string, int, error) {
-	urlSplit := strings.SplitN(url, "/alternate/", 2)
-	if len(urlSplit) == 0 {
-		// URL is the empty string: return
-		return url, 0, nil
-	}
-	if len(urlSplit) == 1 {
-		// URL does not contain "/alternate/".
-		return url, 0, nil
-	}
-	no, err := strconv.Atoi(urlSplit[1])
-	if err != nil {
-		return url, 0, err
-	}
-	if no < 0 {
-		return url, 0, fmt.Errorf("number is negative")
-	}
-	return urlSplit[0], no, nil
-}
-
-// Adds HTTP Link headers for alternate versions of the resource. To the given
-// URL, "/alternate/<no>" will be added as the address of the alternative. Will
-// add links to all alternatives from 0 up to number-1 except for no.
-func addAlternateLinks(response http.ResponseWriter, url string, no int, number int) {
-	if no != 0 {
-		response.Header().Add("Link", link(url, "alternate"))
-	}
-	for i := 1; i < number; i++ {
-		if no == i {
-			continue
-		}
-		path := fmt.Sprintf("%s/alternate/%d", url, i)
-		response.Header().Add("Link", link(path, "alternate"))
-	}
-}
-
 type certGetter func(no int) *core.Certificate
 type keyGetter func(no int) *rsa.PrivateKey
 
@@ -285,7 +243,7 @@ func (wfe *WebFrontEndImpl) handleCert(
 	request *http.Request) {
 	return func(ctx context.Context, response http.ResponseWriter, request *http.Request) {
 		// Check for parameter
-		_, no, err := getAlternateNo(request.URL.Path)
+		no, err := strconv.Atoi(request.URL.Path)
 		if err != nil {
 			response.WriteHeader(http.StatusNotFound)
 			return
@@ -300,7 +258,13 @@ func (wfe *WebFrontEndImpl) handleCert(
 
 		// Add links to alternate roots
 		basePath := wfe.relativeEndpoint(request, relPath)
-		addAlternateLinks(response, basePath, no, wfe.ca.GetNumberOfRootCerts())
+		for i := 0; i < wfe.ca.GetNumberOfRootCerts(); i++ {
+			if no == i {
+				continue
+			}
+			path := fmt.Sprintf("%s%d", basePath, i)
+			response.Header().Add("Link", link(path, "alternate"))
+		}
 
 		// Write main response
 		response.Header().Set("Content-Type", "application/pem-certificate-chain; charset=utf-8")
@@ -317,7 +281,7 @@ func (wfe *WebFrontEndImpl) handleKey(
 	request *http.Request) {
 	return func(ctx context.Context, response http.ResponseWriter, request *http.Request) {
 		// Check for parameter
-		_, no, err := getAlternateNo(request.URL.Path)
+		no, err := strconv.Atoi(request.URL.Path)
 		if err != nil {
 			response.WriteHeader(http.StatusNotFound)
 			return
@@ -332,7 +296,13 @@ func (wfe *WebFrontEndImpl) handleKey(
 
 		// Add links to alternate root keys
 		basePath := wfe.relativeEndpoint(request, relPath)
-		addAlternateLinks(response, basePath, no, wfe.ca.GetNumberOfRootCerts())
+		for i := 0; i < wfe.ca.GetNumberOfRootCerts(); i++ {
+			if no == i {
+				continue
+			}
+			path := fmt.Sprintf("%s%d", basePath, i)
+			response.Header().Add("Link", link(path, "alternate"))
+		}
 
 		// Write main response
 		var buf bytes.Buffer
@@ -374,10 +344,10 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	wfe.HandleFunc(m, rootKeyPath, wfe.handleKey(wfe.ca.GetRootKey, rootKeyPath), "GET")
 	wfe.HandleFunc(m, intermediateCertPath, wfe.handleCert(wfe.ca.GetIntermediateCert, intermediateCertPath), "GET")
 	wfe.HandleFunc(m, intermediateKeyPath, wfe.handleKey(wfe.ca.GetIntermediateKey, intermediateKeyPath), "GET")
-	wfe.HandleFunc(m, "/root", wfe.handleRedirect(RootCertPath), "GET")
-	wfe.HandleFunc(m, "/root-key", wfe.handleRedirect(rootKeyPath), "GET")
-	wfe.HandleFunc(m, "/intermediate", wfe.handleRedirect(intermediateCertPath), "GET")
-	wfe.HandleFunc(m, "/intermediate-key", wfe.handleRedirect(intermediateKeyPath), "GET")
+	wfe.HandleFunc(m, "/root", wfe.handleRedirect(RootCertPath+"0"), "GET")
+	wfe.HandleFunc(m, "/root-key", wfe.handleRedirect(rootKeyPath+"0"), "GET")
+	wfe.HandleFunc(m, "/intermediate", wfe.handleRedirect(intermediateCertPath+"0"), "GET")
+	wfe.HandleFunc(m, "/intermediate-key", wfe.handleRedirect(intermediateKeyPath+"0"), "GET")
 
 	// POST only handlers
 	wfe.HandleFunc(m, newAccountPath, wfe.NewAccount, "POST")
@@ -2039,6 +2009,48 @@ func (wfe *WebFrontEndImpl) updateChallenge(
 	if err != nil {
 		wfe.sendError(acme.InternalErrorProblem("Error marshalling challenge"), response)
 		return
+	}
+}
+
+// Parse the URL to extract alternate number (if available, default 0). Returns the
+// remaining URL, the number (0 or larger), and an error (or nil for success).
+//
+// If the URL contains "/alternate/", everything following that will be interpreted as
+// the number. If it cannot be parsed as an integer, or the number is negative, an error
+// will be returned. The remaining URL is everything before "/alternate/".
+func getAlternateNo(url string) (string, int, error) {
+	urlSplit := strings.SplitN(url, "/alternate/", 2)
+	if len(urlSplit) == 0 {
+		// URL is the empty string: return
+		return url, 0, nil
+	}
+	if len(urlSplit) == 1 {
+		// URL does not contain "/alternate/".
+		return url, 0, nil
+	}
+	no, err := strconv.Atoi(urlSplit[1])
+	if err != nil {
+		return url, 0, err
+	}
+	if no < 0 {
+		return url, 0, fmt.Errorf("number is negative")
+	}
+	return urlSplit[0], no, nil
+}
+
+// Adds HTTP Link headers for alternate versions of the resource. To the given
+// URL, "/alternate/<no>" will be added as the address of the alternative. Will
+// add links to all alternatives from 0 up to number-1 except for no.
+func addAlternateLinks(response http.ResponseWriter, url string, no int, number int) {
+	if no != 0 {
+		response.Header().Add("Link", link(url, "alternate"))
+	}
+	for i := 1; i < number; i++ {
+		if no == i {
+			continue
+		}
+		path := fmt.Sprintf("%s/alternate/%d", url, i)
+		response.Header().Add("Link", link(path, "alternate"))
 	}
 }
 


### PR DESCRIPTION
Allows to offer alternate chains for a certificate according to RFC8555, Section 7.4.2. For this, multiple root and intermediate certs are created (all with the same intermediate private key), and `alternative` relation links are offered during certificate download. The `/root` endpoint has also been extended to allow downloading the alternate roots (`?no=0`, `?no=1` etc.); it also provides `link` headers for its alternate forms.

This feature can be enabled by setting the environment variable `PEBBLE_ALTERNATE_ROOTS` to something larger than 0. For example, with `PEBBLE_ALTERNATE_ROOTS=2`:

```.sh
$ curl -i -k https://0.0.0.0:14000/root
HTTP/2 200 
cache-control: public, max-age=0, no-cache
content-type: application/pem-certificate-chain; charset=utf-8
link: <https://0.0.0.0:14000/dir>;rel="index"
link: <https://0.0.0.0:14000/root%3Fno=0>;rel="alternate"
link: <https://0.0.0.0:14000/root%3Fno=1>;rel="alternate"
content-length: 1107
date: Sun, 12 May 2019 15:05:37 GMT

-----BEGIN CERTIFICATE-----
...

$ curl -i -k https://0.0.0.0:14000/root?no=1
HTTP/2 200 
cache-control: public, max-age=0, no-cache
content-type: application/pem-certificate-chain; charset=utf-8
link: <https://0.0.0.0:14000/dir>;rel="index"
link: <https://0.0.0.0:14000/root>;rel="alternate"
link: <https://0.0.0.0:14000/root%3Fno=0>;rel="alternate"
content-length: 1107
date: Sun, 12 May 2019 15:06:07 GMT

-----BEGIN CERTIFICATE-----
...
```

(For context, see https://community.letsencrypt.org/t/please-update-the-certificate-compatibility-page-to-include-information-about-the-new-isrg-roots/91436/18)