### PR TITLE
Remove `Link` headers for management interface

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -224,7 +224,7 @@ func (wfe *WebFrontEndImpl) HandleFunc(
 func (wfe *WebFrontEndImpl) HandleManagementFunc(
 	mux *http.ServeMux,
 	pattern string,
-	handler wfeHandlerFunc) {
+	handler wfeHandlerFunc) { // nolint:interfacer
 	mux.Handle(pattern, http.StripPrefix(pattern, handler))
 }
 

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -221,6 +221,47 @@ func (wfe *WebFrontEndImpl) HandleFunc(
 	mux.Handle(pattern, defaultHandler)
 }
 
+func (wfe *WebFrontEndImpl) HandleManagementFunc(
+	mux *http.ServeMux,
+	pattern string,
+	handler wfeHandlerFunc,
+	methods ...string) {
+
+	methodsMap := make(map[string]bool)
+	for _, m := range methods {
+		methodsMap[m] = true
+	}
+
+	if methodsMap["GET"] && !methodsMap["HEAD"] {
+		// Allow HEAD for any resource that allows GET
+		methods = append(methods, "HEAD")
+		methodsMap["HEAD"] = true
+	}
+
+	methodsStr := strings.Join(methods, ", ")
+	defaultHandler := http.StripPrefix(pattern,
+		&topHandler{
+			wfe: wfeHandlerFunc(func(ctx context.Context, response http.ResponseWriter, request *http.Request) {
+				addNoCacheHeader(response)
+
+				if !methodsMap[request.Method] {
+					response.Header().Set("Allow", methodsStr)
+					wfe.sendError(acme.MethodNotAllowed(), response)
+					return
+				}
+
+				wfe.log.Printf("%s %s (management) -> calling handler()\n", request.Method, pattern)
+
+				// TODO(@cpu): Configurable request timeout
+				timeout := 1 * time.Minute
+				ctx, cancel := context.WithTimeout(ctx, timeout)
+				handler(ctx, response, request)
+				cancel()
+			},
+			)})
+	mux.Handle(pattern, defaultHandler)
+}
+
 func (wfe *WebFrontEndImpl) sendError(prob *acme.ProblemDetails, response http.ResponseWriter) {
 	problemDoc, err := marshalIndent(prob)
 	if err != nil {
@@ -349,10 +390,10 @@ func (wfe *WebFrontEndImpl) Handler() http.Handler {
 func (wfe *WebFrontEndImpl) ManagementHandler() http.Handler {
 	m := http.NewServeMux()
 	// GET only handlers
-	wfe.HandleFunc(m, RootCertPath, wfe.handleCert(wfe.ca.GetRootCert, RootCertPath), "GET")
-	wfe.HandleFunc(m, rootKeyPath, wfe.handleKey(wfe.ca.GetRootKey, rootKeyPath), "GET")
-	wfe.HandleFunc(m, intermediateCertPath, wfe.handleCert(wfe.ca.GetIntermediateCert, intermediateCertPath), "GET")
-	wfe.HandleFunc(m, intermediateKeyPath, wfe.handleKey(wfe.ca.GetIntermediateKey, intermediateKeyPath), "GET")
+	wfe.HandleManagementFunc(m, RootCertPath, wfe.handleCert(wfe.ca.GetRootCert, RootCertPath), "GET")
+	wfe.HandleManagementFunc(m, rootKeyPath, wfe.handleKey(wfe.ca.GetRootKey, rootKeyPath), "GET")
+	wfe.HandleManagementFunc(m, intermediateCertPath, wfe.handleCert(wfe.ca.GetIntermediateCert, intermediateCertPath), "GET")
+	wfe.HandleManagementFunc(m, intermediateKeyPath, wfe.handleKey(wfe.ca.GetIntermediateKey, intermediateKeyPath), "GET")
 	return m
 }
 


### PR DESCRIPTION
Fixes #253.

I'm not sure that this is the best implementation. Another way would be to add a boolean argument (I don't think this is good, though), or to have a more generic function which is used by `HandleFunc` and `HandleManagementFunc`.

Any opinions on this?