### PR TITLE
Create a new parameter in configuration file to set the OCSP Responder URL in certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,3 +281,17 @@ purposes, since Pebble and its generated keys are not audited or held to the
 same standards as the Let's Encrypt production CA and their keys. Moreover
 these keys are exposed by Pebble and will be lost as soon as the process
 terminates: so they are not safe to use for anything other than testing.**
+
+### OCSP Responder URL
+
+Pebble does not support the OCSP protocol as a responder and so does not set
+the OCSP Responder URL in the issued certificates. However, if you setup a
+proper OCSP Responder piece of software side by side with Pebble, you may want
+to set this URL. This is possible by setting the environment variable
+`PEBBLE_CA_OCSP_RESPONDER_URL`: if this variable is set to a non-empty string,
+its value will be used in the appropriate field of all issued certificates.
+
+For instance, to instruct a client to check the URL `http://127.0.0.1:4002` and
+retrieve the OCSP status of a certificate, run:
+
+`PEBBLE_CA_OCSP_RESPONDER_URL=http://127.0.0.1:4002 pebble`

--- a/README.md
+++ b/README.md
@@ -287,11 +287,13 @@ terminates: so they are not safe to use for anything other than testing.**
 Pebble does not support the OCSP protocol as a responder and so does not set
 the OCSP Responder URL in the issued certificates. However, if you setup a
 proper OCSP Responder run side by side with Pebble, you may want to set this URL.
-This is possible by setting the environment variable `PEBBLE_CA_OCSP_RESPONDER_URL`:
-if this variable is set to a non-empty string, its value will be used in the
-appropriate field of all issued certificates.
+This is possible by setting the field `ocspResponderURL` of the `pebble-config.json`
+consummed by Pebble to a non empty string: in this case, this string will be use
+in the appropriate field of all issued certificates.
 
-For instance, to have Pebble issue certificates that instruct a client to check the URL `http://127.0.0.1:4002` to
-retrieve the OCSP status of a certificate, run:
+For instance, to have Pebble issue certificates that instruct a client to check the URL `http://127.0.0.1:4002`
+to retrieve the OCSP status of a certificate, run Pebble with a `pebble-config.json` that includes:
 
-`PEBBLE_CA_OCSP_RESPONDER_URL=http://127.0.0.1:4002 pebble`
+```
+  "ocspResponderURL": "http://127.0.0.1:4002",
+```

--- a/README.md
+++ b/README.md
@@ -286,10 +286,10 @@ terminates: so they are not safe to use for anything other than testing.**
 
 Pebble does not support the OCSP protocol as a responder and so does not set
 the OCSP Responder URL in the issued certificates. However, if you setup a
