### PR TITLE
Expose a management interface in Pebble

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ This interface is configured by the `managementListenAddress` field in
 interface will listen on. Set `managementListenAddress` to an empty string or `null`
 to disable it.
 
-The proposed configuration for this management interface as defined in
+The default configuration for this management interface as defined in
 `test/config/pebble-config.yml` is to listen on any address on port 15000:
 
 ```

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ repo](test/certs/pebble.minica.key.pem).**
 
 In order to ease the interaction of Pebble with testing systems, a specific HTTP
 management interface is exposed on a different port than the ACME protocol,
-and exposes several useful endpoints.
+and offers several useful testing endpoints.
 
 This interface is configured by the `managementListenAddress` field in
 `pebble-config.json` that defines the address and the port on which the management

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ The proposed configuration for this management interface as defined in
 #### CA Root and Intermediate Certificates
 
 Note that the CA's root and intermediate certificates are regenerated on every
-launch. It can be retrieved by a `GET` request to `https://localhost:15000/roots/0`
+launch. They can be retrieved by a `GET` request to `https://localhost:15000/roots/0`
 and `https://localhost:15000/intermediates/0` respectively.
 
 You might need the root certificate to verify the complete trust chain of

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ In order to ease the interaction of Pebble with testing systems, a specific HTTP
 management interface is exposed on a different port than the ACME protocol,
 and offers several useful testing endpoints.
 
-These endpoints are specific to Pebble and its internal behavior, but are not part
+These endpoints are specific to Pebble and its internal behavior, and are not part
 of the RFC 8555 that defines the ACME protocol.
 
 The management interface is configured by the `managementListenAddress` field in

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ docker-compose up
 ```
 
 Afterwards you can access the ACME API from your host machine at
-`https://localhost:14000/dir` and the `pebble-challtestsrv`'s management
+`https://localhost:14000/dir`, the ̀`pebble`'s management interface
+at `https://localhost:15000` and the `pebble-challtestsrv`'s management
 interface at `http://localhost:8055`.
 
 To get started you may want to update the `pebble-challtestsrv` mock DNS data
@@ -127,7 +128,8 @@ services:
   image: letsencrypt/pebble
   command: pebble -config /test/my-pebble-config.json
   ports:
-    - 14000:14000
+    - 14000:14000  # ACME port
+    - 15000:15000  # Management port
   environment:
     - PEBBLE_VA_NOSLEEP=1
   volumes:
@@ -262,17 +264,35 @@ store or to any production systems/codebases. The private key for this CA is
 intentionally made [publicly available in this
 repo](test/certs/pebble.minica.key.pem).**
 
-### CA Root and Intermediate Certificates
+### Management interface
+
+In order to ease the interaction of Pebble with test systems, a specific HTTP
+management interface is exposed on a different port than the ACME protocol,
+and exposes several useful endpoints.
+
+This interface is configured by the `managementListenAddress` field in
+`pebble-config.json` that defines the address and the port on which the management
+interface will listen on. Set `managementListenAddress` to an empty string or `null`
+to disable it.
+
+The proposed configuration for this management interface as defined in
+`test/config/pebble-config.yml` is to listen on any address on port 15000:
+
+```
+  "managementListenAddress": "0.0.0.0:15000",
+```
+
+#### CA Root and Intermediate Certificates
 
 Note that the CA's root and intermediate certificates are regenerated on every
-launch. It can be retrieved by a `GET` request to `https://localhost:14000/root`
-and `https://localhost:14000/intermediate` respectively.
+launch. It can be retrieved by a `GET` request to `https://localhost:15000/roots/0`
+and `https://localhost:15000/intermediates/0` respectively.
 
 You might need the root certificate to verify the complete trust chain of
 generated certificates, for example in end-to-end tests.
 
 The private keys of these certificates can also be retrieved by a `GET` request
-to `https://localhost:14000/root-key` and `https://localhost:14000/intermediate-key`
+to `https://localhost:15000/root-keys/0` and `https://localhost:15000/intermediate-keys/0`
 respectively.
 
 **IMPORTANT: Do not add Pebble's root or intermediate certificate to a trust
