### PR TITLE
pebble-challtestsrv: fix CNAME delete API

### DIFF
--- a/cmd/pebble-challtestsrv/mockdns.go
+++ b/cmd/pebble-challtestsrv/mockdns.go
@@ -290,7 +290,7 @@ func (srv *managementServer) delDNSCNAMERecord(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	srv.challSrv.DeleteDNSCAARecord(request.Host)
+	srv.challSrv.DeleteDNSCNAMERecord(request.Host)
 	srv.log.Printf("Removed response for DNS CNAME queries to %q", request.Host)
 	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
Bug and fix identified by @nmorsman in https://github.com/letsencrypt/pebble/issues/272. Thanks!

Resolves https://github.com/letsencrypt/pebble/issues/272