### PR TITLE
Update .gitignore to parity with boulder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,14 +2,20 @@
 *.o
 *.a
 *.so
+*.pyc
 
 # Folders
 _obj
 _test
+bin
+.gocache
 
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out
+
+# Vim swap files
+*.sw?
 
 *.cgo1.go
 *.cgo2.c
@@ -19,6 +25,15 @@ _cgo_export.*
 
 _testmain.go
 
+*.sw?
 *.exe
 *.test
 *.prof
+*.coverprofile
+
+tags
+
+# IDE support files
+.idea
+
+.vscode/*


### PR DESCRIPTION
This just brings the .gitgnore in line with boulder.

Mostly for myself it is for the IDE exceptions, but figure it can't hurt to add the rest.