### PR TITLE
Expose issuer root key, intermediate issuer cert and key through entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,5 +279,5 @@ respectively.
 store that you use for ordinary browsing or that is used for non-testing
 purposes, since Pebble and its generated keys are not audited or held to the
 same standards as the Let's Encrypt production CA and their keys, are exposed
-by pebble and so are not safe to use for anything other than testing. Also,
+by Pebble and so are not safe to use for anything other than testing. Also,
 their private keys will be lost as soon as the Pebble process terminates.**

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ and `https://localhost:14000/intermediate` respectively.
 You might need the root certificate to verify the complete trust chain of
 generated certificates, for example in end-to-end tests.
 
-The private keys of these certificates can also be retreived by a `GET` request
+The private keys of these certificates can also be retrieved by a `GET` request
 to `https://localhost:14000/root-key` and `https://localhost:14000/intermediate-key`
 respectively.
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,6 @@ respectively.
 **IMPORTANT: Do not add Pebble's root or intermediate certificate to a trust
 store that you use for ordinary browsing or that is used for non-testing
 purposes, since Pebble and its generated keys are not audited or held to the
-same standards as the Let's Encrypt production CA and their keys, are expose
+same standards as the Let's Encrypt production CA and their keys, are exposed
 by pebble and so are not safe to use for anything other than testing. Also,
 their private keys will be lost as soon as the Pebble process terminates.**

--- a/README.md
+++ b/README.md
@@ -278,6 +278,6 @@ respectively.
 **IMPORTANT: Do not add Pebble's root or intermediate certificate to a trust
 store that you use for ordinary browsing or that is used for non-testing
 purposes, since Pebble and its generated keys are not audited or held to the
-same standards as the Let's Encrypt production CA and their keys, are exposed
-by Pebble and so are not safe to use for anything other than testing. Also,
-their private keys will be lost as soon as the Pebble process terminates.**
+same standards as the Let's Encrypt production CA and their keys. Moreover
+these keys are exposed by Pebble and will be lost as soon as the process
+terminates: so they are not safe to use for anything other than testing.**

--- a/README.md
+++ b/README.md
@@ -262,17 +262,22 @@ store or to any production systems/codebases. The private key for this CA is
 intentionally made [publicly available in this
 repo](test/certs/pebble.minica.key.pem).**
 
-### CA Root Certificate
+### CA Root and Intermediate Certificates
 
-Note that the CA's root certificate is regenerated on every launch. It can be
-retrieved by a `GET` request to `https://localhost:14000/root`.
+Note that the CA's root and intermediate certificates are regenerated on every
+launch. It can be retrieved by a `GET` request to `https://localhost:14000/root`
+and `https://localhost:14000/intermediate` respectively.
 
 You might need the root certificate to verify the complete trust chain of
 generated certificates, for example in end-to-end tests.
 
+The private keys of these certificates can also be retreived by a `GET` request
+to `https://localhost:14000/root-key` and `https://localhost:14000/intermediate-key`
+respectively.
+
 **IMPORTANT: Do not add Pebble's root or intermediate certificate to a trust
 store that you use for ordinary browsing or that is used for non-testing
 purposes, since Pebble and its generated keys are not audited or held to the
-same standards as the Let's Encrypt production CA and their keys, and so are
-not safe to use for anything other than testing. Also, their private keys
-will be lost as soon as the Pebble process terminates.**
+same standards as the Let's Encrypt production CA and their keys, are expose
+by pebble and so are not safe to use for anything other than testing. Also,
+their private keys will be lost as soon as the Pebble process terminates.**

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -73,7 +73,7 @@ func (ca *CAImpl) makeRootCert(
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 	}
 
 	var signerKey crypto.Signer
