### PR TITLE
Management interface: add /cert-status-by-serial/ endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ intermediate certificates and keys.
 
 The certificate (in PEM format) and its revocation status can be queried by doing
 a `GET` request to `https://localhost:15000/cert-status-by-serial/<serial>`, where
-`<serial>` is the hexadecimal representation of the certificate's serial number.
+`<serial>` is the hexadecimal representation of the certificate's serial number (no `0x` prefix).
 It can be obtained via:
 
     openssl x509 -in cert.pem -noout -serial | cut -d= -f2

--- a/README.md
+++ b/README.md
@@ -312,6 +312,17 @@ request to `https://localhost:15000/roots/0`, `https://localhost:15000/root-keys
 etc. These endpoints also send `Link` HTTP headers for all alternative root and
 intermediate certificates and keys.
 
+#### Certificate Status
+
+The certificate (in PEM format) and its revocation status can be queried by doing
+a `GET` request to `https://localhost:15000/cert-status-by-serial/<serial>`, where
+`<serial>` is the hexadecimal representation of the certificate's serial number.
+It can be obtained via:
+
+    openssl x509 -in cert.pem -noout -text | sed -En 's/.*Serial Number.*\(0x([0-9a-f]+)\)/\1/p'
+
+The endpoint returns the information as a JSON.
+
 ### OCSP Responder URL
 
 Pebble does not support the OCSP protocol as a responder and so does not set

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ intermediate certificates and keys.
 
 #### Certificate Status
 
-The certificate (in PEM format) and its revocation status can be queried by doing
+The certificate (in PEM format) and its revocation status can be queried by sending
 a `GET` request to `https://localhost:15000/cert-status-by-serial/<serial>`, where
 `<serial>` is the hexadecimal representation of the certificate's serial number (no `0x` prefix).
 It can be obtained via:

--- a/README.md
+++ b/README.md
@@ -319,9 +319,26 @@ a `GET` request to `https://localhost:15000/cert-status-by-serial/<serial>`, whe
 `<serial>` is the hexadecimal representation of the certificate's serial number.
 It can be obtained via:
 
-    openssl x509 -in cert.pem -noout -text | sed -En 's/.*Serial Number.*\(0x([0-9a-f]+)\)/\1/p'
+    openssl x509 -in cert.pem -noout -serial | cut -d= -f2
 
-The endpoint returns the information as a JSON.
+The endpoint returns the information as a JSON:
+
+    $ curl -ki https://127.0.0.1:15000/cert-status-by-serial/66317d2e02f5d3d6
+    HTTP/2 200
+    cache-control: public, max-age=0, no-cache
+    content-type: application/json; charset=utf-8
+    link: <https://127.0.0.1:15000/dir>;rel="index"
+    content-length: 1740
+    date: Fri, 12 Jul 2019 22:14:21 GMT
+
+    {
+       "Certificate": "-----BEGIN CERTIFICATE-----\nMIIEVz...tcw=\n-----END CERTIFICATE-----\n",
+       "Reason": 4,
+       "RevokedAt": "2019-07-13T00:13:20.418489956+02:00",
+       "Serial": "66317d2e02f5d3d6",
+       "Status": "Revoked"
+    }
+
 
 ### OCSP Responder URL
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ It can be obtained via:
 
     openssl x509 -in cert.pem -noout -serial | cut -d= -f2
 
-The endpoint returns the information as a JSON:
+The endpoint returns the information as a JSON object:
 
     $ curl -ki https://127.0.0.1:15000/cert-status-by-serial/66317d2e02f5d3d6
     HTTP/2 200

--- a/core/types.go
+++ b/core/types.go
@@ -192,6 +192,7 @@ func (c Certificate) Chain(no int) []byte {
 	return bytes.Join(chain, nil)
 }
 
