### PR TITLE
Unknown identifier type in order causes two problems to be returned

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1356,6 +1356,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 		default:
 			wfe.sendError(acme.MalformedProblem(
 				fmt.Sprintf("Order includes unknown identifier type %s", ident.Type)), response)
+			return
 		}
 	}
 	orderDNSs = uniqueLowerNames(orderDNSs)
@@ -1609,6 +1610,7 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(
 		default:
 			wfe.sendError(acme.MalformedProblem(
 				fmt.Sprintf("Order includes unknown identifier type %s", ident.Type)), response)
+			return
 		}
 	}
 	// looks like saving order to db doesn't preserve order of Identifiers, so sort them again.


### PR DESCRIPTION
For example, sending this identifier:

```json
{
   "type": "bad",
   "value": "example.com"
}
```

Results in two malformed problems being returned, which will cause simple json parsing problems having two root objects, eg:

```json
{
   "type": "urn:ietf:params:acme:error:malformed",
   "detail": "Order includes unknown identifier type bad",
   "status": 400
}{
   "type": "urn:ietf:params:acme:error:malformed",
   "detail": "Order did not specify any identifiers",
   "status": 400
}
```