@@ -284,8 +304,8 @@ terminates: so they are not safe to use for anything other than testing.**
 
 In case alternative root chains are enabled by setting `PEBBLE_ALTERNATE_ROOTS` to a
 positive integer, the root certificates for these can be retrieved by doing a `GET`
-request to `https://localhost:14000/roots/0`, `https://localhost:14000/root-keys/1`
-`https://localhost:14000/intermediates/2`, `https://localhost:14000/intermediate-keys/3`
+request to `https://localhost:15000/roots/0`, `https://localhost:15000/root-keys/1`
+`https://localhost:15000/intermediates/2`, `https://localhost:15000/intermediate-keys/3`
 etc. These endpoints also send `Link` HTTP headers for all alternative root and
 intermediate certificates and keys.
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ repo](test/certs/pebble.minica.key.pem).**
 
 ### Management interface
 
-In order to ease the interaction of Pebble with test systems, a specific HTTP
+In order to ease the interaction of Pebble with testing systems, a specific HTTP
 management interface is exposed on a different port than the ACME protocol,
 and exposes several useful endpoints.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ docker-compose up
 ```
 
 Afterwards you can access the ACME API from your host machine at
-`https://localhost:14000/dir`, the ̀`pebble`'s management interface
+`https://localhost:14000/dir`, `pebble`'s management interface
 at `https://localhost:15000` and the `pebble-challtestsrv`'s management
 interface at `http://localhost:8055`.
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,10 @@ In order to ease the interaction of Pebble with testing systems, a specific HTTP
 management interface is exposed on a different port than the ACME protocol,
 and offers several useful testing endpoints.
 
