### PR TITLE
Fix dns-01 validation, improve DNS error logging

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -304,7 +304,7 @@ func (va VAImpl) validateDNS01(task *vaTask) *core.ValidationRecord {
 
 	txts, err := net.DefaultResolver.LookupTXT(ctx, challengeSubdomain)
 	if err != nil {
-		result.Error = acme.UnauthorizedProblem("Error retrieving TXT records for DNS challenge")
+		result.Error = acme.UnauthorizedProblem(fmt.Sprintf("Error retrieving TXT records for DNS challenge (%q)", err))
 		return result
 	}
 

--- a/va/va.go
+++ b/va/va.go
@@ -292,7 +292,7 @@ func (va VAImpl) performValidation(task *vaTask, results chan<- *core.Validation
 
 func (va VAImpl) validateDNS01(task *vaTask) *core.ValidationRecord {
 	const dns01Prefix = "_acme-challenge"
-	challengeSubdomain := fmt.Sprintf("%s.%s", dns01Prefix, task.Identifier)
+	challengeSubdomain := fmt.Sprintf("%s.%s", dns01Prefix, task.Identifier.Value)
 
 	result := &core.ValidationRecord{
 		URL:         challengeSubdomain,


### PR DESCRIPTION
Fixes another bug in #221 which makes dns-01 validation no longer work. The problem is that to create `_acme-challenge.xxx`, `task.Identifier` was used for `xxx` instead of `task.Identifier.Value` (`task.Identifier` used to be a string, now it is a `Identifier` object).

This also improves DNS validation error logging a bit by including the DNS error message. This helped me finding this...