### PR TITLE
Fix tls-alpn-01 challenges with a custom DNS resolver

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -342,7 +342,7 @@ func (va VAImpl) validateDNS01(task *vaTask) *core.ValidationRecord {
 
 func (va VAImpl) validateTLSALPN01(task *vaTask) *core.ValidationRecord {
 	portString := strconv.Itoa(va.tlsPort)
-	hostPort := net.JoinHostPort(task.Identifier.Value, portString)
+
 	var serverNameIdentifier string
 	switch task.Identifier.Type {
 	case acme.IdentifierDNS:
@@ -351,11 +351,25 @@ func (va VAImpl) validateTLSALPN01(task *vaTask) *core.ValidationRecord {
 		serverNameIdentifier = reverseaddr(task.Identifier.Value)
 	}
 	result := &core.ValidationRecord{
-		URL:         hostPort,
+		URL:         net.JoinHostPort(task.Identifier.Value, portString),
 		ValidatedAt: time.Now(),
 	}
 
-	cs, problem := va.fetchConnectionState(hostPort, &tls.Config{
+	addrs, err := va.resolveIP(task.Identifier.Value)
+
+	if err != nil {
+		result.Error = acme.MalformedProblem(
+			fmt.Sprintf("Error occurred while resolving URL %q: %q", task.Identifier.Value, err))
+		return result
+	}
+
+	if len(addrs) == 0 {
+		result.Error = acme.MalformedProblem(
+			fmt.Sprintf("Could not resolve URL %q", task.Identifier.Value))
+		return result
+	}
+
+	cs, problem := va.fetchConnectionState(net.JoinHostPort(addrs[0], portString), &tls.Config{
 		ServerName:         serverNameIdentifier,
 		NextProtos:         []string{acme.ACMETLS1Protocol},
 		InsecureSkipVerify: true,

--- a/va/va.go
+++ b/va/va.go
@@ -411,7 +411,7 @@ func (va VAImpl) validateTLSALPN01(task *vaTask) *core.ValidationRecord {
 			"Incorrect validation certificate for %s challenge. "+
 				"Requested %s from %s. Received %d certificate(s), "+
 				"first certificate had names %q",
-			acme.ChallengeTLSALPN01, task.Identifier, hostPort, len(certs), names)
+			acme.ChallengeTLSALPN01, task.Identifier, net.JoinHostPort(task.Identifier.Value, portString), len(certs), names)
 		result.Error = acme.UnauthorizedProblem(errText)
 		return result
 	}


### PR DESCRIPTION
As noted in #264, my PR #255 to fix custom DNS resolver on Windows broke that specific feature for TLS-ALPN-01. This is because I did not use the new implementation of DNS resolvers for `va.validateTLSALPN01`, and so it was using the system DNS resolver, ignoring `--dnsserver` flag.

This can be revealed by running the integration tests of acme4j here: https://github.com/adferrand/acme4j/tree/master/acme4j-it

This PR fixes the defect by using the dedicate `va.resolveIP` into `va.validateTLSALPN01`, in order to take also advantage of the custom DNS resolver in that type of challenges.

This PR has been tested with success against the acme4j integration tests, removing the error observed.

Resolves https://github.com/letsencrypt/pebble/issues/264