+// RevokedCertificate is a certificate together with information about its revocation.
 type RevokedCertificate struct {
 	Certificate *Certificate
 	RevokedAt   time.Time

--- a/core/types.go
+++ b/core/types.go
@@ -192,6 +192,12 @@ func (c Certificate) Chain(no int) []byte {
 	return bytes.Join(chain, nil)
 }
 
+type RevokedCertificate struct {
+	Certificate *Certificate
+	RevokedAt   time.Time
+	Reason      *uint
+}
+
 type ValidationRecord struct {
 	URL         string
 	Error       *acme.ProblemDetails

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"reflect"
 	"strconv"
 	"sync"
@@ -321,4 +322,33 @@ func keyToID(key crypto.PublicKey) (string, error) {
 		spkiDigest := sha256.Sum256(keyDER)
 		return hex.EncodeToString(spkiDigest[:]), nil
 	}
+}
+
+// GetCertificateBySerial loops over all certificates to find the one that matches the provided
+// serial number. This method is linear and it's not optimized to give you a quick response.
+func (m *MemoryStore) GetCertificateBySerial(serialNumber *big.Int) *core.Certificate {
+	m.RLock()
+	defer m.RUnlock()
+	for _, c := range m.certificatesByID {
+		if serialNumber.Cmp(c.Cert.SerialNumber) == 0 {
+			return c
+		}
+	}
+
+	return nil
+}
+
+// GetCertificateBySerial loops over all revoked certificates to find the one that matches the
+// provided serial number. This method is linear and it's not optimized to give you a quick
+// response.
+func (m *MemoryStore) GetRevokedCertificateBySerial(serialNumber *big.Int) *core.Certificate {
+	m.RLock()
+	defer m.RUnlock()
+	for _, c := range m.revokedCertificatesByID {
+		if serialNumber.Cmp(c.Cert.SerialNumber) == 0 {
+			return c
+		}
+	}
+
+	return nil
 }

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -47,7 +47,7 @@ type MemoryStore struct {
 	challengesByID map[string]*core.Challenge
 
 	certificatesByID        map[string]*core.Certificate
-	revokedCertificatesByID map[string]*core.Certificate
+	revokedCertificatesByID map[string]*core.RevokedCertificate
 }
 
 func NewMemoryStore() *MemoryStore {
@@ -59,7 +59,7 @@ func NewMemoryStore() *MemoryStore {
 		authorizationsByID:      make(map[string]*core.Authorization),
 		challengesByID:          make(map[string]*core.Challenge),
 		certificatesByID:        make(map[string]*core.Certificate),
-		revokedCertificatesByID: make(map[string]*core.Certificate),
+		revokedCertificatesByID: make(map[string]*core.RevokedCertificate),
 	}
 }
 
@@ -281,11 +281,11 @@ func (m *MemoryStore) GetCertificateByDER(der []byte) *core.Certificate {
 
 // GetCertificateByDER loops over all revoked certificates to find the one that matches the provided
 // DER bytes. This method is linear and it's not optimized to give you a quick response.
-func (m *MemoryStore) GetRevokedCertificateByDER(der []byte) *core.Certificate {
+func (m *MemoryStore) GetRevokedCertificateByDER(der []byte) *core.RevokedCertificate {
 	m.RLock()
 	defer m.RUnlock()
 	for _, c := range m.revokedCertificatesByID {
-		if reflect.DeepEqual(c.DER, der) {
+		if reflect.DeepEqual(c.Certificate.DER, der) {
 			return c
 		}
 	}
@@ -293,11 +293,11 @@ func (m *MemoryStore) GetRevokedCertificateByDER(der []byte) *core.Certificate {
 	return nil
 }
 
-func (m *MemoryStore) RevokeCertificate(cert *core.Certificate) {
+func (m *MemoryStore) RevokeCertificate(cert *core.RevokedCertificate) {
 	m.Lock()
 	defer m.Unlock()
-	m.revokedCertificatesByID[cert.ID] = cert
-	delete(m.certificatesByID, cert.ID)
+	m.revokedCertificatesByID[cert.Certificate.ID] = cert
+	delete(m.certificatesByID, cert.Certificate.ID)
 }
 
 /*
@@ -341,11 +341,11 @@ func (m *MemoryStore) GetCertificateBySerial(serialNumber *big.Int) *core.Certif
 // GetCertificateBySerial loops over all revoked certificates to find the one that matches the
 // provided serial number. This method is linear and it's not optimized to give you a quick
 // response.
-func (m *MemoryStore) GetRevokedCertificateBySerial(serialNumber *big.Int) *core.Certificate {
+func (m *MemoryStore) GetRevokedCertificateBySerial(serialNumber *big.Int) *core.RevokedCertificate {
 	m.RLock()
 	defer m.RUnlock()
 	for _, c := range m.revokedCertificatesByID {
-		if serialNumber.Cmp(c.Cert.SerialNumber) == 0 {
+		if serialNumber.Cmp(c.Certificate.Cert.SerialNumber) == 0 {
 			return c
 		}
 	}

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -338,7 +338,7 @@ func (m *MemoryStore) GetCertificateBySerial(serialNumber *big.Int) *core.Certif
 	return nil
 }
 
-// GetCertificateBySerial loops over all revoked certificates to find the one that matches the
+// GetRevokedCertificateBySerial loops over all revoked certificates to find the one that matches the
 // provided serial number. This method is linear and it's not optimized to give you a quick
 // response.
 func (m *MemoryStore) GetRevokedCertificateBySerial(serialNumber *big.Int) *core.RevokedCertificate {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -357,15 +357,22 @@ func (wfe *WebFrontEndImpl) handleCertStatusBySerial(
 		response.WriteHeader(http.StatusNotFound)
 		return
 	}
-	result := make(map[string]interface{})
-	result["Status"] = status
-	result["Serial"] = serial.Text(16)
-	result["Certificate"] = string(cert.PEM())
+	result := struct {
+		Status      string
+		Serial      string
+		Certificate string
+		Reason      *uint  `json:",omitempty"`
+		RevokedAt   string `json:",omitempty"`
+	}{
+		Status:      status,
+		Serial:      serial.Text(16),
+		Certificate: string(cert.PEM()),
+	}
 	if rcert != nil {
 		if rcert.Reason != nil {
-			result["Reason"] = rcert.Reason
+			result.Reason = rcert.Reason
 		}
-		result["RevokedAt"] = rcert.RevokedAt.UTC()
+		result.RevokedAt = rcert.RevokedAt.UTC().String()
 	}
 
 	resultJSON, err := marshalIndent(result)

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -346,12 +346,11 @@ func (wfe *WebFrontEndImpl) handleCertStatusBySerial(
 	var status string
 	var cert *core.Certificate
 	var rcert *core.RevokedCertificate
-	if cert = wfe.db.GetCertificateBySerial(serial); cert != nil {
-		status = "Valid"
-	}
 	if rcert = wfe.db.GetRevokedCertificateBySerial(serial); rcert != nil {
 		status = "Revoked"
 		cert = rcert.Certificate
+	} else if cert = wfe.db.GetCertificateBySerial(serial); cert != nil {
+		status = "Valid"
 	}
 
 	if status == "" {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -375,14 +375,11 @@ func (wfe *WebFrontEndImpl) handleCertStatusBySerial(
 		result.RevokedAt = rcert.RevokedAt.UTC().String()
 	}
 
-	resultJSON, err := marshalIndent(result)
+	err := wfe.writeJSONResponse(response, http.StatusOK, result)
 	if err != nil {
 		response.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	response.Header().Set("Content-Type", "application/json; charset=utf-8")
-	response.WriteHeader(http.StatusOK)
-	_, _ = response.Write(resultJSON)
 }
 
 func (wfe *WebFrontEndImpl) Handler() http.Handler {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -339,7 +339,7 @@ func (wfe *WebFrontEndImpl) handleCertStatusBySerial(
 	serialStr := strings.TrimPrefix(request.URL.Path, certStatusBySerial)
 	serial := big.NewInt(0)
 	if _, ok := serial.SetString(serialStr, 16); !ok {
-		response.WriteHeader(http.StatusNotFound)
+		response.WriteHeader(http.StatusBadRequest)
 		return
 	}
 

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -353,7 +353,7 @@ func (wfe *WebFrontEndImpl) handleCertStatusBySerial(
 		status = "Valid"
 	}
 
-	if status == "" {
+	if status == "" || cert == nil {
 		response.WriteHeader(http.StatusNotFound)
 		return
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -366,7 +366,7 @@ func (wfe *WebFrontEndImpl) handleCertStatusBySerial(
 		if rcert.Reason != nil {
 			result["Reason"] = rcert.Reason
 		}
-		result["RevokedAt"] = rcert.RevokedAt
+		result["RevokedAt"] = rcert.RevokedAt.UTC()
 	}
 
 	resultJSON, err := marshalIndent(result)


### PR DESCRIPTION
This adds a `/cert-status-by-serial/` endpoint to the management interface. The certificate is identified by its serial number (in hexadecimal). (It can be extracted with OpenSSL via `openssl x509 -in cert.pem -noout -text | sed -En 's/.*Serial Number.*\(0x([0-9a-f]+)\)/\1/p'`.) The endpoint returns the certificate itself (in PEM format), the serial (hexadecimal) and the revocation status (`Valid` or `Revoked`) as JSON.

Example usage:
```
$ curl -ki https://127.0.0.1:15000/cert-status-by-serial/5ab954d39632fd78
HTTP/2 200 
cache-control: public, max-age=0, no-cache
content-type: application/json; charset=utf-8
link: <https://127.0.0.1:15000/dir>;rel="index"
content-length: 1671
date: Fri, 12 Jul 2019 21:39:24 GMT

{
   "Certificate": "-----BEGIN CERTIFICATE-----\nMIIEVz...tcw=\n-----END CERTIFICATE-----\n",
   "Serial": "5ab954d39632fd78",
   "Status": "Valid"
}

$ curl -ki https://127.0.0.1:15000/cert-status-by-serial/7811e0b42b98cc1c
HTTP/2 200 
cache-control: public, max-age=0, no-cache
content-type: application/json; charset=utf-8
link: <https://127.0.0.1:15000/dir>;rel="index"
content-length: 1728
date: Fri, 12 Jul 2019 22:14:17 GMT

{
   "Certificate": "-----BEGIN CERTIFICATE-----\nMIIEVz...tcw=\n-----END CERTIFICATE-----\n",
   "RevokedAt": "2019-07-13T00:14:13.719654003+02:00",
   "Serial": "7811e0b42b98cc1c",
   "Status": "Revoked"
}

$ curl -ki https://127.0.0.1:15000/cert-status-by-serial/66317d2e02f5d3d6
HTTP/2 200 
cache-control: public, max-age=0, no-cache
content-type: application/json; charset=utf-8
link: <https://127.0.0.1:15000/dir>;rel="index"
content-length: 1740
date: Fri, 12 Jul 2019 22:14:21 GMT

{
   "Certificate": "-----BEGIN CERTIFICATE-----\nMIIEVz...tcw=\n-----END CERTIFICATE-----\n",
   "Reason": 4,
   "RevokedAt": "2019-07-13T00:13:20.418489956+02:00",
   "Serial": "66317d2e02f5d3d6",
   "Status": "Revoked"
}
```

CC @adferrand 