### PR TITLE
WFE: reject legacy JWS requests in -strict

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1870,7 +1870,7 @@ func (wfe *WebFrontEndImpl) updateChallenge(
 
 	// In strict mode we reject any challenge POST with a body other than `{}`.
 	// This matches RFC 8555 Section 7.5.1.
-	if wfe.strict && bytes.Compare(postData.body, []byte("{}")) != 0 {
+	if wfe.strict && !bytes.Equal(postData.body, []byte("{}")) {
 		wfe.sendError(
 			acme.MalformedProblem(`challenge initiation POST JWS body was not "{}"`), response)
 		return

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1869,7 +1869,11 @@ func (wfe *WebFrontEndImpl) updateChallenge(
 	}
 
 	// In strict mode we reject any challenge POST with a body other than `{}`.
-	// This matches RFC 8555 Section 7.5.1.
+	// This matches RFC 8555 Section 7.5.1 and the ACME challenge types that
+	// Pebble has implemented. Per ACME errata 5729[0] it may not be true for
+	// extensions to ACME that add new challenge types.
+	//
+	// [0]: https://www.rfc-editor.org/errata/eid5729
 	if wfe.strict && !bytes.Equal(postData.body, []byte("{}")) {
 		wfe.sendError(
 			acme.MalformedProblem(`challenge initiation POST JWS body was not "{}"`), response)


### PR DESCRIPTION
## wfe: reject out-of-spec chall POST in strict.

Challenge POST JWS bodies should be exactly `{}` per [RFC 8555 Section 7.5.1](https://tools.ietf.org/html/rfc8555#section-7.5.1).

Running `pebble -strict` and using the `chisel2.py` client based on the Certbot `acme` module now results in the following Problem being returned on the first challenge initiation POST:
```
{
   "type": "urn:ietf:params:acme:error:malformed",
   "detail": "challenge initiation POST JWS body was not \"{}\"",
   "status": 400
}
```
See https://github.com/certbot/certbot/issues/7171

Resolves https://github.com/letsencrypt/pebble/issues/244

## wfe: reject JWS JSON with non-empty "resource".

The "resource" field of a JSON JWS body is a legacy artifact of ACME v1 and should not be sent in RFC 8555/ACME v2 requests.

Running `pebble -strict` and using the `chisel2.py` client based on the Certbot `acme` module now results in the following Problem being returned on the first POST request to `newAccount`:
```
{
   "type": "urn:ietf:params:acme:error:malformed",
   "detail": "JWS body included JSON with a deprecated ACME v1 \"resource\" field (\"new-reg\")",
   "status": 400
}
```
See https://github.com/certbot/certbot/issues/5708

Resolves https://github.com/letsencrypt/pebble/issues/245