-proper OCSP Responder piece of software side by side with Pebble, you may want
-to set this URL. This is possible by setting the environment variable
-`PEBBLE_CA_OCSP_RESPONDER_URL`: if this variable is set to a non-empty string,
-its value will be used in the appropriate field of all issued certificates.
+proper OCSP Responder run side by side with Pebble, you may want to set this URL.
+This is possible by setting the environment variable `PEBBLE_CA_OCSP_RESPONDER_URL`:
+if this variable is set to a non-empty string, its value will be used in the
+appropriate field of all issued certificates.
 
 For instance, to instruct a client to check the URL `http://127.0.0.1:4002` and
 retrieve the OCSP status of a certificate, run:

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ This is possible by setting the environment variable `PEBBLE_CA_OCSP_RESPONDER_U
 if this variable is set to a non-empty string, its value will be used in the
 appropriate field of all issued certificates.
 
-For instance, to instruct a client to check the URL `http://127.0.0.1:4002` and
+For instance, to have Pebble issue certificates that instruct a client to check the URL `http://127.0.0.1:4002` to
 retrieve the OCSP status of a certificate, run:
 
 `PEBBLE_CA_OCSP_RESPONDER_URL=http://127.0.0.1:4002 pebble`

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -24,7 +24,7 @@ const (
 	rootCAPrefix         = "Pebble Root CA "
 	intermediateCAPrefix = "Pebble Intermediate CA "
 
-	// ocspResponderURL defines the URL to set in the 1.3.6.1.5.5.7.48.1 field
+	// ocspResponderURL defines the URL to set in the OCSPServer field
 	// of an issued certificate and so gives to a client the URL to contact to
 	// get the OCSP status of this certificate, e.g:
 	//	PEBBLE_CA_OCSP_RESPONDER_URL=http://127.0.0.1:4002 pebble

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -234,7 +234,7 @@ func New(log *log.Logger, db *db.MemoryStore) *CAImpl {
 	oscpRespURL := os.Getenv(ocspResponderURL)
 	if oscpRespURL != "" {
 		ca.ocspRespURL = oscpRespURL
-		ca.log.Printf("Setting OCSP responder URL for issued certificates to %s", ca.ocspRespURL)
+		ca.log.Printf("Setting OCSP responder URL for issued certificates to %q", ca.ocspRespURL)
 	}
 
 	err := ca.newRootIssuer()

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -38,10 +38,6 @@ func main() {
 		"dnsserver",
 		"",
 		"Define a custom DNS server address (ex: 192.168.0.56:5053 or 8.8.8.8:53).")
-	ocspResponder := flag.String(
-		"ocspresponder",
-		"",
-		"Define an OCSP responder URL to put in the 1.3.6.1.5.5.7.48.1 field of an issued certificate.")
 	flag.Parse()
 	if *configFile == "" {
 		flag.Usage()
@@ -61,7 +57,7 @@ func main() {
 	}
 
 	db := db.NewMemoryStore()
-	ca := ca.New(logger, db, *ocspResponder)
+	ca := ca.New(logger, db)
 	va := va.New(logger, c.Pebble.HTTPPort, c.Pebble.TLSPort, *strictMode)
 
 	wfeImpl := wfe.New(logger, db, va, ca, *strictMode)

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -17,11 +17,12 @@ import (
 
 type config struct {
 	Pebble struct {
-		ListenAddress string
-		HTTPPort      int
-		TLSPort       int
-		Certificate   string
-		PrivateKey    string
+		ListenAddress    string
+		HTTPPort         int
+		TLSPort          int
+		Certificate      string
+		PrivateKey       string
+		OCSPResponderURL string
 	}
 }
 
@@ -57,7 +58,7 @@ func main() {
 	}
 
 	db := db.NewMemoryStore()
-	ca := ca.New(logger, db)
+	ca := ca.New(logger, db, c.Pebble.OCSPResponderURL)
 	va := va.New(logger, c.Pebble.HTTPPort, c.Pebble.TLSPort, *strictMode)
 
 	wfeImpl := wfe.New(logger, db, va, ca, *strictMode)

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -38,6 +38,10 @@ func main() {
 		"dnsserver",
 		"",
 		"Define a custom DNS server address (ex: 192.168.0.56:5053 or 8.8.8.8:53).")
+	ocspResponder := flag.String(
+		"ocspresponder",
+		"",
+		"Define an OCSP responder URL to put in the 1.3.6.1.5.5.7.48.1 field of an issued certificate.")
 	flag.Parse()
 	if *configFile == "" {
 		flag.Usage()
@@ -57,7 +61,7 @@ func main() {
 	}
 
 	db := db.NewMemoryStore()
-	ca := ca.New(logger, db)
+	ca := ca.New(logger, db, *ocspResponder)
 	va := va.New(logger, c.Pebble.HTTPPort, c.Pebble.TLSPort, *strictMode)
 
 	wfeImpl := wfe.New(logger, db, va, ca, *strictMode)

--- a/test/config/pebble-config.json
+++ b/test/config/pebble-config.json
@@ -5,6 +5,6 @@
     "privateKey": "test/certs/localhost/key.pem",
     "httpPort": 5002,
     "tlsPort": 5001,
-    "ocspResponderURL": "test"
+    "ocspResponderURL": ""
   }
 }

--- a/test/config/pebble-config.json
+++ b/test/config/pebble-config.json
@@ -4,6 +4,7 @@
     "certificate": "test/certs/localhost/cert.pem",
     "privateKey": "test/certs/localhost/key.pem",
     "httpPort": 5002,
-    "tlsPort": 5001
+    "tlsPort": 5001,
+    "ocspResponderURL": "test"
   }
 }


### PR DESCRIPTION
Pebble is not designed to be an OCSP responder of the certificates it issues, since it is not its purpose. However, it is easy to setup a proper OCSP responder alongside it, thanks to the ability to get the intermediate CA certificate with `/intermediate` and `/intermediate-key` endpoints.

To make this interaction complete, and allow a client (like Certbot) to get a proper OCSP response status during tests, the certificates generated by Pebble need to contain an arbitrary OCSP Responder URL.

This PR allows that, by setting a `ocspResponderURL` configuration field. If set, then Pebble will add to the certificate template the given OCSP Responder URL, to be included in the certificates when they are generated. If not set (empty string), the template does not contain the OCSP field.

Typical example is:
`"ocspResponderURL": "http://127.0.0.1:4002 pebble"`

Instruction in README are updated with this new config variable.