@@ -182,7 +182,7 @@ func (ca *CAImpl) newCertificate(domains []string, key crypto.PublicKey, account
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
-		IsCA: false,
+		IsCA:                  false,
 	}
 	der, err := x509.CreateCertificate(rand.Reader, template, issuer.cert.Cert, key, issuer.key)
 	if err != nil {

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -74,7 +74,7 @@ func (ca *CAImpl) makeRootCert(
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 	}
 
 	var signerKey crypto.Signer
@@ -185,7 +185,7 @@ func (ca *CAImpl) newCertificate(domains []string, key crypto.PublicKey, account
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
-		IsCA: false,
+		IsCA:                  false,
 	}
 	der, err := x509.CreateCertificate(rand.Reader, template, issuer.cert.Cert, key, issuer.key)
 	if err != nil {

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -280,3 +280,18 @@ func (ca *CAImpl) GetRootKey() *rsa.PrivateKey {
 
 	return ca.root.keyRaw
 }
+
+func (ca *CAImpl) GetIntermediateCert() *core.Certificate {
+	if ca.root == nil {
+		return nil
+	}
+	return ca.intermediate.cert
+}
+
+func (ca *CAImpl) GetIntermediateKey() *rsa.PrivateKey {
+	if ca.root == nil {
+		return nil
+	}
+
+	return ca.intermediate.keyRaw
+}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -264,8 +264,8 @@ func (wfe *WebFrontEndImpl) RootKey(
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	})
 	if err != nil {
-		panic(fmt.Sprintf("Unable to encode private key to PEM: %s",
-			err.Error()))
+		wfe.sendError(acme.InternalErrorProblem("unable to encode private key to PEM"), response)
+		return
 	}
 
 	response.Header().Set("Content-Type", "application/x-pem-file; charset=utf-8")
@@ -307,8 +307,8 @@ func (wfe *WebFrontEndImpl) IntermediateKey(
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	})
 	if err != nil {
-		panic(fmt.Sprintf("Unable to encode private key to PEM: %s",
-			err.Error()))
+		wfe.sendError(acme.InternalErrorProblem("unable to encode private key to PEM"), response)
+		return
 	}
 
 	response.Header().Set("Content-Type", "application/x-pem-file; charset=utf-8")

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -52,12 +52,12 @@ const (
 	keyRolloverPath   = "/rollover-account-key"
 
 	// Theses entrypoints are not a part of the standard ACME endpoints,
-	// and are exposed by Pebble as an integration test tool.
-	intermediateKeyPath  = "/intermediate-key"
+	// and are exposed by Pebble as an integration test tool. We export
+        // RootCertPath so that the pebble binary can reference it.
+        RootCertPath         = "/root"
+        rootKeyPath          = "/root-key"
 	intermediateCertPath = "/intermediate"
-	rootKeyPath          = "/root-key"
-        // We export RootCertPath so that the pebble binary can reference it
-        RootCertPath = "/root"
+	intermediateKeyPath  = "/intermediate-key"
 
 	// How long do pending authorizations last before expiring?
 	pendingAuthzExpire = time.Hour

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -51,7 +51,7 @@ const (
 	revokeCertPath    = "/revoke-cert"
 	keyRolloverPath   = "/rollover-account-key"
 
-	// Theses entrypoint is obviously not a part of the standard ACME endpoints,
+	// Theses entrypoints are not a part of the standard ACME endpoints,
 	// and are expose by Pebble as an integration tests tool.
 	IntermediateCertPath = "/intermediate"
 	IntermediateKeyPath  = "/intermediate-key"

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -52,7 +52,7 @@ const (
 	keyRolloverPath   = "/rollover-account-key"
 
 	// Theses entrypoints are not a part of the standard ACME endpoints,
-	// and are expose by Pebble as an integration tests tool.
+	// and are exposed by Pebble as an integration test tool.
 	IntermediateCertPath = "/intermediate"
 	IntermediateKeyPath  = "/intermediate-key"
 	RootKeyPath          = "/root-key"

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -37,9 +37,8 @@ import (
 const (
 	// Note: We deliberately pick endpoint paths that differ from Boulder to
 	// exercise clients processing of the /directory response
-	// We export the DirectoryPath and RootCertPath so that the pebble binary can reference it
+	// We export the DirectoryPath so that the pebble binary can reference it
 	DirectoryPath     = "/dir"
-	RootCertPath      = "/root"
 	noncePath         = "/nonce-plz"
 	newAccountPath    = "/sign-me-up"
 	acctPath          = "/my-account/"
@@ -54,9 +53,11 @@ const (
 
 	// Theses entrypoints are not a part of the standard ACME endpoints,
 	// and are exposed by Pebble as an integration test tool.
-	IntermediateCertPath = "/intermediate"
-	IntermediateKeyPath  = "/intermediate-key"
-	RootKeyPath          = "/root-key"
+	intermediateKeyPath  = "/intermediate-key"
+	intermediateCertPath = "/intermediate"
+	rootKeyPath          = "/root-key"
+        // We export RootCertPath so that the pebble binary can reference it
+        RootCertPath         = "/root"
 
 	// How long do pending authorizations last before expiring?
 	pendingAuthzExpire = time.Hour
@@ -282,10 +283,10 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	wfe.HandleFunc(m, DirectoryPath, wfe.Directory, "GET")
 	// Note for noncePath: "GET" also implies "HEAD"
 	wfe.HandleFunc(m, noncePath, wfe.Nonce, "GET")
-	wfe.HandleFunc(m, RootCertPath, wfe.handleCert(wfe.ca.GetRootCert()), "GET")
+	wfe.HandleFunc(m, rootCertPath, wfe.handleCert(wfe.ca.GetRootCert()), "GET")
 	wfe.HandleFunc(m, RootKeyPath, wfe.handleKey(wfe.ca.GetRootKey()), "GET")
-	wfe.HandleFunc(m, IntermediateCertPath, wfe.handleCert(wfe.ca.GetIntermediateCert()), "GET")
-	wfe.HandleFunc(m, IntermediateKeyPath, wfe.handleKey(wfe.ca.GetIntermediateKey()), "GET")
+	wfe.HandleFunc(m, intermediateCertPath, wfe.handleCert(wfe.ca.GetIntermediateCert()), "GET")
+	wfe.HandleFunc(m, intermediateKeyPath, wfe.handleKey(wfe.ca.GetIntermediateKey()), "GET")
 
 	// POST only handlers
 	wfe.HandleFunc(m, newAccountPath, wfe.NewAccount, "POST")

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -53,9 +53,9 @@ const (
 
 	// Theses entrypoints are not a part of the standard ACME endpoints,
 	// and are exposed by Pebble as an integration test tool. We export
-        // RootCertPath so that the pebble binary can reference it.
-        RootCertPath         = "/root"
-        rootKeyPath          = "/root-key"
+	// RootCertPath so that the pebble binary can reference it.
+	RootCertPath         = "/root"
+	rootKeyPath          = "/root-key"
 	intermediateCertPath = "/intermediate"
 	intermediateKeyPath  = "/intermediate-key"
 

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -57,7 +57,7 @@ const (
 	intermediateCertPath = "/intermediate"
 	rootKeyPath          = "/root-key"
         // We export RootCertPath so that the pebble binary can reference it
-        RootCertPath         = "/root"
+        RootCertPath = "/root"
 
 	// How long do pending authorizations last before expiring?
 	pendingAuthzExpire = time.Hour
@@ -283,8 +283,8 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	wfe.HandleFunc(m, DirectoryPath, wfe.Directory, "GET")
 	// Note for noncePath: "GET" also implies "HEAD"
 	wfe.HandleFunc(m, noncePath, wfe.Nonce, "GET")
-	wfe.HandleFunc(m, rootCertPath, wfe.handleCert(wfe.ca.GetRootCert()), "GET")
-	wfe.HandleFunc(m, RootKeyPath, wfe.handleKey(wfe.ca.GetRootKey()), "GET")
+	wfe.HandleFunc(m, RootCertPath, wfe.handleCert(wfe.ca.GetRootCert()), "GET")
+	wfe.HandleFunc(m, rootKeyPath, wfe.handleKey(wfe.ca.GetRootKey()), "GET")
 	wfe.HandleFunc(m, intermediateCertPath, wfe.handleCert(wfe.ca.GetIntermediateCert()), "GET")
 	wfe.HandleFunc(m, intermediateKeyPath, wfe.handleKey(wfe.ca.GetIntermediateKey()), "GET")
 


### PR DESCRIPTION
Since Pebble generates the issuer root and intermediate certificates on-the-fly at each startup, it can be useful for test purpose to get their current private key and certificate themselves.

The specific use case I have is a project of external OCSP mock server to run alongside with Pebble. 

The issuer root certificate is already exposed with `/root`, this PR adds the ad-hoc `/root-key`, `/intermediate` and `/intermediate-key` endpoints to dump them in PEM format. 