-This interface is configured by the `managementListenAddress` field in
+These endpoints are specific to Pebble and its internal behavior, but are not part
+of the RFC 8555 that defines the ACME protocol.
+
+The management interface is configured by the `managementListenAddress` field in
 `pebble-config.json` that defines the address and the port on which the management
 interface will listen on. Set `managementListenAddress` to an empty string or `null`
 to disable it.

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -18,12 +18,13 @@ import (
 
 type config struct {
 	Pebble struct {
-		ListenAddress    string
-		HTTPPort         int
-		TLSPort          int
-		Certificate      string
-		PrivateKey       string
-		OCSPResponderURL string
+		ListenAddress           string
+		ManagementListenAddress string
+		HTTPPort                int
+		TLSPort                 int
+		Certificate             string
+		PrivateKey              string
+		OCSPResponderURL        string
 	}
 }
 
@@ -71,11 +72,26 @@ func main() {
 	wfeImpl := wfe.New(logger, db, va, ca, *strictMode)
 	muxHandler := wfeImpl.Handler()
 
+	if len(c.Pebble.ManagementListenAddress) > 0 {
+		go func() {
+			adminHandler := wfeImpl.ManagementHandler()
+			err = http.ListenAndServeTLS(
+				c.Pebble.ManagementListenAddress,
+				c.Pebble.Certificate,
+				c.Pebble.PrivateKey,
+				adminHandler)
+			cmd.FailOnError(err, "Calling ListenAndServeTLS() for admin interface")
+		}()
+		logger.Printf("Management interface listening on: %s\n", c.Pebble.ManagementListenAddress)
+		logger.Printf("Root CA certificate(s) available at: https://%s%s",
+			c.Pebble.ManagementListenAddress, wfe.RootCertPath)
+	} else {
+		logger.Printf("Management interface is disabled")
+	}
+
 	logger.Printf("Listening on: %s\n", c.Pebble.ListenAddress)
 	logger.Printf("ACME directory available at: https://%s%s",
 		c.Pebble.ListenAddress, wfe.DirectoryPath)
-	logger.Printf("Root CA certificate(s) available at: https://%s%s",
-		c.Pebble.ListenAddress, wfe.RootCertPath)
 	err = http.ListenAndServeTLS(
 		c.Pebble.ListenAddress,
 		c.Pebble.Certificate,

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -86,7 +86,7 @@ func main() {
 		logger.Printf("Root CA certificate(s) available at: https://%s%s",
 			c.Pebble.ManagementListenAddress, wfe.RootCertPath)
 	} else {
-		logger.Printf("Management interface is disabled")
+		logger.Print("Management interface is disabled")
 	}
 
 	logger.Printf("Listening on: %s\n", c.Pebble.ListenAddress)

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -72,7 +72,7 @@ func main() {
 	wfeImpl := wfe.New(logger, db, va, ca, *strictMode)
 	muxHandler := wfeImpl.Handler()
 
-	if c.Pebble.ManagementListenAddress == "" {
+	if c.Pebble.ManagementListenAddress != "" {
 		go func() {
 			adminHandler := wfeImpl.ManagementHandler()
 			err = http.ListenAndServeTLS(
@@ -83,8 +83,12 @@ func main() {
 			cmd.FailOnError(err, "Calling ListenAndServeTLS() for admin interface")
 		}()
 		logger.Printf("Management interface listening on: %s\n", c.Pebble.ManagementListenAddress)
-		logger.Printf("Root CA certificate(s) available at: https://%s%s",
+		logger.Printf("Root CA certificate available at: https://%s%s0",
 			c.Pebble.ManagementListenAddress, wfe.RootCertPath)
+		for i := 0; i < alternateRoots; i++ {
+			logger.Printf("Alternate (%d) root CA certificate available at: https://%s%s%d",
+				i+1, c.Pebble.ManagementListenAddress, wfe.RootCertPath, i+1)
+		}
 	} else {
 		logger.Print("Management interface is disabled")
 	}

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -72,7 +72,7 @@ func main() {
 	wfeImpl := wfe.New(logger, db, va, ca, *strictMode)
 	muxHandler := wfeImpl.Handler()
 
-	if len(c.Pebble.ManagementListenAddress) > 0 {
+	if c.Pebble.ManagementListenAddress == "" {
 		go func() {
 			adminHandler := wfeImpl.ManagementHandler()
 			err = http.ListenAndServeTLS(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     image: letsencrypt/pebble:v2.0.0
     command: pebble -config /test/config/pebble-config.json -strict -dnsserver 10.30.50.3:8053
     ports:
-      # HTTPS ACME API
-      - 14000:14000
+      - 14000:14000  # HTTPS ACME API
+      - 15000:15000  # HTTPS Management API
     networks:
       acmenet:
         ipv4_address: 10.30.50.2
@@ -13,8 +13,7 @@ services:
     image: letsencrypt/pebble-challtestsrv:v2.0.0
     command: pebble-challtestsrv -defaultIPv6 "" -defaultIPv4 10.30.50.3
     ports:
-      # HTTP Management Interface
-      - 8055:8055
+      - 8055:8055  # HTTP Management API
     networks:
       acmenet:
         ipv4_address: 10.30.50.3

--- a/test/config/pebble-config.json
+++ b/test/config/pebble-config.json
@@ -1,6 +1,7 @@
 {
   "pebble": {
     "listenAddress": "0.0.0.0:14000",
+    "managementListenAddress": "0.0.0.0:15000",
     "certificate": "test/certs/localhost/cert.pem",
     "privateKey": "test/certs/localhost/key.pem",
     "httpPort": 5002,

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -322,32 +322,12 @@ func (wfe *WebFrontEndImpl) handleKey(
 	}
 }
 
-func (wfe *WebFrontEndImpl) handleRedirect(
-	relPath string) func(
-	ctx context.Context,
-	response http.ResponseWriter,
-	request *http.Request) {
-	return func(ctx context.Context, response http.ResponseWriter, request *http.Request) {
-		response.Header().Set("Location", wfe.relativeEndpoint(request, relPath))
-		response.WriteHeader(http.StatusMovedPermanently)
-		_, _ = response.Write([]byte("Please update your URLs!\n"))
-	}
-}
-
 func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	m := http.NewServeMux()
 	// GET only handlers
 	wfe.HandleFunc(m, DirectoryPath, wfe.Directory, "GET")
 	// Note for noncePath: "GET" also implies "HEAD"
 	wfe.HandleFunc(m, noncePath, wfe.Nonce, "GET")
-	wfe.HandleFunc(m, RootCertPath, wfe.handleCert(wfe.ca.GetRootCert, RootCertPath), "GET")
-	wfe.HandleFunc(m, rootKeyPath, wfe.handleKey(wfe.ca.GetRootKey, rootKeyPath), "GET")
-	wfe.HandleFunc(m, intermediateCertPath, wfe.handleCert(wfe.ca.GetIntermediateCert, intermediateCertPath), "GET")
-	wfe.HandleFunc(m, intermediateKeyPath, wfe.handleKey(wfe.ca.GetIntermediateKey, intermediateKeyPath), "GET")
-	wfe.HandleFunc(m, "/root", wfe.handleRedirect(RootCertPath+"0"), "GET")
-	wfe.HandleFunc(m, "/root-key", wfe.handleRedirect(rootKeyPath+"0"), "GET")
-	wfe.HandleFunc(m, "/intermediate", wfe.handleRedirect(intermediateCertPath+"0"), "GET")
-	wfe.HandleFunc(m, "/intermediate-key", wfe.handleRedirect(intermediateKeyPath+"0"), "GET")
 
 	// POST only handlers
 	wfe.HandleFunc(m, newAccountPath, wfe.NewAccount, "POST")
@@ -360,6 +340,17 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	wfe.HandleFunc(m, orderPath, wfe.Order, "POST")
 	wfe.HandleFunc(m, authzPath, wfe.Authz, "POST")
 	wfe.HandleFunc(m, challengePath, wfe.Challenge, "POST")
+
+	return m
+}
+
+func (wfe *WebFrontEndImpl) ManagementHandler() http.Handler {
+	m := http.NewServeMux()
+	// GET only handlers
+	wfe.HandleFunc(m, RootCertPath, wfe.handleCert(wfe.ca.GetRootCert, RootCertPath), "GET")
+	wfe.HandleFunc(m, rootKeyPath, wfe.handleKey(wfe.ca.GetRootKey, rootKeyPath), "GET")
+	wfe.HandleFunc(m, intermediateCertPath, wfe.handleCert(wfe.ca.GetIntermediateCert, intermediateCertPath), "GET")
+	wfe.HandleFunc(m, intermediateKeyPath, wfe.handleKey(wfe.ca.GetIntermediateKey, intermediateKeyPath), "GET")
 
 	return m
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -344,6 +344,8 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 	return m
 }
 
+// ManagementHandler handles the endpoints exposed on the management interface that is configured
+// by the `managementListenAddress` parameter in Pebble JSON config file.
 func (wfe *WebFrontEndImpl) ManagementHandler() http.Handler {
 	m := http.NewServeMux()
 	// GET only handlers

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -351,7 +351,6 @@ func (wfe *WebFrontEndImpl) ManagementHandler() http.Handler {
 	wfe.HandleFunc(m, rootKeyPath, wfe.handleKey(wfe.ca.GetRootKey, rootKeyPath), "GET")
 	wfe.HandleFunc(m, intermediateCertPath, wfe.handleCert(wfe.ca.GetIntermediateCert, intermediateCertPath), "GET")
 	wfe.HandleFunc(m, intermediateKeyPath, wfe.handleKey(wfe.ca.GetIntermediateKey, intermediateKeyPath), "GET")
-
 	return m
 }
 


### PR DESCRIPTION
Fixes https://github.com/letsencrypt/pebble/issues/74

This PR adds a management interface, that listens to a specific address and port as defined by the field `managementListenAddress` in the Pebble JSON configuration file, and serves endpoints unrelated to the ACME protocol, but useful to interface Pebble in a testing environment. This interface is reached through HTTPS and is secured using the same certificate than the ACME interface.

I moved on this interface the endpoints related to dump the internal certificates/keys used by the CA in Pebble. I disabled the redirections done from `/intermediate` to `/intermediates/0` (and equivalent for the other endpoints) because I think it adds unnessarily some complexity, and most of these endpoints have been added in the latest release by me, and I do not consumes them yet. However if you disagree with this approach for `/root`, since it was there before, I can make a specific redirection from `/root` on the ACME port to `/roots/0` on the management port. 

Not setting `managementListenAddress` disables the management interface.

`README.md` and docker compose files are updated accordingly. 