### PR TITLE
wfe: always render authz challenges as an array

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1690,7 +1690,7 @@ func prepAuthorizationForDisplay(authz *core.Authorization) acme.Authorization {
 
 	// Build a list of plain acme.Challenges to display using the core.Challenge
 	// objects from the authorization.
-	var chals []acme.Challenge
+	chals := make([]acme.Challenge, 0)
 	for _, c := range authz.Challenges {
 		c.RLock()
 		// If the authz isn't pending then we need to filter the challenges displayed


### PR DESCRIPTION
From https://tools.ietf.org/html/rfc8555#section-7.1.4

  (required, array of objects)

This commit fixes the case where Pebble renders "challenge: null"
when e.g. the authorization has been deactivated.

Ref #256 