### PR TITLE
wfe: don't render account contact when empty

### DIFF
--- a/acme/common.go
+++ b/acme/common.go
@@ -31,7 +31,7 @@ type Identifier struct {
 
 type Account struct {
 	Status  string   `json:"status"`
-	Contact []string `json:"contact"`
+	Contact []string `json:"contact,omitempty"`
 	Orders  string   `json:"orders,omitempty"`
 }
 


### PR DESCRIPTION
From https://tools.ietf.org/html/rfc8555#section-7.1.2:

  (optional, array of string)

This commit fixes Pebble rendering "contact: null" in WFE
responses.

Ref #256 