### PR TITLE
created IMemoryStore interface from existing methods.

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -26,7 +26,7 @@ const (
 
 type CAImpl struct {
 	log *log.Logger
-	db  *db.MemoryStore
+	db  db.IMemoryStore
 
 	root         *issuer
 	intermediate *issuer
@@ -106,6 +106,7 @@ func (ca *CAImpl) makeRootCert(
 	if signer != nil && signer.cert != nil {
 		newCert.Issuer = signer.cert
 	}
+
 	_, err = ca.db.AddCertificate(newCert)
 	if err != nil {
 		return nil, err
@@ -212,7 +213,7 @@ func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.Publ
 	return newCert, nil
 }
 
-func New(log *log.Logger, db *db.MemoryStore) *CAImpl {
+func New(log *log.Logger, db db.IMemoryStore) *CAImpl {
 	ca := &CAImpl{
 		log: log,
 		db:  db,

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -115,7 +115,7 @@ func (th *topHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 type WebFrontEndImpl struct {
 	log             *log.Logger
-	db              *db.MemoryStore
+	db              db.IMemoryStore
 	nonce           *nonceMap
 	nonceErrPercent int
 	va              *va.VAImpl
@@ -127,7 +127,7 @@ const ToSURL = "data:text/plain,Do%20what%20thou%20wilt"
 
 func New(
 	log *log.Logger,
-	db *db.MemoryStore,
+	db db.IMemoryStore,
 	va *va.VAImpl,
 	ca *ca.CAImpl,
 	strict bool) WebFrontEndImpl {


### PR DESCRIPTION
in order to use pebble as an in-process integration test suite, being able to
implement the memory store by hand or with mocks is very helpful. this
change only extracts existing methods and updates the methods which
relied on the original MemoryStore receiver.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>