### PR TITLE
Bugfix for IP address support: uniqueIPs() result contains nil as first element(s)

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1994,7 +1994,7 @@ func uniqueIPs(IPs []net.IP) []net.IP {
 	for _, ip := range IPs {
 		uniqMap[ip.String()] = ip
 	}
-	results := make([]net.IP, len(uniqMap))
+	results := make([]net.IP, 0, len(uniqMap))
 	for _, v := range uniqMap {
 		results = append(results, v)
 	}


### PR DESCRIPTION
If `uniqueIPs()` is called with a non-empty list (of `n` IP addresses), the resulting list will be preceeded by `n` `nil` values. This leads to an error result: `{'type': 'urn:ietf:params:acme:error:malformed', 'detail': 'Order included malformed IP type identifier value: \"<nil>\"\\n', 'status': 400}`