### PR TITLE
Docker: switch to Go 1.12 base images.

### DIFF
--- a/docker/pebble-challtestsrv/linux.Dockerfile
+++ b/docker/pebble-challtestsrv/linux.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine as builder
+FROM golang:1.12-alpine as builder
 
 RUN apk --update upgrade \
 && apk --no-cache --no-progress add git bash curl \

--- a/docker/pebble-challtestsrv/windows.Dockerfile
+++ b/docker/pebble-challtestsrv/windows.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-nanoserver-sac2016 as builder
+FROM golang:1.12-nanoserver-sac2016 as builder
 
 ENV CGO_ENABLED=0 GOFLAGS=-mod=vendor
 

--- a/docker/pebble/linux.Dockerfile
+++ b/docker/pebble/linux.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine as builder
+FROM golang:1.12-alpine as builder
 
 RUN apk --update upgrade \
 && apk --no-cache --no-progress add git bash curl \

--- a/docker/pebble/windows.Dockerfile
+++ b/docker/pebble/windows.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-nanoserver-sac2016 as builder
+FROM golang:1.12-nanoserver-sac2016 as builder
 
 ENV CGO_ENABLED=0 GOFLAGS=-mod=vendor
 


### PR DESCRIPTION
I don't plan to rebuild the existing images after this commit but it will be nice to have ready for the next tagged release. CI is already using Go 1.12.x