### PR TITLE
Implement reuse of valid authorizations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,9 @@ ACME servers may choose to reuse valid authorizations from previous orders in ne
 
 **Pebble will reuse valid authorizations in new orders, if they exist, 50% of the time**.
 
-The percentage may be controlled with the environment variable `PEBBLE_WFE_AUTHZREUSE`, e.g. to always reuse authorizations:
+The percentage may be controlled with the environment variable `PEBBLE_AUTHZREUSE`, e.g. to always reuse authorizations:
 
-`PEBBLE_WFE_AUTHZREUSE=100 pebble`
+`PEBBLE_AUTHZREUSE=100 pebble`
 
 ### Avoiding Client HTTPS Errors
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,16 @@ To **never** reject a valid nonce as invalid run:
 
 `PEBBLE_WFE_NONCEREJECT=0 pebble`
 
+### Authorization Reuse
+
+ACME servers may choose to reuse valid authorizations from previous orders in new orders. ACME clients [should always check](https://tools.ietf.org/html/rfc8555#section-7.1.3) the status of a new order and its authorizations to confirm whether they need to respond to any challenges.
+
+**Pebble will reuse valid authorizations in new orders, if they exist, 50% of the time**.
+
+The percentage may be controlled with the environment variable `PEBBLE_WFE_AUTHZREUSE`, e.g. to always reuse authorizations:
+
+`PEBBLE_WFE_AUTHZREUSE=100 pebble`
+
 ### Avoiding Client HTTPS Errors
 
 By default Pebble is accessible over HTTPS-only and uses a [test

--- a/acme/common.go
+++ b/acme/common.go
@@ -29,6 +29,10 @@ type Identifier struct {
 	Value string `json:"value"`
 }
 
+func (ident Identifier) Equals(other Identifier) bool {
+	return ident.Type == other.Type && ident.Value == other.Value
+}
+
 type Account struct {
 	Status  string   `json:"status"`
 	Contact []string `json:"contact"`

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -215,8 +215,8 @@ func (m *MemoryStore) GetAuthorizationByID(id string) *core.Authorization {
 	return m.authorizationsByID[id]
 }
 
-// FindValidAuthorization locates an existing valid authorization for an identifier
-// from the ACME account matching accountID.
+// FindValidAuthorization fetches the first, if any, valid and unexpired authorization for the
+// provided identifier, from the ACME account matching accountID.
 func (m *MemoryStore) FindValidAuthorization(accountID string, identifier acme.Identifier) *core.Authorization {
 	m.RLock()
 	defer m.RUnlock()

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -215,13 +215,15 @@ func (m *MemoryStore) GetAuthorizationByID(id string) *core.Authorization {
 	return m.authorizationsByID[id]
 }
 
+// FindValidAuthorization locates an existing valid authorization for an identifier
+// from the ACME account matching accountID.
 func (m *MemoryStore) FindValidAuthorization(accountID string, identifier acme.Identifier) *core.Authorization {
 	m.RLock()
 	defer m.RUnlock()
 	for _, authz := range m.authorizationsByID {
-		if authz.Identifier.Type == identifier.Type && authz.Identifier.Value == identifier.Value &&
-			authz.Order.AccountID == accountID && authz.ExpiresDate.After(time.Now()) &&
-			authz.Status == acme.StatusValid {
+		if authz.Status == acme.StatusValid && identifier.Equals(authz.Identifier) &&
+			authz.Order != nil && authz.Order.AccountID == accountID &&
+			authz.ExpiresDate.After(time.Now()) {
 			return authz
 		}
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -97,7 +97,7 @@ const (
 	// percentage value for how often Pebble should try to reuse valid authorizations
 	// for each identifier in an order. The percentage is independent of whether a
 	// valid authorization exists or not for each identifier in an order.
-	authzReuseEnvVar = "PEBBLE_WFE_AUTHZREUSE"
+	authzReuseEnvVar = "PEBBLE_AUTHZREUSE"
 
 	// The default value when PEBBLE_WFE_AUTHZREUSE is not set, how often to try
 	// and reuse valid authorizations.

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -100,7 +100,7 @@ const (
 	authzReuseEnvVar = "PEBBLE_WFE_AUTHZREUSE"
 
 	// The default value when PEBBLE_WFE_AUTHZREUSE is not set, how often to try
-	// and reuse valid authorizations?
+	// and reuse valid authorizations.
 	defaultAuthzReuse = 50
 )
 
@@ -171,7 +171,7 @@ func New(
 		val >= 0 && val <= 100 {
 		authzReusePercent = int(val)
 	}
-	log.Printf("Configured to attempt authz reuse for each identifiers %d%% of the time",
+	log.Printf("Configured to attempt authz reuse for each identifier %d%% of the time",
 		authzReusePercent)
 
 	return WebFrontEndImpl{


### PR DESCRIPTION
I am not sure whether the probabilistic aspect of this furthers the goals of Pebble or not. I am more than happy to remove it if that's the feedback. 

---

RFC8555 mentions (https://tools.ietf.org/html/rfc8555#section-7.1.3)
that clients should check the "status" field of an order to determine
whether they need to take any action.

This commit implements authorization reuse, such that any valid and
unexpired authz completed by the ACME account for that identifier has a
chance to be reused in new orders. The chance is controlled by the env
variable PEBBLE_WFE_AUTHZREUSE and it defaults to 50 (percent). The
chance is evaluated regardless of whether there is an eligible authz to
reuse or not.