### PR TITLE
Fix custom resolver implementation for Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/letsencrypt/pebble
 
 require (
 	github.com/letsencrypt/challtestsrv v1.1.0
+	github.com/miekg/dns v1.1.15
 	golang.org/x/net v0.0.0-20181207154023-610586996380 // indirect
 	golang.org/x/sys v0.0.0-20181206074257-70b957f3b65e // indirect
 	gopkg.in/square/go-jose.v2 v2.1.9

--- a/va/va.go
+++ b/va/va.go
@@ -593,7 +593,7 @@ func (va VAImpl) getTXTEntry(name string) ([]string, error) {
 	return txts, nil
 }
 
-// resolveIP find all associated IPs to the given domain name using the recursive resolver located at
+// resolveIP find all IPs for the given domain name using the recursive resolver located at
 // `va.customResolverAddr`, or the default system resolver if no custom resolver addr is specified
 func (va VAImpl) resolveIP(name string) ([]string, error) {
 	ctx, cancelfunc := context.WithTimeout(context.Background(), validationTimeout)

--- a/va/va.go
+++ b/va/va.go
@@ -104,7 +104,7 @@ type VAImpl struct {
 	alwaysValid        bool
 	strict             bool
 	customResolverAddr string
-	dnsClient 		   *dns.Client
+	dnsClient          *dns.Client
 }
 
 func New(

--- a/va/va.go
+++ b/va/va.go
@@ -503,7 +503,7 @@ func (va VAImpl) fetchHTTP(identifier string, token string) ([]byte, string, *ac
 
 	if err != nil {
 		return nil, url.String(), acme.MalformedProblem(
-			fmt.Sprintf("Error occured while resolving URL %q: %q", url.String(), err))
+			fmt.Sprintf("Error occurred while resolving URL %q: %q", url.String(), err))
 	}
 
 	if len(addrs) == 0 {

--- a/va/va.go
+++ b/va/va.go
@@ -127,8 +127,6 @@ func New(
 		va.log.Print("Using system DNS resolver for ACME challenges")
 	}
 
-	va.log.Print(va.resolveIP("8.8.8.8"))
-
 	// Read the PEBBLE_VA_NOSLEEP environment variable string
 	noSleep := os.Getenv(noSleepEnvVar)
 	// If it is set to something true-like, then the VA shouldn't sleep

--- a/va/va.go
+++ b/va/va.go
@@ -602,30 +602,30 @@ func (va VAImpl) resolveIP(name string) ([]string, error) {
 		return addrs, nil
 	}
 
-	messageA := new(dns.Msg)
-	messageA.SetQuestion(dns.Fqdn(name), dns.TypeA)
-	inA, _, errA := va.dnsClient.ExchangeContext(ctx, messageA, va.customResolverAddr)
 	messageAAAA := new(dns.Msg)
 	messageAAAA.SetQuestion(dns.Fqdn(name), dns.TypeAAAA)
 	inAAAA, _, errAAAA := va.dnsClient.ExchangeContext(ctx, messageAAAA, va.customResolverAddr)
-
-	if errA != nil {
-		return addrs, errA
-	}
+	messageA := new(dns.Msg)
+	messageA.SetQuestion(dns.Fqdn(name), dns.TypeA)
+	inA, _, errA := va.dnsClient.ExchangeContext(ctx, messageA, va.customResolverAddr)
 
 	if errAAAA != nil {
 		return addrs, errAAAA
 	}
 
-	for _, record := range inA.Answer {
-		if t, ok := record.(*dns.A); ok {
-			addrs = append(addrs, t.A.String())
-		}
+	if errA != nil {
+		return addrs, errA
 	}
 
 	for _, record := range inAAAA.Answer {
 		if t, ok := record.(*dns.AAAA); ok {
 			addrs = append(addrs, t.AAAA.String())
+		}
+	}
+
+	for _, record := range inA.Answer {
+		if t, ok := record.(*dns.A); ok {
+			addrs = append(addrs, t.A.String())
 		}
 	}
 


### PR DESCRIPTION
Pebble accepts a `--dnsserver` flag, that allows to select a custom DNS resolver to use when validating the ACME challenges. This option is critical to make the certbot integration tests work in particular.

Current implementation is to set the `net.DefaultResolver` on a new `net.Resolver` instance with a custom `Dial` property to consume the value from `--dnsserver`. This allows to transparently resolve any host using this custom DNS resolver from a pure-Go implementation of the DNS resolution API.

Sadly this approach does not work on Windows, and the `--dnsserver` has no effect on how resolution is done, and it is always the OS mechanism that is used.

One can reveal this behavior by running the following piece of code on Linux and on Windows:
```go
// test.go
package main

import (
	"context"
	"fmt"
	"net"
)

func main() {
	resolver := &net.Resolver{
		PreferGo: true,
		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
			d := net.Dialer{}
			return d.DialContext(ctx, "udp", "4.3.2.1:404")
		},
	}
	net.DefaultResolver = resolver
	ctx, cancelfunc := context.WithTimeout(context.Background(), 30)
	defer cancelfunc()
	_, err := resolver.LookupTXT(ctx, "stupid.entry.net")

	fmt.Printf("Error is: %s\n", err)
}
```

This piece of code tries to resolve a non-existent domain on a non-existent DNS server as IP `4.3.2.1:404`.

On Linux, you will get the following error:
```bash
Error is: lookup stupid.entry.net on 127.0.0.53:53: dial udp 4.3.2.1:404: i/o timeout
```

That indicates that the system tried to reach the non-existent DNS server, and get back a timeout exception on it.

However on Windows you will get:
```bash
Error is: lookup stupid.entry.net: dnsquery: DNS name does not exist.
```

This indicates that the system ignored the dummy DNS server address, contacted the OS DNS resolver, that responded that the DNS name does not exist.

One can see also the reason for this behavior on Windows on the `net` godoc, https://godoc.org/net, in particular this line in the module introduction:
```
On Windows, the resolver always uses C library functions, such as GetAddrInfo and DnsQuery.
```

In fact, the pure Go DNS resolver is not applicable on Windows, the OS DNS resolver will be used, ignoring any customization.

Several relevant discussions, in particular a proposal (not developed yet) to make the pure Go DNS resolver available on Windows:
* https://github.com/golang/go/issues/29621
* https://github.com/golang/go/issues/33097
* https://github.com/golang/go/issues/33086

To fix this, this PR makes Pebble switch to a different logic:
* if `-dnsserver` is not set, use the default API to resolve the names
* if `-dnsserver` is set, use a dedicated DNS client, to avoid to use the OS one both on Linux and Windows

The DNS client is https://github.com/miekg/dns, a highly used and supported DNS library.

With these modifications, integrations tests on Certbot are running correctly both on Linux and Windows.
