### PR TITLE
pebble-challtestsrv: add SERVFAIL mocking support.

### DIFF
--- a/cmd/pebble-challtestsrv/README.md
+++ b/cmd/pebble-challtestsrv/README.md
@@ -103,6 +103,18 @@ To remove a mocked CNAME record for `_acme-challenge.test-host.letsencrypt.org` 
 
     curl -X POST -d '{"host":"_acme-challenge.test-host.letsencrypt.org", "target": "challenges.letsencrypt.org"}' http://localhost:8055/clear-cname
 
+##### Mocked SERVFAIL Responses
+
+To configure the DNS server to return SERVFAIL for all queries for `test-host.letsencrypt.org` run:
+
+    curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/set-servfail
+
+Subsequently any query types (A, AAAA, TXT) for the name will return a SERVFAIL response, overriding any A/AAAA/TXT/CNAME mocks that may also be configured.
+
+To remove the SERVFAIL configuration for `test-host.letsencrypt.org` run:
+
+    curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/clear-servfail
+
 #### HTTP-01
 
 To add an HTTP-01 challenge response for the token `"aaaa"` with the content `"bbbb"` run:

--- a/cmd/pebble-challtestsrv/main.go
+++ b/cmd/pebble-challtestsrv/main.go
@@ -108,6 +108,9 @@ func main() {
 	if *dnsOneBind != "" {
 		http.HandleFunc("/set-default-ipv4", oobSrv.setDefaultDNSIPv4)
 		http.HandleFunc("/set-default-ipv6", oobSrv.setDefaultDNSIPv6)
+		// TODO(@cpu): It might make sense to revisit this API in the future to have
+		// one endpoint that accepts the mock type required (A, AAAA, CNAME, etc)
+		// instead of having separate endpoints per type.
 		http.HandleFunc("/set-txt", oobSrv.addDNS01)
 		http.HandleFunc("/clear-txt", oobSrv.delDNS01)
 		http.HandleFunc("/add-a", oobSrv.addDNSARecord)
@@ -118,6 +121,8 @@ func main() {
 		http.HandleFunc("/clear-caa", oobSrv.delDNSCAARecord)
 		http.HandleFunc("/set-cname", oobSrv.addDNSCNAMERecord)
 		http.HandleFunc("/clear-cname", oobSrv.delDNSCNAMERecord)
+		http.HandleFunc("/set-servfail", oobSrv.addDNSServFailRecord)
+		http.HandleFunc("/clear-servfail", oobSrv.delDNSServFailRecord)
 
 		srv.SetDefaultDNSIPv4(*defaultIPv4)
 		srv.SetDefaultDNSIPv6(*defaultIPv6)

--- a/cmd/pebble-challtestsrv/mockdns.go
+++ b/cmd/pebble-challtestsrv/mockdns.go
@@ -294,3 +294,58 @@ func (srv *managementServer) delDNSCNAMERecord(w http.ResponseWriter, r *http.Re
 	srv.log.Printf("Removed response for DNS CNAME queries to %q", request.Host)
 	w.WriteHeader(http.StatusOK)
 }
+
+// addDNSServFailRecord handles an HTTP POST request to add a mock SERVFAIL
+// response record for a host. All queries for that host will subsequently
+// result in SERVFAIL responses, overriding any other mocks.
+//
+// The POST body is expected to have one non-empty parameter:
+// "host" - the hostname that should return SERVFAIL responses.
+//
+// A successful POST will write http.StatusOK to the client.
+func (srv *managementServer) addDNSServFailRecord(w http.ResponseWriter, r *http.Request) {
+	var request struct {
+		Host string
+	}
+	if err := mustParsePOST(&request, r); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// If the request has no host it's a bad request
+	if request.Host == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	srv.challSrv.AddDNSServFailRecord(request.Host)
+	srv.log.Printf("Added SERVFAIL response for DNS queries to %q", request.Host)
+	w.WriteHeader(http.StatusOK)
+}
+
+// delDNSServFailRecord handles an HTTP POST request to delete an existing mock
+// SERVFAIL record for a host.
+//
+// The POST body is expected to have one non-empty parameters:
+// "host" - the hostname to remove the mock SERVFAIL response from.
+//
+// A successful POST will write http.StatusOK to the client.
+func (srv *managementServer) delDNSServFailRecord(w http.ResponseWriter, r *http.Request) {
+	var request struct {
+		Host string
+	}
+	if err := mustParsePOST(&request, r); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// If the request has an empty host it's a bad request
+	if request.Host == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	srv.challSrv.DeleteDNSServFailRecord(request.Host)
+	srv.log.Printf("Removed SERVFAIL response for DNS queries to %q", request.Host)
+	w.WriteHeader(http.StatusOK)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/letsencrypt/pebble
 
 require (
-	github.com/letsencrypt/challtestsrv v1.1.0
+	github.com/letsencrypt/challtestsrv v1.2.0
 	github.com/miekg/dns v1.1.15
 	golang.org/x/net v0.0.0-20181207154023-610586996380 // indirect
 	golang.org/x/sys v0.0.0-20181206074257-70b957f3b65e // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,12 @@ github.com/letsencrypt/challtestsrv v1.0.2 h1:nBAQjKvVMLhpj4cg2Px6jMyvMbQNdJrCEd
 github.com/letsencrypt/challtestsrv v1.0.2/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/letsencrypt/challtestsrv v1.1.0 h1:2r5Wa7LvOqUsM8skGSaRnf3CV6WYPQ/OgLF1U6bCt4I=
 github.com/letsencrypt/challtestsrv v1.1.0/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
+github.com/letsencrypt/challtestsrv v1.2.0 h1:Z/hu1JPFR+cCuI92Hb+LFNxSHG4ARjRYGUipW1S71Vo=
+github.com/letsencrypt/challtestsrv v1.2.0/go.mod h1:/gzSMb+5FjprRIa1TtW6ngjhUOr8JbEFM2XESzK2zPg=
 github.com/miekg/dns v1.1.1 h1:DVkblRdiScEnEr0LR9nTnEQqHYycjkXW9bOjd+2EL2o=
 github.com/miekg/dns v1.1.1/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miekg/dns v1.1.15 h1:CSSIDtllwGLMoA6zjdKnaE6Tx6eVUxQ29LUgGetiDCI=
+github.com/miekg/dns v1.1.15/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc h1:a3CU5tJYVj92DY2LaA1kUkrsqD5/3mLDhx2NcNqyW+0=

--- a/vendor/github.com/letsencrypt/challtestsrv/.golangci.yaml
+++ b/vendor/github.com/letsencrypt/challtestsrv/.golangci.yaml
@@ -1,0 +1,22 @@
+linters-settings:
+  gocyclo:
+    min-complexity: 25
+  govet:
+    check-shadowing: false
+  misspell:
+    locale: "US"
+
+linters:
+  enable-all: true
+  disable:
+    - stylecheck
+    - gosec
+    - dupl
+    - maligned
+    - depguard
+    - lll
+    - prealloc
+    - scopelint
+    - gocritic
+    - gochecknoinits
+    - gochecknoglobals

--- a/vendor/github.com/letsencrypt/challtestsrv/CODE_OF_CONDUCT.md
+++ b/vendor/github.com/letsencrypt/challtestsrv/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Contributor Code of Conduct
+
+The contributor code of conduct is available for reference [on the community forum](https://community.letsencrypt.org/guidelines).

--- a/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go
@@ -76,6 +76,8 @@ type mockDNSData struct {
 	caaRecords map[string][]MockCAAPolicy
 	// A map of host to CNAME records.
 	cnameRecords map[string]string
+	// A map of hostnames that should receive a SERVFAIL response for all queries.
+	servFailRecords map[string]bool
 }
 
 // MockCAAPolicy holds a tag and a value for a CAA record. See
@@ -133,12 +135,13 @@ func New(config Config) (*ChallSrv, error) {
 		tlsALPNOne:     make(map[string]string),
 		redirects:      make(map[string]string),
 		dnsMocks: mockDNSData{
-			defaultIPv4:  defaultIPv4,
-			defaultIPv6:  defaultIPv6,
-			aRecords:     make(map[string][]string),
-			aaaaRecords:  make(map[string][]string),
-			caaRecords:   make(map[string][]MockCAAPolicy),
-			cnameRecords: make(map[string]string),
+			defaultIPv4:     defaultIPv4,
+			defaultIPv6:     defaultIPv6,
+			aRecords:        make(map[string][]string),
+			aaaaRecords:     make(map[string][]string),
+			caaRecords:      make(map[string][]MockCAAPolicy),
+			cnameRecords:    make(map[string]string),
+			servFailRecords: make(map[string]bool),
 		},
 	}
 

--- a/vendor/github.com/letsencrypt/challtestsrv/dns.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/dns.go
@@ -170,6 +170,13 @@ func (s *ChallSrv) dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 			Question: q,
 		})
 
+		// If there is a ServFail mock set then ignore the question and set the
+		// SERVFAIL rcode and continue.
+		if s.GetDNSServFailRecord(q.Name) {
+			m.SetRcode(r, dns.RcodeServerFailure)
+			continue
+		}
+
 		// If a CNAME exists for the question include the CNAME record and modify
 		// the question to instead lookup based on that CNAME's target
 		if cname := s.GetDNSCNAMERecord(q.Name); cname != "" {

--- a/vendor/github.com/letsencrypt/challtestsrv/mockdns.go
+++ b/vendor/github.com/letsencrypt/challtestsrv/mockdns.go
@@ -145,3 +145,30 @@ func (s *ChallSrv) GetDNSCAARecord(host string) []MockCAAPolicy {
 	host = dns.Fqdn(host)
 	return s.dnsMocks.caaRecords[host]
 }
+
+// AddDNSServFailRecord configures the chall srv to return SERVFAIL responses
+// for all queries for the given host.
+func (s *ChallSrv) AddDNSServFailRecord(host string) {
+	s.challMu.Lock()
+	defer s.challMu.Unlock()
+	host = dns.Fqdn(host)
+	s.dnsMocks.servFailRecords[host] = true
+}
+
+// DeleteDNSServFailRecord configures the chall srv to no longer return SERVFAIL
+// responses for all queries for the given host.
+func (s *ChallSrv) DeleteDNSServFailRecord(host string) {
+	s.challMu.Lock()
+	defer s.challMu.Unlock()
+	host = dns.Fqdn(host)
+	delete(s.dnsMocks.servFailRecords, host)
+}
+
+// GetDNSServFailRecord returns true when the chall srv has been configured with
+// AddDNSServFailRecord to return SERVFAIL for all queries to the given host.
+func (s *ChallSrv) GetDNSServFailRecord(host string) bool {
+	s.challMu.RLock()
+	defer s.challMu.RUnlock()
+	host = dns.Fqdn(host)
+	return s.dnsMocks.servFailRecords[host]
+}

--- a/vendor/github.com/miekg/dns/.travis.yml
+++ b/vendor/github.com/miekg/dns/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 go:
   - 1.10.x
   - 1.11.x
+  - 1.12.x
   - tip
 
 before_install:

--- a/vendor/github.com/miekg/dns/Gopkg.lock
+++ b/vendor/github.com/miekg/dns/Gopkg.lock
@@ -3,55 +3,31 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:6914c49eed986dfb8dffb33516fa129c49929d4d873f41e073c83c11c372b870"
   name = "golang.org/x/crypto"
-  packages = [
-    "ed25519",
-    "ed25519/internal/edwards25519",
-  ]
-  pruneopts = ""
-  revision = "e3636079e1a4c1f337f212cc5cd2aca108f6c900"
+  packages = ["ed25519","ed25519/internal/edwards25519"]
+  revision = "20be4c3c3ed52bfccdb2d59a412ee1a936d175a7"
 
 [[projects]]
   branch = "master"
-  digest = "1:08e41d63f8dac84d83797368b56cf0b339e42d0224e5e56668963c28aec95685"
   name = "golang.org/x/net"
-  packages = [
-    "bpf",
-    "context",
-    "internal/iana",
-    "internal/socket",
-    "ipv4",
-    "ipv6",
-  ]
-  pruneopts = ""
-  revision = "4dfa2610cdf3b287375bbba5b8f2a14d3b01d8de"
+  packages = ["bpf","internal/iana","internal/socket","ipv4","ipv6"]
+  revision = "60506f45cf65977eb3a9c6e30f995f54a721c271"
 
 [[projects]]
   branch = "master"
-  digest = "1:b2ea75de0ccb2db2ac79356407f8a4cd8f798fe15d41b381c00abf3ae8e55ed1"
   name = "golang.org/x/sync"
   packages = ["errgroup"]
-  pruneopts = ""
-  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
+  revision = "112230192c580c3556b8cee6403af37a4fc5f28c"
 
 [[projects]]
   branch = "master"
-  digest = "1:149a432fabebb8221a80f77731b1cd63597197ded4f14af606ebe3a0959004ec"
   name = "golang.org/x/sys"
-  packages = ["unix"]
-  pruneopts = ""
-  revision = "e4b3c5e9061176387e7cea65e4dc5853801f3fb7"
+  packages = ["unix","windows"]
+  revision = "4c4f7f33c9ed00de01c4c741d2177abfcfe19307"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "golang.org/x/crypto/ed25519",
-    "golang.org/x/net/ipv4",
-    "golang.org/x/net/ipv6",
-    "golang.org/x/sync/errgroup",
-    "golang.org/x/sys/unix",
-  ]
+  inputs-digest = "fc70ece982d3660454fe1b9ccd5c91162a1cc080b58ad82aa065ad4a2ec93ce9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/miekg/dns/README.md
+++ b/vendor/github.com/miekg/dns/README.md
@@ -67,6 +67,9 @@ A not-so-up-to-date-list-that-may-be-actually-current:
 * https://github.com/rs/dnstrace
 * https://blitiri.com.ar/p/dnss ([github mirror](https://github.com/albertito/dnss))
 * https://github.com/semihalev/sdns
+* https://render.com
+* https://github.com/peterzen/goresolver
+* https://github.com/folbricht/routedns
 
 Send pull request if you want to be listed here.
 
@@ -99,8 +102,8 @@ work:
 
 ## Examples
 
-A short "how to use the API" is at the beginning of doc.go (this also will show
-when you call `godoc github.com/miekg/dns`).
+A short "how to use the API" is at the beginning of doc.go (this also will show when you call `godoc
+github.com/miekg/dns`).
 
 Example programs can be found in the `github.com/miekg/exdns` repository.
 
@@ -150,6 +153,7 @@ Example programs can be found in the `github.com/miekg/exdns` repository.
 * 6844 - CAA record
 * 6891 - EDNS0 update
 * 6895 - DNS IANA considerations
+* 6944 - DNSSEC DNSKEY Algorithm Status
 * 6975 - Algorithm Understanding in DNSSEC
 * 7043 - EUI48/EUI64 records
 * 7314 - DNS (EDNS) EXPIRE Option
@@ -158,8 +162,9 @@ Example programs can be found in the `github.com/miekg/exdns` repository.
 * 7553 - URI record
 * 7858 - DNS over TLS: Initiation and Performance Considerations
 * 7871 - EDNS0 Client Subnet
-* 7873 - Domain Name System (DNS) Cookies (draft-ietf-dnsop-cookies)
+* 7873 - Domain Name System (DNS) Cookies
 * 8080 - EdDSA for DNSSEC
+* 8499 - DNS Terminology
 
 ## Loosely Based Upon
 

--- a/vendor/github.com/miekg/dns/acceptfunc.go
+++ b/vendor/github.com/miekg/dns/acceptfunc.go
@@ -10,7 +10,7 @@ type MsgAcceptFunc func(dh Header) MsgAcceptAction
 // * opcode isn't OpcodeQuery or OpcodeNotify
 // * Zero bit isn't zero
 // * has more than 1 question in the question section
-// * has more than 0 RRs in the Answer section
+// * has more than 1 RR in the Answer section
 // * has more than 0 RRs in the Authority section
 // * has more than 2 RRs in the Additional section
 var DefaultMsgAcceptFunc MsgAcceptFunc = defaultMsgAcceptFunc
@@ -19,12 +19,13 @@ var DefaultMsgAcceptFunc MsgAcceptFunc = defaultMsgAcceptFunc
 type MsgAcceptAction int
 
 const (
-	MsgAccept MsgAcceptAction = iota // Accept the message
-	MsgReject                        // Reject the message with a RcodeFormatError
-	MsgIgnore                        // Ignore the error and send nothing back.
+	MsgAccept         MsgAcceptAction = iota // Accept the message
+	MsgReject                                // Reject the message with a RcodeFormatError
+	MsgIgnore                                // Ignore the error and send nothing back.
+	MsgRejectNotImplemented                        // Reject the message with a RcodeNotImplemented
 )
 
-var defaultMsgAcceptFunc = func(dh Header) MsgAcceptAction {
+func defaultMsgAcceptFunc(dh Header) MsgAcceptAction {
 	if isResponse := dh.Bits&_QR != 0; isResponse {
 		return MsgIgnore
 	}
@@ -32,19 +33,18 @@ var defaultMsgAcceptFunc = func(dh Header) MsgAcceptAction {
 	// Don't allow dynamic updates, because then the sections can contain a whole bunch of RRs.
 	opcode := int(dh.Bits>>11) & 0xF
 	if opcode != OpcodeQuery && opcode != OpcodeNotify {
-		return MsgReject
+		return MsgRejectNotImplemented
 	}
 
-	if isZero := dh.Bits&_Z != 0; isZero {
-		return MsgReject
-	}
 	if dh.Qdcount != 1 {
 		return MsgReject
 	}
-	if dh.Ancount != 0 {
+	// NOTIFY requests can have a SOA in the ANSWER section. See RFC 1996 Section 3.7 and 3.11.
+	if dh.Ancount > 1 {
 		return MsgReject
 	}
-	if dh.Nscount != 0 {
+	// IXFR request could have one SOA RR in the NS section. See RFC 1995, section 3.
+	if dh.Nscount > 1 {
 		return MsgReject
 	}
 	if dh.Arcount > 2 {

--- a/vendor/github.com/miekg/dns/client.go
+++ b/vendor/github.com/miekg/dns/client.go
@@ -3,10 +3,10 @@ package dns
 // A client implementation.
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -129,20 +129,15 @@ func (c *Client) Exchange(m *Msg, address string) (r *Msg, rtt time.Duration, er
 		return c.exchange(m, address)
 	}
 
-	t := "nop"
-	if t1, ok := TypeToString[m.Question[0].Qtype]; ok {
-		t = t1
-	}
-	cl := "nop"
-	if cl1, ok := ClassToString[m.Question[0].Qclass]; ok {
-		cl = cl1
-	}
-	r, rtt, err, shared := c.group.Do(m.Question[0].Name+t+cl, func() (*Msg, time.Duration, error) {
+	q := m.Question[0]
+	key := fmt.Sprintf("%s:%d:%d", q.Name, q.Qtype, q.Qclass)
+	r, rtt, err, shared := c.group.Do(key, func() (*Msg, time.Duration, error) {
 		return c.exchange(m, address)
 	})
 	if r != nil && shared {
 		r = r.Copy()
 	}
+
 	return r, rtt, err
 }
 
@@ -221,24 +216,21 @@ func (co *Conn) ReadMsgHeader(hdr *Header) ([]byte, error) {
 		err error
 	)
 
-	switch t := co.Conn.(type) {
-	case *net.TCPConn, *tls.Conn:
-		r := t.(io.Reader)
-
-		// First two bytes specify the length of the entire message.
-		l, err := tcpMsgLen(r)
-		if err != nil {
-			return nil, err
-		}
-		p = make([]byte, l)
-		n, err = tcpRead(r, p)
-	default:
+	if _, ok := co.Conn.(net.PacketConn); ok {
 		if co.UDPSize > MinMsgSize {
 			p = make([]byte, co.UDPSize)
 		} else {
 			p = make([]byte, MinMsgSize)
 		}
 		n, err = co.Read(p)
+	} else {
+		var length uint16
+		if err := binary.Read(co.Conn, binary.BigEndian, &length); err != nil {
+			return nil, err
+		}
+
+		p = make([]byte, length)
+		n, err = io.ReadFull(co.Conn, p)
 	}
 
 	if err != nil {
@@ -258,78 +250,26 @@ func (co *Conn) ReadMsgHeader(hdr *Header) ([]byte, error) {
 	return p, err
 }
 
-// tcpMsgLen is a helper func to read first two bytes of stream as uint16 packet length.
-func tcpMsgLen(t io.Reader) (int, error) {
-	p := []byte{0, 0}
-	n, err := t.Read(p)
-	if err != nil {
-		return 0, err
-	}
-
-	// As seen with my local router/switch, returns 1 byte on the above read,
-	// resulting a a ShortRead. Just write it out (instead of loop) and read the
-	// other byte.
-	if n == 1 {
-		n1, err := t.Read(p[1:])
-		if err != nil {
-			return 0, err
-		}
-		n += n1
-	}
-
-	if n != 2 {
-		return 0, ErrShortRead
-	}
-	l := binary.BigEndian.Uint16(p)
-	if l == 0 {
-		return 0, ErrShortRead
-	}
-	return int(l), nil
-}
-
-// tcpRead calls TCPConn.Read enough times to fill allocated buffer.
-func tcpRead(t io.Reader, p []byte) (int, error) {
-	n, err := t.Read(p)
-	if err != nil {
-		return n, err
-	}
-	for n < len(p) {
-		j, err := t.Read(p[n:])
-		if err != nil {
-			return n, err
-		}
-		n += j
-	}
-	return n, err
-}
-
 // Read implements the net.Conn read method.
 func (co *Conn) Read(p []byte) (n int, err error) {
 	if co.Conn == nil {
 		return 0, ErrConnEmpty
 	}
-	if len(p) < 2 {
+
+	if _, ok := co.Conn.(net.PacketConn); ok {
+		// UDP connection
+		return co.Conn.Read(p)
+	}
+
+	var length uint16
+	if err := binary.Read(co.Conn, binary.BigEndian, &length); err != nil {
+		return 0, err
+	}
+	if int(length) > len(p) {
 		return 0, io.ErrShortBuffer
 	}
-	switch t := co.Conn.(type) {
-	case *net.TCPConn, *tls.Conn:
-		r := t.(io.Reader)
 
-		l, err := tcpMsgLen(r)
-		if err != nil {
-			return 0, err
-		}
-		if l > len(p) {
-			return int(l), io.ErrShortBuffer
-		}
-		return tcpRead(r, p[:l])
-	}
-	// UDP connection
-	n, err = co.Conn.Read(p)
-	if err != nil {
-		return n, err
-	}
-	return n, err
+	return io.ReadFull(co.Conn, p[:length])
 }
 
 // WriteMsg sends a message through the connection co.
@@ -351,33 +291,25 @@ func (co *Conn) WriteMsg(m *Msg) (err error) {
 	if err != nil {
 		return err
 	}
-	if _, err = co.Write(out); err != nil {
-		return err
-	}
-	return nil
+	_, err = co.Write(out)
+	return err
 }
 
 // Write implements the net.Conn Write method.
-func (co *Conn) Write(p []byte) (n int, err error) {
-	switch t := co.Conn.(type) {
-	case *net.TCPConn, *tls.Conn:
-		w := t.(io.Writer)
-
-		lp := len(p)
-		if lp < 2 {
-			return 0, io.ErrShortBuffer
-		}
-		if lp > MaxMsgSize {
-			return 0, &Error{err: "message too large"}
-		}
-		l := make([]byte, 2, lp+2)
-		binary.BigEndian.PutUint16(l, uint16(lp))
-		p = append(l, p...)
-		n, err := io.Copy(w, bytes.NewReader(p))
-		return int(n), err
+func (co *Conn) Write(p []byte) (int, error) {
+	if len(p) > MaxMsgSize {
+		return 0, &Error{err: "message too large"}
 	}
-	n, err = co.Conn.Write(p)
-	return n, err
+
+	if _, ok := co.Conn.(net.PacketConn); ok {
+		return co.Conn.Write(p)
+	}
+
+	l := make([]byte, 2)
+	binary.BigEndian.PutUint16(l, uint16(len(p)))
+
+	n, err := (&net.Buffers{l, p}).WriteTo(co.Conn)
+	return int(n), err
 }
 
 // Return the appropriate timeout for a specific request
@@ -420,7 +352,7 @@ func ExchangeContext(ctx context.Context, m *Msg, a string) (r *Msg, err error) 
 
 // ExchangeConn performs a synchronous query. It sends the message m via the connection
 // c and waits for a reply. The connection c is not closed by ExchangeConn.
-// This function is going away, but can easily be mimicked:
+// Deprecated: This function is going away, but can easily be mimicked:
 //
 //	co := &dns.Conn{Conn: c} // c is your net.Conn
 //	co.WriteMsg(m)
@@ -444,11 +376,7 @@ func ExchangeConn(c net.Conn, m *Msg) (r *Msg, err error) {
 // DialTimeout acts like Dial but takes a timeout.
 func DialTimeout(network, address string, timeout time.Duration) (conn *Conn, err error) {
 	client := Client{Net: network, Dialer: &net.Dialer{Timeout: timeout}}
-	conn, err = client.Dial(address)
-	if err != nil {
-		return nil, err
-	}
-	return conn, nil
+	return client.Dial(address)
 }
 
 // DialWithTLS connects to the address on the named network with TLS.
@@ -457,12 +385,7 @@ func DialWithTLS(network, address string, tlsConfig *tls.Config) (conn *Conn, er
 		network += "-tls"
 	}
 	client := Client{Net: network, TLSConfig: tlsConfig}
-	conn, err = client.Dial(address)
-
-	if err != nil {
-		return nil, err
-	}
-	return conn, nil
+	return client.Dial(address)
 }
 
 // DialTimeoutWithTLS acts like DialWithTLS but takes a timeout.
@@ -471,11 +394,7 @@ func DialTimeoutWithTLS(network, address string, tlsConfig *tls.Config, timeout 
 		network += "-tls"
 	}
 	client := Client{Net: network, Dialer: &net.Dialer{Timeout: timeout}, TLSConfig: tlsConfig}
-	conn, err = client.Dial(address)
-	if err != nil {
-		return nil, err
-	}
-	return conn, nil
+	return client.Dial(address)
 }
 
 // ExchangeContext acts like Exchange, but honors the deadline on the provided

--- a/vendor/github.com/miekg/dns/clientconfig.go
+++ b/vendor/github.com/miekg/dns/clientconfig.go
@@ -68,14 +68,10 @@ func ClientConfigFromReader(resolvconf io.Reader) (*ClientConfig, error) {
 			}
 
 		case "search": // set search path to given servers
-			c.Search = make([]string, len(f)-1)
-			for i := 0; i < len(c.Search); i++ {
-				c.Search[i] = f[i+1]
-			}
+			c.Search = append([]string(nil), f[1:]...)
 
 		case "options": // magic options
-			for i := 1; i < len(f); i++ {
-				s := f[i]
+			for _, s := range f[1:] {
 				switch {
 				case len(s) >= 6 && s[:6] == "ndots:":
 					n, _ := strconv.Atoi(s[6:])

--- a/vendor/github.com/miekg/dns/defaults.go
+++ b/vendor/github.com/miekg/dns/defaults.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"strconv"
+	"strings"
 )
 
 const hexDigit = "0123456789abcdef"
@@ -145,13 +146,27 @@ func (dns *Msg) IsTsig() *TSIG {
 // record in the additional section will do. It returns the OPT record
 // found or nil.
 func (dns *Msg) IsEdns0() *OPT {
-	// EDNS0 is at the end of the additional section, start there.
-	// We might want to change this to *only* look at the last two
-	// records. So we see TSIG and/or OPT - this a slightly bigger
-	// change though.
+	// RFC 6891, Section 6.1.1 allows the OPT record to appear
+	// anywhere in the additional record section, but it's usually at
+	// the end so start there.
 	for i := len(dns.Extra) - 1; i >= 0; i-- {
 		if dns.Extra[i].Header().Rrtype == TypeOPT {
 			return dns.Extra[i].(*OPT)
+		}
+	}
+	return nil
+}
+
+// popEdns0 is like IsEdns0, but it removes the record from the message.
+func (dns *Msg) popEdns0() *OPT {
+	// RFC 6891, Section 6.1.1 allows the OPT record to appear
+	// anywhere in the additional record section, but it's usually at
+	// the end so start there.
+	for i := len(dns.Extra) - 1; i >= 0; i-- {
+		if dns.Extra[i].Header().Rrtype == TypeOPT {
+			opt := dns.Extra[i].(*OPT)
+			dns.Extra = append(dns.Extra[:i], dns.Extra[i+1:]...)
+			return opt
 		}
 	}
 	return nil
@@ -163,11 +178,72 @@ func (dns *Msg) IsEdns0() *OPT {
 // the number of labels.  When false is returned the number of labels is not
 // defined.  Also note that this function is extremely liberal; almost any
 // string is a valid domain name as the DNS is 8 bit protocol. It checks if each
-// label fits in 63 characters, but there is no length check for the entire
-// string s. I.e.  a domain name longer than 255 characters is considered valid.
+// label fits in 63 characters and that the entire name will fit into the 255
+// octet wire format limit.
 func IsDomainName(s string) (labels int, ok bool) {
-	_, labels, err := packDomainName(s, nil, 0, compressionMap{}, false)
-	return labels, err == nil
+	// XXX: The logic in this function was copied from packDomainName and
+	// should be kept in sync with that function.
+
+	const lenmsg = 256
+
+	if len(s) == 0 { // Ok, for instance when dealing with update RR without any rdata.
+		return 0, false
+	}
+
+	s = Fqdn(s)
+
+	// Each dot ends a segment of the name. Except for escaped dots (\.), which
+	// are normal dots.
+
+	var (
+		off    int
+		begin  int
+		wasDot bool
+	)
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			if off+1 > lenmsg {
+				return labels, false
+			}
+
+			// check for \DDD
+			if i+3 < len(s) && isDigit(s[i+1]) && isDigit(s[i+2]) && isDigit(s[i+3]) {
+				i += 3
+				begin += 3
+			} else {
+				i++
+				begin++
+			}
+
+			wasDot = false
+		case '.':
+			if wasDot {
+				// two dots back to back is not legal
+				return labels, false
+			}
+			wasDot = true
+
+			labelLen := i - begin
+			if labelLen >= 1<<6 { // top two bits of length must be clear
+				return labels, false
+			}
+
+			// off can already (we're in a loop) be bigger than lenmsg
+			// this happens when a name isn't fully qualified
+			off += 1 + labelLen
+			if off > lenmsg {
+				return labels, false
+			}
+
+			labels++
+			begin = i + 1
+		default:
+			wasDot = false
+		}
+	}
+
+	return labels, true
 }
 
 // IsSubDomain checks if child is indeed a child of the parent. If child and parent
@@ -181,7 +257,7 @@ func IsSubDomain(parent, child string) bool {
 // The checking is performed on the binary payload.
 func IsMsg(buf []byte) error {
 	// Header
-	if len(buf) < 12 {
+	if len(buf) < headerSize {
 		return errors.New("dns: bad message header")
 	}
 	// Header: Opcode
@@ -191,11 +267,18 @@ func IsMsg(buf []byte) error {
 
 // IsFqdn checks if a domain name is fully qualified.
 func IsFqdn(s string) bool {
-	l := len(s)
-	if l == 0 {
+	s2 := strings.TrimSuffix(s, ".")
+	if s == s2 {
 		return false
 	}
-	return s[l-1] == '.'
+
+	i := strings.LastIndexFunc(s2, func(r rune) bool {
+		return r != '\\'
+	})
+
+	// Test whether we have an even number of escape sequences before
+	// the dot or none.
+	return (len(s2)-i)%2 != 0
 }
 
 // IsRRset checks if a set of RRs is a valid RRset as defined by RFC 2181.
@@ -244,12 +327,19 @@ func ReverseAddr(addr string) (arpa string, err error) {
 	if ip == nil {
 		return "", &Error{err: "unrecognized address: " + addr}
 	}
-	if ip.To4() != nil {
-		return strconv.Itoa(int(ip[15])) + "." + strconv.Itoa(int(ip[14])) + "." + strconv.Itoa(int(ip[13])) + "." +
-			strconv.Itoa(int(ip[12])) + ".in-addr.arpa.", nil
+	if v4 := ip.To4(); v4 != nil {
+		buf := make([]byte, 0, net.IPv4len*4+len("in-addr.arpa."))
+		// Add it, in reverse, to the buffer
+		for i := len(v4) - 1; i >= 0; i-- {
+			buf = strconv.AppendInt(buf, int64(v4[i]), 10)
+			buf = append(buf, '.')
+		}
+		// Append "in-addr.arpa." and return (buf already has the final .)
+		buf = append(buf, "in-addr.arpa."...)
+		return string(buf), nil
 	}
 	// Must be IPv6
-	buf := make([]byte, 0, len(ip)*4+len("ip6.arpa."))
+	buf := make([]byte, 0, net.IPv6len*4+len("ip6.arpa."))
 	// Add it, in reverse, to the buffer
 	for i := len(ip) - 1; i >= 0; i-- {
 		v := ip[i]

--- a/vendor/github.com/miekg/dns/dns.go
+++ b/vendor/github.com/miekg/dns/dns.go
@@ -41,8 +41,23 @@ type RR interface {
 	// size will be returned and domain names will be added to the map for future compression.
 	len(off int, compression map[string]struct{}) int
 
-	// pack packs an RR into wire format.
-	pack(msg []byte, off int, compression compressionMap, compress bool) (headerEnd int, off1 int, err error)
+	// pack packs the records RDATA into wire format. The header will
+	// already have been packed into msg.
+	pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error)
+
+	// unpack unpacks an RR from wire format.
+	//
+	// This will only be called on a new and empty RR type with only the header populated. It
+	// will only be called if the record's RDATA is non-empty.
+	unpack(msg []byte, off int) (off1 int, err error)
+
+	// parse parses an RR from zone file format.
+	//
+	// This will only be called on a new and empty RR type with only the header populated.
+	parse(c *zlexer, origin string) *ParseError
+
+	// isDuplicate returns whether the two RRs are duplicates.
+	isDuplicate(r2 RR) bool
 }
 
 // RR_Header is the header all DNS resource records share.
@@ -81,6 +96,19 @@ func (h *RR_Header) len(off int, compression map[string]struct{}) int {
 	return l
 }
 
+func (h *RR_Header) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	// RR_Header has no RDATA to pack.
+	return off, nil
+}
+
+func (h *RR_Header) unpack(msg []byte, off int) (int, error) {
+	panic("dns: internal error: unpack should never be called on RR_Header")
+}
+
+func (h *RR_Header) parse(c *zlexer, origin string) *ParseError {
+	panic("dns: internal error: parse should never be called on RR_Header")
+}
+
 // ToRFC3597 converts a known RR to the unknown RR representation from RFC 3597.
 func (rr *RFC3597) ToRFC3597(r RR) error {
 	buf := make([]byte, Len(r)*2)
@@ -90,14 +118,17 @@ func (rr *RFC3597) ToRFC3597(r RR) error {
 	}
 	buf = buf[:off]
 
-	hdr := *r.Header()
-	hdr.Rdlength = uint16(off - headerEnd)
+	*rr = RFC3597{Hdr: *r.Header()}
+	rr.Hdr.Rdlength = uint16(off - headerEnd)
 
-	rfc3597, _, err := unpackRFC3597(hdr, buf, headerEnd)
+	if noRdata(rr.Hdr) {
+		return nil
+	}
+
+	_, err = rr.unpack(buf, headerEnd)
 	if err != nil {
 		return err
 	}
 
-	*rr = *rfc3597.(*RFC3597)
 	return nil
 }

--- a/vendor/github.com/miekg/dns/dnssec.go
+++ b/vendor/github.com/miekg/dns/dnssec.go
@@ -67,9 +67,6 @@ var AlgorithmToString = map[uint8]string{
 	PRIVATEOID:       "PRIVATEOID",
 }
 
-// StringToAlgorithm is the reverse of AlgorithmToString.
-var StringToAlgorithm = reverseInt8(AlgorithmToString)
-
 // AlgorithmToHash is a map of algorithm crypto hash IDs to crypto.Hash's.
 var AlgorithmToHash = map[uint8]crypto.Hash{
 	RSAMD5:           crypto.MD5, // Deprecated in RFC 6725
@@ -101,9 +98,6 @@ var HashToString = map[uint8]string{
 	SHA384: "SHA384",
 	SHA512: "SHA512",
 }
-
-// StringToHash is a map of names to hash IDs.
-var StringToHash = reverseInt8(HashToString)
 
 // DNSKEY flag values.
 const (
@@ -147,8 +141,8 @@ func (k *DNSKEY) KeyTag() uint16 {
 	switch k.Algorithm {
 	case RSAMD5:
 		// Look at the bottom two bytes of the modules, which the last
-		// item in the pubkey. We could do this faster by looking directly
-		// at the base64 values. But I'm lazy.
+		// item in the pubkey.
+		// This algorithm has been deprecated, but keep this key-tag calculation.
 		modulus, _ := fromBase64([]byte(k.PublicKey))
 		if len(modulus) > 1 {
 			x := binary.BigEndian.Uint16(modulus[len(modulus)-2:])
@@ -268,16 +262,17 @@ func (rr *RRSIG) Sign(k crypto.Signer, rrset []RR) error {
 		return ErrKey
 	}
 
+	h0 := rrset[0].Header()
 	rr.Hdr.Rrtype = TypeRRSIG
-	rr.Hdr.Name = rrset[0].Header().Name
-	rr.Hdr.Class = rrset[0].Header().Class
+	rr.Hdr.Name = h0.Name
+	rr.Hdr.Class = h0.Class
 	if rr.OrigTtl == 0 { // If set don't override
-		rr.OrigTtl = rrset[0].Header().Ttl
+		rr.OrigTtl = h0.Ttl
 	}
-	rr.TypeCovered = rrset[0].Header().Rrtype
-	rr.Labels = uint8(CountLabel(rrset[0].Header().Name))
+	rr.TypeCovered = h0.Rrtype
+	rr.Labels = uint8(CountLabel(h0.Name))
 
-	if strings.HasPrefix(rrset[0].Header().Name, "*") {
+	if strings.HasPrefix(h0.Name, "*") {
 		rr.Labels-- // wildcard, remove from label count
 	}
 
@@ -323,6 +318,9 @@ func (rr *RRSIG) Sign(k crypto.Signer, rrset []RR) error {
 		}
 
 		rr.Signature = toBase64(signature)
+	case RSAMD5, DSA, DSANSEC3SHA1:
+		// See RFC 6944.
+		return ErrAlg
 	default:
 		h := hash.New()
 		h.Write(signdata)
@@ -411,10 +409,7 @@ func (rr *RRSIG) Verify(k *DNSKEY, rrset []RR) error {
 	// IsRRset checked that we have at least one RR and that the RRs in
 	// the set have consistent type, class, and name. Also check that type and
 	// class matches the RRSIG record.
-	if rrset[0].Header().Class != rr.Hdr.Class {
-		return ErrRRset
-	}
-	if rrset[0].Header().Rrtype != rr.TypeCovered {
+	if h0 := rrset[0].Header(); h0.Class != rr.Hdr.Class || h0.Rrtype != rr.TypeCovered {
 		return ErrRRset
 	}
 
@@ -563,20 +558,19 @@ func (k *DNSKEY) publicKeyRSA() *rsa.PublicKey {
 
 	pubkey := new(rsa.PublicKey)
 
-	expo := uint64(0)
-	for i := 0; i < int(explen); i++ {
+	var expo uint64
+	// The exponent of length explen is between keyoff and modoff.
+	for _, v := range keybuf[keyoff:modoff] {
 		expo <<= 8
-		expo |= uint64(keybuf[keyoff+i])
+		expo |= uint64(v)
 	}
 	if expo > 1<<31-1 {
 		// Larger exponent than supported by the crypto package.
 		return nil
 	}
+
 	pubkey.E = int(expo)
-
-	pubkey.N = big.NewInt(0)
-	pubkey.N.SetBytes(keybuf[modoff:])
-
+	pubkey.N = new(big.Int).SetBytes(keybuf[modoff:])
 	return pubkey
 }
 
@@ -601,10 +595,8 @@ func (k *DNSKEY) publicKeyECDSA() *ecdsa.PublicKey {
 			return nil
 		}
 	}
-	pubkey.X = big.NewInt(0)
-	pubkey.X.SetBytes(keybuf[:len(keybuf)/2])
-	pubkey.Y = big.NewInt(0)
-	pubkey.Y.SetBytes(keybuf[len(keybuf)/2:])
+	pubkey.X = new(big.Int).SetBytes(keybuf[:len(keybuf)/2])
+	pubkey.Y = new(big.Int).SetBytes(keybuf[len(keybuf)/2:])
 	return pubkey
 }
 
@@ -625,10 +617,10 @@ func (k *DNSKEY) publicKeyDSA() *dsa.PublicKey {
 	p, keybuf := keybuf[:size], keybuf[size:]
 	g, y := keybuf[:size], keybuf[size:]
 	pubkey := new(dsa.PublicKey)
-	pubkey.Parameters.Q = big.NewInt(0).SetBytes(q)
-	pubkey.Parameters.P = big.NewInt(0).SetBytes(p)
-	pubkey.Parameters.G = big.NewInt(0).SetBytes(g)
-	pubkey.Y = big.NewInt(0).SetBytes(y)
+	pubkey.Parameters.Q = new(big.Int).SetBytes(q)
+	pubkey.Parameters.P = new(big.Int).SetBytes(p)
+	pubkey.Parameters.G = new(big.Int).SetBytes(g)
+	pubkey.Y = new(big.Int).SetBytes(y)
 	return pubkey
 }
 
@@ -658,15 +650,16 @@ func rawSignatureData(rrset []RR, s *RRSIG) (buf []byte, err error) {
 	wires := make(wireSlice, len(rrset))
 	for i, r := range rrset {
 		r1 := r.copy()
-		r1.Header().Ttl = s.OrigTtl
-		labels := SplitDomainName(r1.Header().Name)
+		h := r1.Header()
+		h.Ttl = s.OrigTtl
+		labels := SplitDomainName(h.Name)
 		// 6.2. Canonical RR Form. (4) - wildcards
 		if len(labels) > int(s.Labels) {
 			// Wildcard
-			r1.Header().Name = "*." + strings.Join(labels[len(labels)-int(s.Labels):], ".") + "."
+			h.Name = "*." + strings.Join(labels[len(labels)-int(s.Labels):], ".") + "."
 		}
 		// RFC 4034: 6.2.  Canonical RR Form. (2) - domain name to lowercase
-		r1.Header().Name = strings.ToLower(r1.Header().Name)
+		h.Name = strings.ToLower(h.Name)
 		// 6.2. Canonical RR Form. (3) - domain rdata to lowercase.
 		//   NS, MD, MF, CNAME, SOA, MB, MG, MR, PTR,
 		//   HINFO, MINFO, MX, RP, AFSDB, RT, SIG, PX, NXT, NAPTR, KX,

--- a/vendor/github.com/miekg/dns/dnssec_keygen.go
+++ b/vendor/github.com/miekg/dns/dnssec_keygen.go
@@ -2,7 +2,6 @@ package dns
 
 import (
 	"crypto"
-	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -20,11 +19,9 @@ import (
 // bits should be set to the size of the algorithm.
 func (k *DNSKEY) Generate(bits int) (crypto.PrivateKey, error) {
 	switch k.Algorithm {
-	case DSA, DSANSEC3SHA1:
-		if bits != 1024 {
-			return nil, ErrKeySize
-		}
-	case RSAMD5, RSASHA1, RSASHA256, RSASHA1NSEC3SHA1:
+	case RSAMD5, DSA, DSANSEC3SHA1:
+		return nil, ErrAlg
+	case RSASHA1, RSASHA256, RSASHA1NSEC3SHA1:
 		if bits < 512 || bits > 4096 {
 			return nil, ErrKeySize
 		}
@@ -47,20 +44,7 @@ func (k *DNSKEY) Generate(bits int) (crypto.PrivateKey, error) {
 	}
 
 	switch k.Algorithm {
-	case DSA, DSANSEC3SHA1:
-		params := new(dsa.Parameters)
-		if err := dsa.GenerateParameters(params, rand.Reader, dsa.L1024N160); err != nil {
-			return nil, err
-		}
-		priv := new(dsa.PrivateKey)
-		priv.PublicKey.Parameters = *params
-		err := dsa.GenerateKey(priv, rand.Reader)
-		if err != nil {
-			return nil, err
-		}
-		k.setPublicKeyDSA(params.Q, params.P, params.G, priv.PublicKey.Y)
-		return priv, nil
-	case RSAMD5, RSASHA1, RSASHA256, RSASHA512, RSASHA1NSEC3SHA1:
+	case RSASHA1, RSASHA256, RSASHA512, RSASHA1NSEC3SHA1:
 		priv, err := rsa.GenerateKey(rand.Reader, bits)
 		if err != nil {
 			return nil, err
@@ -120,16 +104,6 @@ func (k *DNSKEY) setPublicKeyECDSA(_X, _Y *big.Int) bool {
 	return true
 }
 
-// Set the public key for DSA
-func (k *DNSKEY) setPublicKeyDSA(_Q, _P, _G, _Y *big.Int) bool {
-	if _Q == nil || _P == nil || _G == nil || _Y == nil {
-		return false
-	}
-	buf := dsaToBuf(_Q, _P, _G, _Y)
-	k.PublicKey = toBase64(buf)
-	return true
-}
-
 // Set the public key for Ed25519
 func (k *DNSKEY) setPublicKeyED25519(_K ed25519.PublicKey) bool {
 	if _K == nil {
@@ -162,17 +136,5 @@ func exponentToBuf(_E int) []byte {
 func curveToBuf(_X, _Y *big.Int, intlen int) []byte {
 	buf := intToBytes(_X, intlen)
 	buf = append(buf, intToBytes(_Y, intlen)...)
-	return buf
-}
-
-// Set the public key for X and Y for Curve. The two
-// values are just concatenated.
-func dsaToBuf(_Q, _P, _G, _Y *big.Int) []byte {
-	t := divRoundUp(divRoundUp(_G.BitLen(), 8)-64, 8)
-	buf := []byte{byte(t)}
-	buf = append(buf, intToBytes(_Q, 20)...)
-	buf = append(buf, intToBytes(_P, 64+t*8)...)
-	buf = append(buf, intToBytes(_G, 64+t*8)...)
-	buf = append(buf, intToBytes(_Y, 64+t*8)...)
 	return buf
 }

--- a/vendor/github.com/miekg/dns/dnssec_privkey.go
+++ b/vendor/github.com/miekg/dns/dnssec_privkey.go
@@ -13,6 +13,8 @@ import (
 
 const format = "Private-key-format: v1.3\n"
 
+var bigIntOne = big.NewInt(1)
+
 // PrivateKeyString converts a PrivateKey to a string. This string has the same
 // format as the private-key-file of BIND9 (Private-key-format: v1.3).
 // It needs some info from the key (the algorithm), so its a method of the DNSKEY
@@ -31,12 +33,11 @@ func (r *DNSKEY) PrivateKeyString(p crypto.PrivateKey) string {
 		prime2 := toBase64(p.Primes[1].Bytes())
 		// Calculate Exponent1/2 and Coefficient as per: http://en.wikipedia.org/wiki/RSA#Using_the_Chinese_remainder_algorithm
 		// and from: http://code.google.com/p/go/issues/detail?id=987
-		one := big.NewInt(1)
-		p1 := big.NewInt(0).Sub(p.Primes[0], one)
-		q1 := big.NewInt(0).Sub(p.Primes[1], one)
-		exp1 := big.NewInt(0).Mod(p.D, p1)
-		exp2 := big.NewInt(0).Mod(p.D, q1)
-		coeff := big.NewInt(0).ModInverse(p.Primes[1], p.Primes[0])
+		p1 := new(big.Int).Sub(p.Primes[0], bigIntOne)
+		q1 := new(big.Int).Sub(p.Primes[1], bigIntOne)
+		exp1 := new(big.Int).Mod(p.D, p1)
+		exp2 := new(big.Int).Mod(p.D, q1)
+		coeff := new(big.Int).ModInverse(p.Primes[1], p.Primes[0])
 
 		exponent1 := toBase64(exp1.Bytes())
 		exponent2 := toBase64(exp2.Bytes())

--- a/vendor/github.com/miekg/dns/duplicate.go
+++ b/vendor/github.com/miekg/dns/duplicate.go
@@ -7,19 +7,32 @@ package dns
 // is so, otherwise false.
 // It's is a protocol violation to have identical RRs in a message.
 func IsDuplicate(r1, r2 RR) bool {
-	if r1.Header().Class != r2.Header().Class {
+	// Check whether the record header is identical.
+	if !r1.Header().isDuplicate(r2.Header()) {
 		return false
 	}
-	if r1.Header().Rrtype != r2.Header().Rrtype {
+
+	// Check whether the RDATA is identical.
+	return r1.isDuplicate(r2)
+}
+
+func (r1 *RR_Header) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*RR_Header)
+	if !ok {
 		return false
 	}
-	if !isDulicateName(r1.Header().Name, r2.Header().Name) {
+	if r1.Class != r2.Class {
+		return false
+	}
+	if r1.Rrtype != r2.Rrtype {
+		return false
+	}
+	if !isDuplicateName(r1.Name, r2.Name) {
 		return false
 	}
 	// ignore TTL
-
-	return isDuplicateRdata(r1, r2)
+	return true
 }
 
-// isDulicateName checks if the domain names s1 and s2 are equal.
-func isDulicateName(s1, s2 string) bool { return equal(s1, s2) }
+// isDuplicateName checks if the domain names s1 and s2 are equal.
+func isDuplicateName(s1, s2 string) bool { return equal(s1, s2) }

--- a/vendor/github.com/miekg/dns/duplicate_generate.go
+++ b/vendor/github.com/miekg/dns/duplicate_generate.go
@@ -57,10 +57,7 @@ func main() {
 			continue
 		}
 
-		if name == "PrivateRR" || name == "RFC3597" {
-			continue
-		}
-		if name == "OPT" || name == "ANY" || name == "IXFR" || name == "AXFR" {
+		if name == "PrivateRR" || name == "OPT" {
 			continue
 		}
 
@@ -69,22 +66,6 @@ func main() {
 
 	b := &bytes.Buffer{}
 	b.WriteString(packageHdr)
-
-	// Generate the giant switch that calls the correct function for each type.
-	fmt.Fprint(b, "// isDuplicateRdata calls the rdata specific functions\n")
-	fmt.Fprint(b, "func isDuplicateRdata(r1, r2 RR) bool {\n")
-	fmt.Fprint(b, "switch r1.Header().Rrtype {\n")
-
-	for _, name := range namedTypes {
-
-		o := scope.Lookup(name)
-		_, isEmbedded := getTypeStruct(o.Type(), scope)
-		if isEmbedded {
-			continue
-		}
-		fmt.Fprintf(b, "case Type%s:\nreturn isDuplicate%s(r1.(*%s), r2.(*%s))\n", name, name, name, name)
-	}
-	fmt.Fprintf(b, "}\nreturn false\n}\n")
 
 	// Generate the duplicate check for each type.
 	fmt.Fprint(b, "// isDuplicate() functions\n\n")
@@ -95,7 +76,10 @@ func main() {
 		if isEmbedded {
 			continue
 		}
-		fmt.Fprintf(b, "func isDuplicate%s(r1, r2 *%s) bool {\n", name, name)
+		fmt.Fprintf(b, "func (r1 *%s) isDuplicate(_r2 RR) bool {\n", name)
+		fmt.Fprintf(b, "r2, ok := _r2.(*%s)\n", name)
+		fmt.Fprint(b, "if !ok { return false }\n")
+		fmt.Fprint(b, "_ = r2\n")
 		for i := 1; i < st.NumFields(); i++ {
 			field := st.Field(i).Name()
 			o2 := func(s string) { fmt.Fprintf(b, s+"\n", field, field) }
@@ -103,12 +87,12 @@ func main() {
 
 			// For some reason, a and aaaa don't pop up as *types.Slice here (mostly like because the are
 			// *indirectly* defined as a slice in the net package).
-			if _, ok := st.Field(i).Type().(*types.Slice); ok || st.Tag(i) == `dns:"a"` || st.Tag(i) == `dns:"aaaa"` {
+			if _, ok := st.Field(i).Type().(*types.Slice); ok {
 				o2("if len(r1.%s) != len(r2.%s) {\nreturn false\n}")
 
 				if st.Tag(i) == `dns:"cdomain-name"` || st.Tag(i) == `dns:"domain-name"` {
 					o3(`for i := 0; i < len(r1.%s); i++ {
-						if !isDulicateName(r1.%s[i], r2.%s[i]) {
+						if !isDuplicateName(r1.%s[i], r2.%s[i]) {
 							return false
 						}
 					}`)
@@ -128,8 +112,10 @@ func main() {
 			switch st.Tag(i) {
 			case `dns:"-"`:
 				// ignored
+			case `dns:"a"`, `dns:"aaaa"`:
+				o2("if !r1.%s.Equal(r2.%s) {\nreturn false\n}")
 			case `dns:"cdomain-name"`, `dns:"domain-name"`:
-				o2("if !isDulicateName(r1.%s, r2.%s) {\nreturn false\n}")
+				o2("if !isDuplicateName(r1.%s, r2.%s) {\nreturn false\n}")
 			default:
 				o2("if r1.%s != r2.%s {\nreturn false\n}")
 			}

--- a/vendor/github.com/miekg/dns/edns.go
+++ b/vendor/github.com/miekg/dns/edns.go
@@ -80,13 +80,19 @@ func (rr *OPT) String() string {
 
 func (rr *OPT) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
-	for i := 0; i < len(rr.Option); i++ {
+	for _, o := range rr.Option {
 		l += 4 // Account for 2-byte option code and 2-byte option length.
-		lo, _ := rr.Option[i].pack()
+		lo, _ := o.pack()
 		l += len(lo)
 	}
 	return l
 }
+
+func (rr *OPT) parse(c *zlexer, origin string) *ParseError {
+	panic("dns: internal error: parse should never be called on OPT")
+}
+
+func (r1 *OPT) isDuplicate(r2 RR) bool { return false }
 
 // return the old value -> delete SetVersion?
 
@@ -153,6 +159,8 @@ type EDNS0 interface {
 	unpack([]byte) error
 	// String returns the string representation of the option.
 	String() string
+	// copy returns a deep-copy of the option.
+	copy() EDNS0
 }
 
 // EDNS0_NSID option is used to retrieve a nameserver
@@ -183,7 +191,8 @@ func (e *EDNS0_NSID) pack() ([]byte, error) {
 // Option implements the EDNS0 interface.
 func (e *EDNS0_NSID) Option() uint16        { return EDNS0NSID } // Option returns the option code.
 func (e *EDNS0_NSID) unpack(b []byte) error { e.Nsid = hex.EncodeToString(b); return nil }
-func (e *EDNS0_NSID) String() string        { return string(e.Nsid) }
+func (e *EDNS0_NSID) String() string        { return e.Nsid }
+func (e *EDNS0_NSID) copy() EDNS0           { return &EDNS0_NSID{e.Code, e.Nsid} }
 
 // EDNS0_SUBNET is the subnet option that is used to give the remote nameserver
 // an idea of where the client lives. See RFC 7871. It can then give back a different
@@ -301,6 +310,16 @@ func (e *EDNS0_SUBNET) String() (s string) {
 	return
 }
 
+func (e *EDNS0_SUBNET) copy() EDNS0 {
+	return &EDNS0_SUBNET{
+		e.Code,
+		e.Family,
+		e.SourceNetmask,
+		e.SourceScope,
+		e.Address,
+	}
+}
+
 // The EDNS0_COOKIE option is used to add a DNS Cookie to a message.
 //
 //	o := new(dns.OPT)
@@ -336,6 +355,7 @@ func (e *EDNS0_COOKIE) pack() ([]byte, error) {
 func (e *EDNS0_COOKIE) Option() uint16        { return EDNS0COOKIE }
 func (e *EDNS0_COOKIE) unpack(b []byte) error { e.Cookie = hex.EncodeToString(b); return nil }
 func (e *EDNS0_COOKIE) String() string        { return e.Cookie }
+func (e *EDNS0_COOKIE) copy() EDNS0           { return &EDNS0_COOKIE{e.Code, e.Cookie} }
 
 // The EDNS0_UL (Update Lease) (draft RFC) option is used to tell the server to set
 // an expiration on an update RR. This is helpful for clients that cannot clean
@@ -357,6 +377,7 @@ type EDNS0_UL struct {
 // Option implements the EDNS0 interface.
 func (e *EDNS0_UL) Option() uint16 { return EDNS0UL }
 func (e *EDNS0_UL) String() string { return strconv.FormatUint(uint64(e.Lease), 10) }
+func (e *EDNS0_UL) copy() EDNS0    { return &EDNS0_UL{e.Code, e.Lease} }
 
 // Copied: http://golang.org/src/pkg/net/dnsmsg.go
 func (e *EDNS0_UL) pack() ([]byte, error) {
@@ -411,9 +432,12 @@ func (e *EDNS0_LLQ) unpack(b []byte) error {
 
 func (e *EDNS0_LLQ) String() string {
 	s := strconv.FormatUint(uint64(e.Version), 10) + " " + strconv.FormatUint(uint64(e.Opcode), 10) +
-		" " + strconv.FormatUint(uint64(e.Error), 10) + " " + strconv.FormatUint(uint64(e.Id), 10) +
+		" " + strconv.FormatUint(uint64(e.Error), 10) + " " + strconv.FormatUint(e.Id, 10) +
 		" " + strconv.FormatUint(uint64(e.LeaseLife), 10)
 	return s
+}
+func (e *EDNS0_LLQ) copy() EDNS0 {
+	return &EDNS0_LLQ{e.Code, e.Version, e.Opcode, e.Error, e.Id, e.LeaseLife}
 }
 
 // EDNS0_DUA implements the EDNS0 "DNSSEC Algorithm Understood" option. See RFC 6975.
@@ -429,15 +453,16 @@ func (e *EDNS0_DAU) unpack(b []byte) error { e.AlgCode = b; return nil }
 
 func (e *EDNS0_DAU) String() string {
 	s := ""
-	for i := 0; i < len(e.AlgCode); i++ {
-		if a, ok := AlgorithmToString[e.AlgCode[i]]; ok {
+	for _, alg := range e.AlgCode {
+		if a, ok := AlgorithmToString[alg]; ok {
 			s += " " + a
 		} else {
-			s += " " + strconv.Itoa(int(e.AlgCode[i]))
+			s += " " + strconv.Itoa(int(alg))
 		}
 	}
 	return s
 }
+func (e *EDNS0_DAU) copy() EDNS0 { return &EDNS0_DAU{e.Code, e.AlgCode} }
 
 // EDNS0_DHU implements the EDNS0 "DS Hash Understood" option. See RFC 6975.
 type EDNS0_DHU struct {
@@ -452,15 +477,16 @@ func (e *EDNS0_DHU) unpack(b []byte) error { e.AlgCode = b; return nil }
 
 func (e *EDNS0_DHU) String() string {
 	s := ""
-	for i := 0; i < len(e.AlgCode); i++ {
-		if a, ok := HashToString[e.AlgCode[i]]; ok {
+	for _, alg := range e.AlgCode {
+		if a, ok := HashToString[alg]; ok {
 			s += " " + a
 		} else {
-			s += " " + strconv.Itoa(int(e.AlgCode[i]))
+			s += " " + strconv.Itoa(int(alg))
 		}
 	}
 	return s
 }
+func (e *EDNS0_DHU) copy() EDNS0 { return &EDNS0_DHU{e.Code, e.AlgCode} }
 
 // EDNS0_N3U implements the EDNS0 "NSEC3 Hash Understood" option. See RFC 6975.
 type EDNS0_N3U struct {
@@ -476,15 +502,16 @@ func (e *EDNS0_N3U) unpack(b []byte) error { e.AlgCode = b; return nil }
 func (e *EDNS0_N3U) String() string {
 	// Re-use the hash map
 	s := ""
-	for i := 0; i < len(e.AlgCode); i++ {
-		if a, ok := HashToString[e.AlgCode[i]]; ok {
+	for _, alg := range e.AlgCode {
+		if a, ok := HashToString[alg]; ok {
 			s += " " + a
 		} else {
-			s += " " + strconv.Itoa(int(e.AlgCode[i]))
+			s += " " + strconv.Itoa(int(alg))
 		}
 	}
 	return s
 }
+func (e *EDNS0_N3U) copy() EDNS0 { return &EDNS0_N3U{e.Code, e.AlgCode} }
 
 // EDNS0_EXPIRE implementes the EDNS0 option as described in RFC 7314.
 type EDNS0_EXPIRE struct {
@@ -495,13 +522,11 @@ type EDNS0_EXPIRE struct {
 // Option implements the EDNS0 interface.
 func (e *EDNS0_EXPIRE) Option() uint16 { return EDNS0EXPIRE }
 func (e *EDNS0_EXPIRE) String() string { return strconv.FormatUint(uint64(e.Expire), 10) }
+func (e *EDNS0_EXPIRE) copy() EDNS0    { return &EDNS0_EXPIRE{e.Code, e.Expire} }
 
 func (e *EDNS0_EXPIRE) pack() ([]byte, error) {
 	b := make([]byte, 4)
-	b[0] = byte(e.Expire >> 24)
-	b[1] = byte(e.Expire >> 16)
-	b[2] = byte(e.Expire >> 8)
-	b[3] = byte(e.Expire)
+	binary.BigEndian.PutUint32(b, e.Expire)
 	return b, nil
 }
 
@@ -535,6 +560,11 @@ type EDNS0_LOCAL struct {
 func (e *EDNS0_LOCAL) Option() uint16 { return e.Code }
 func (e *EDNS0_LOCAL) String() string {
 	return strconv.FormatInt(int64(e.Code), 10) + ":0x" + hex.EncodeToString(e.Data)
+}
+func (e *EDNS0_LOCAL) copy() EDNS0 {
+	b := make([]byte, len(e.Data))
+	copy(b, e.Data)
+	return &EDNS0_LOCAL{e.Code, b}
 }
 
 func (e *EDNS0_LOCAL) pack() ([]byte, error) {
@@ -608,6 +638,7 @@ func (e *EDNS0_TCP_KEEPALIVE) String() (s string) {
 	}
 	return
 }
+func (e *EDNS0_TCP_KEEPALIVE) copy() EDNS0 { return &EDNS0_TCP_KEEPALIVE{e.Code, e.Length, e.Timeout} }
 
 // EDNS0_PADDING option is used to add padding to a request/response. The default
 // value of padding SHOULD be 0x0 but other values MAY be used, for instance if
@@ -621,3 +652,8 @@ func (e *EDNS0_PADDING) Option() uint16        { return EDNS0PADDING }
 func (e *EDNS0_PADDING) pack() ([]byte, error) { return e.Padding, nil }
 func (e *EDNS0_PADDING) unpack(b []byte) error { e.Padding = b; return nil }
 func (e *EDNS0_PADDING) String() string        { return fmt.Sprintf("%0X", e.Padding) }
+func (e *EDNS0_PADDING) copy() EDNS0 {
+	b := make([]byte, len(e.Padding))
+	copy(b, e.Padding)
+	return &EDNS0_PADDING{b}
+}

--- a/vendor/github.com/miekg/dns/format.go
+++ b/vendor/github.com/miekg/dns/format.go
@@ -20,7 +20,7 @@ func Field(r RR, i int) string {
 		return ""
 	}
 	d := reflect.ValueOf(r).Elem().Field(i)
-	switch k := d.Kind(); k {
+	switch d.Kind() {
 	case reflect.String:
 		return d.String()
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
@@ -31,6 +31,9 @@ func Field(r RR, i int) string {
 		switch reflect.ValueOf(r).Elem().Type().Field(i).Tag {
 		case `dns:"a"`:
 			// TODO(miek): Hmm store this as 16 bytes
+			if d.Len() < net.IPv4len {
+				return ""
+			}
 			if d.Len() < net.IPv6len {
 				return net.IPv4(byte(d.Index(0).Uint()),
 					byte(d.Index(1).Uint()),
@@ -42,6 +45,9 @@ func Field(r RR, i int) string {
 				byte(d.Index(14).Uint()),
 				byte(d.Index(15).Uint())).String()
 		case `dns:"aaaa"`:
+			if d.Len() < net.IPv6len {
+				return ""
+			}
 			return net.IP{
 				byte(d.Index(0).Uint()),
 				byte(d.Index(1).Uint()),

--- a/vendor/github.com/miekg/dns/labels.go
+++ b/vendor/github.com/miekg/dns/labels.go
@@ -16,7 +16,7 @@ func SplitDomainName(s string) (labels []string) {
 	fqdnEnd := 0 // offset of the final '.' or the length of the name
 	idx := Split(s)
 	begin := 0
-	if s[len(s)-1] == '.' {
+	if IsFqdn(s) {
 		fqdnEnd = len(s) - 1
 	} else {
 		fqdnEnd = len(s)
@@ -28,16 +28,13 @@ func SplitDomainName(s string) (labels []string) {
 	case 1:
 		// no-op
 	default:
-		end := 0
-		for i := 1; i < len(idx); i++ {
-			end = idx[i]
+		for _, end := range idx[1:] {
 			labels = append(labels, s[begin:end-1])
 			begin = end
 		}
 	}
 
-	labels = append(labels, s[begin:fqdnEnd])
-	return labels
+	return append(labels, s[begin:fqdnEnd])
 }
 
 // CompareDomainName compares the names s1 and s2 and

--- a/vendor/github.com/miekg/dns/msg_helpers.go
+++ b/vendor/github.com/miekg/dns/msg_helpers.go
@@ -25,12 +25,13 @@ func unpackDataA(msg []byte, off int) (net.IP, int, error) {
 }
 
 func packDataA(a net.IP, msg []byte, off int) (int, error) {
-	// It must be a slice of 4, even if it is 16, we encode only the first 4
-	if off+net.IPv4len > len(msg) {
-		return len(msg), &Error{err: "overflow packing a"}
-	}
 	switch len(a) {
 	case net.IPv4len, net.IPv6len:
+		// It must be a slice of 4, even if it is 16, we encode only the first 4
+		if off+net.IPv4len > len(msg) {
+			return len(msg), &Error{err: "overflow packing a"}
+		}
+
 		copy(msg[off:], a.To4())
 		off += net.IPv4len
 	case 0:
@@ -51,12 +52,12 @@ func unpackDataAAAA(msg []byte, off int) (net.IP, int, error) {
 }
 
 func packDataAAAA(aaaa net.IP, msg []byte, off int) (int, error) {
-	if off+net.IPv6len > len(msg) {
-		return len(msg), &Error{err: "overflow packing aaaa"}
-	}
-
 	switch len(aaaa) {
 	case net.IPv6len:
+		if off+net.IPv6len > len(msg) {
+			return len(msg), &Error{err: "overflow packing aaaa"}
+		}
+
 		copy(msg[off:], aaaa)
 		off += net.IPv6len
 	case 0:
@@ -99,34 +100,34 @@ func unpackHeader(msg []byte, off int) (rr RR_Header, off1 int, truncmsg []byte,
 	return hdr, off, msg, err
 }
 
-// pack packs an RR header, returning the offset to the end of the header.
+// packHeader packs an RR header, returning the offset to the end of the header.
 // See PackDomainName for documentation about the compression.
-func (hdr RR_Header) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
+func (hdr RR_Header) packHeader(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	if off == len(msg) {
-		return off, off, nil
+		return off, nil
 	}
 
-	off, _, err := packDomainName(hdr.Name, msg, off, compression, compress)
+	off, err := packDomainName(hdr.Name, msg, off, compression, compress)
 	if err != nil {
-		return off, len(msg), err
+		return len(msg), err
 	}
 	off, err = packUint16(hdr.Rrtype, msg, off)
 	if err != nil {
-		return off, len(msg), err
+		return len(msg), err
 	}
 	off, err = packUint16(hdr.Class, msg, off)
 	if err != nil {
-		return off, len(msg), err
+		return len(msg), err
 	}
 	off, err = packUint32(hdr.Ttl, msg, off)
 	if err != nil {
-		return off, len(msg), err
+		return len(msg), err
 	}
 	off, err = packUint16(0, msg, off) // The RDLENGTH field will be set later in packRR.
 	if err != nil {
-		return off, len(msg), err
+		return len(msg), err
 	}
-	return off, off, nil
+	return off, nil
 }
 
 // helper helper functions.
@@ -177,14 +178,14 @@ func unpackUint8(msg []byte, off int) (i uint8, off1 int, err error) {
 	if off+1 > len(msg) {
 		return 0, len(msg), &Error{err: "overflow unpacking uint8"}
 	}
-	return uint8(msg[off]), off + 1, nil
+	return msg[off], off + 1, nil
 }
 
 func packUint8(i uint8, msg []byte, off int) (off1 int, err error) {
 	if off+1 > len(msg) {
 		return len(msg), &Error{err: "overflow packing uint8"}
 	}
-	msg[off] = byte(i)
+	msg[off] = i
 	return off + 1, nil
 }
 
@@ -363,6 +364,22 @@ func packStringHex(s string, msg []byte, off int) (int, error) {
 	return off, nil
 }
 
+func unpackStringAny(msg []byte, off, end int) (string, int, error) {
+	if end > len(msg) {
+		return "", len(msg), &Error{err: "overflow unpacking anything"}
+	}
+	return string(msg[off:end]), end, nil
+}
+
+func packStringAny(s string, msg []byte, off int) (int, error) {
+	if off+len(s) > len(msg) {
+		return len(msg), &Error{err: "overflow packing anything"}
+	}
+	copy(msg[off:off+len(s)], s)
+	off += len(s)
+	return off, nil
+}
+
 func unpackStringTxt(msg []byte, off int) ([]string, int, error) {
 	txt, off, err := unpackTxt(msg, off)
 	if err != nil {
@@ -383,7 +400,7 @@ func packStringTxt(s []string, msg []byte, off int) (int, error) {
 func unpackDataOpt(msg []byte, off int) ([]EDNS0, int, error) {
 	var edns []EDNS0
 Option:
-	code := uint16(0)
+	var code uint16
 	if off+4 > len(msg) {
 		return nil, len(msg), &Error{err: "overflow unpacking opt"}
 	}
@@ -478,7 +495,7 @@ Option:
 func packDataOpt(options []EDNS0, msg []byte, off int) (int, error) {
 	for _, el := range options {
 		b, err := el.pack()
-		if err != nil || off+3 > len(msg) {
+		if err != nil || off+4 > len(msg) {
 			return len(msg), &Error{err: "overflow packing opt"}
 		}
 		binary.BigEndian.PutUint16(msg[off:], el.Option())      // Option code
@@ -537,8 +554,7 @@ func unpackDataNsec(msg []byte, off int) ([]uint16, int, error) {
 		}
 
 		// Walk the bytes in the window and extract the type bits
-		for j := 0; j < length; j++ {
-			b := msg[off+j]
+		for j, b := range msg[off : off+length] {
 			// Check the bits one by one, and set the type
 			if b&0x80 == 0x80 {
 				nsec = append(nsec, uint16(window*256+j*8+0))
@@ -571,13 +587,35 @@ func unpackDataNsec(msg []byte, off int) ([]uint16, int, error) {
 	return nsec, off, nil
 }
 
+// typeBitMapLen is a helper function which computes the "maximum" length of
+// a the NSEC Type BitMap field.
+func typeBitMapLen(bitmap []uint16) int {
+	var l int
+	var lastwindow, lastlength uint16
+	for _, t := range bitmap {
+		window := t / 256
+		length := (t-window*256)/8 + 1
+		if window > lastwindow && lastlength != 0 { // New window, jump to the new offset
+			l += int(lastlength) + 2
+			lastlength = 0
+		}
+		if window < lastwindow || length < lastlength {
+			// packDataNsec would return Error{err: "nsec bits out of order"} here, but
+			// when computing the length, we want do be liberal.
+			continue
+		}
+		lastwindow, lastlength = window, length
+	}
+	l += int(lastlength) + 2
+	return l
+}
+
 func packDataNsec(bitmap []uint16, msg []byte, off int) (int, error) {
 	if len(bitmap) == 0 {
 		return off, nil
 	}
 	var lastwindow, lastlength uint16
-	for j := 0; j < len(bitmap); j++ {
-		t := bitmap[j]
+	for _, t := range bitmap {
 		window := t / 256
 		length := (t-window*256)/8 + 1
 		if window > lastwindow && lastlength != 0 { // New window, jump to the new offset
@@ -623,8 +661,8 @@ func unpackDataDomainNames(msg []byte, off, end int) ([]string, int, error) {
 
 func packDataDomainNames(names []string, msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	var err error
-	for j := 0; j < len(names); j++ {
-		off, _, err = packDomainName(names[j], msg, off, compression, compress)
+	for _, name := range names {
+		off, err = packDomainName(name, msg, off, compression, compress)
 		if err != nil {
 			return len(msg), err
 		}

--- a/vendor/github.com/miekg/dns/msg_truncate.go
+++ b/vendor/github.com/miekg/dns/msg_truncate.go
@@ -1,0 +1,111 @@
+package dns
+
+// Truncate ensures the reply message will fit into the requested buffer
+// size by removing records that exceed the requested size.
+//
+// It will first check if the reply fits without compression and then with
+// compression. If it won't fit with compression, Truncate then walks the
+// record adding as many records as possible without exceeding the
+// requested buffer size.
+//
+// The TC bit will be set if any records were excluded from the message.
+// This indicates to that the client should retry over TCP.
+//
+// According to RFC 2181, the TC bit should only be set if not all of the
+// "required" RRs can be included in the response. Unfortunately, we have
+// no way of knowing which RRs are required so we set the TC bit if any RR
+// had to be omitted from the response.
+//
+// The appropriate buffer size can be retrieved from the requests OPT
+// record, if present, and is transport specific otherwise. dns.MinMsgSize
+// should be used for UDP requests without an OPT record, and
+// dns.MaxMsgSize for TCP requests without an OPT record.
+func (dns *Msg) Truncate(size int) {
+	if dns.IsTsig() != nil {
+		// To simplify this implementation, we don't perform
+		// truncation on responses with a TSIG record.
+		return
+	}
+
+	// RFC 6891 mandates that the payload size in an OPT record
+	// less than 512 bytes must be treated as equal to 512 bytes.
+	//
+	// For ease of use, we impose that restriction here.
+	if size < 512 {
+		size = 512
+	}
+
+	l := msgLenWithCompressionMap(dns, nil) // uncompressed length
+	if l <= size {
+		// Don't waste effort compressing this message.
+		dns.Compress = false
+		return
+	}
+
+	dns.Compress = true
+
+	edns0 := dns.popEdns0()
+	if edns0 != nil {
+		// Account for the OPT record that gets added at the end,
+		// by subtracting that length from our budget.
+		//
+		// The EDNS(0) OPT record must have the root domain and
+		// it's length is thus unaffected by compression.
+		size -= Len(edns0)
+	}
+
+	compression := make(map[string]struct{})
+
+	l = headerSize
+	for _, r := range dns.Question {
+		l += r.len(l, compression)
+	}
+
+	var numAnswer int
+	if l < size {
+		l, numAnswer = truncateLoop(dns.Answer, size, l, compression)
+	}
+
+	var numNS int
+	if l < size {
+		l, numNS = truncateLoop(dns.Ns, size, l, compression)
+	}
+
+	var numExtra int
+	if l < size {
+		l, numExtra = truncateLoop(dns.Extra, size, l, compression)
+	}
+
+	// See the function documentation for when we set this.
+	dns.Truncated = len(dns.Answer) > numAnswer ||
+		len(dns.Ns) > numNS || len(dns.Extra) > numExtra
+
+	dns.Answer = dns.Answer[:numAnswer]
+	dns.Ns = dns.Ns[:numNS]
+	dns.Extra = dns.Extra[:numExtra]
+
+	if edns0 != nil {
+		// Add the OPT record back onto the additional section.
+		dns.Extra = append(dns.Extra, edns0)
+	}
+}
+
+func truncateLoop(rrs []RR, size, l int, compression map[string]struct{}) (int, int) {
+	for i, r := range rrs {
+		if r == nil {
+			continue
+		}
+
+		l += r.len(l, compression)
+		if l > size {
+			// Return size, rather than l prior to this record,
+			// to prevent any further records being added.
+			return size, i
+		}
+		if l == size {
+			return l, i + 1
+		}
+	}
+
+	return l, len(rrs)
+}

--- a/vendor/github.com/miekg/dns/privaterr.go
+++ b/vendor/github.com/miekg/dns/privaterr.go
@@ -1,9 +1,6 @@
 package dns
 
-import (
-	"fmt"
-	"strings"
-)
+import "strings"
 
 // PrivateRdata is an interface used for implementing "Private Use" RR types, see
 // RFC 6895. This allows one to experiment with new RR types, without requesting an
@@ -18,7 +15,7 @@ type PrivateRdata interface {
 	// Unpack is used when unpacking a private RR from a buffer.
 	// TODO(miek): diff. signature than Pack, see edns0.go for instance.
 	Unpack([]byte) (int, error)
-	// Copy copies the Rdata.
+	// Copy copies the Rdata into the PrivateRdata argument.
 	Copy(PrivateRdata) error
 	// Len returns the length in octets of the Rdata.
 	Len() int
@@ -29,21 +26,8 @@ type PrivateRdata interface {
 type PrivateRR struct {
 	Hdr  RR_Header
 	Data PrivateRdata
-}
 
-func mkPrivateRR(rrtype uint16) *PrivateRR {
-	// Panics if RR is not an instance of PrivateRR.
-	rrfunc, ok := TypeToRR[rrtype]
-	if !ok {
-		panic(fmt.Sprintf("dns: invalid operation with Private RR type %d", rrtype))
-	}
-
-	anyrr := rrfunc()
-	switch rr := anyrr.(type) {
-	case *PrivateRR:
-		return rr
-	}
-	panic(fmt.Sprintf("dns: RR is not a PrivateRR, TypeToRR[%d] generator returned %T", rrtype, anyrr))
+	generator func() PrivateRdata // for copy
 }
 
 // Header return the RR header of r.
@@ -60,82 +44,63 @@ func (r *PrivateRR) len(off int, compression map[string]struct{}) int {
 
 func (r *PrivateRR) copy() RR {
 	// make new RR like this:
-	rr := mkPrivateRR(r.Hdr.Rrtype)
-	rr.Hdr = r.Hdr
+	rr := &PrivateRR{r.Hdr, r.generator(), r.generator}
 
-	err := r.Data.Copy(rr.Data)
-	if err != nil {
-		panic("dns: got value that could not be used to copy Private rdata")
+	if err := r.Data.Copy(rr.Data); err != nil {
+		panic("dns: got value that could not be used to copy Private rdata: " + err.Error())
 	}
+
 	return rr
 }
 
-func (r *PrivateRR) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := r.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return off, off, err
-	}
+func (r *PrivateRR) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	n, err := r.Data.Pack(msg[off:])
 	if err != nil {
-		return headerEnd, len(msg), err
+		return len(msg), err
 	}
 	off += n
-	return headerEnd, off, nil
+	return off, nil
 }
+
+func (r *PrivateRR) unpack(msg []byte, off int) (int, error) {
+	off1, err := r.Data.Unpack(msg[off:])
+	off += off1
+	return off, err
+}
+
+func (r *PrivateRR) parse(c *zlexer, origin string) *ParseError {
+	var l lex
+	text := make([]string, 0, 2) // could be 0..N elements, median is probably 1
+Fetch:
+	for {
+		// TODO(miek): we could also be returning _QUOTE, this might or might not
+		// be an issue (basically parsing TXT becomes hard)
+		switch l, _ = c.Next(); l.value {
+		case zNewline, zEOF:
+			break Fetch
+		case zString:
+			text = append(text, l.token)
+		}
+	}
+
+	err := r.Data.Parse(text)
+	if err != nil {
+		return &ParseError{"", err.Error(), l}
+	}
+
+	return nil
+}
+
+func (r1 *PrivateRR) isDuplicate(r2 RR) bool { return false }
 
 // PrivateHandle registers a private resource record type. It requires
 // string and numeric representation of private RR type and generator function as argument.
 func PrivateHandle(rtypestr string, rtype uint16, generator func() PrivateRdata) {
 	rtypestr = strings.ToUpper(rtypestr)
 
-	TypeToRR[rtype] = func() RR { return &PrivateRR{RR_Header{}, generator()} }
+	TypeToRR[rtype] = func() RR { return &PrivateRR{RR_Header{}, generator(), generator} }
 	TypeToString[rtype] = rtypestr
 	StringToType[rtypestr] = rtype
-
-	typeToUnpack[rtype] = func(h RR_Header, msg []byte, off int) (RR, int, error) {
-		if noRdata(h) {
-			return &h, off, nil
-		}
-		var err error
-
-		rr := mkPrivateRR(h.Rrtype)
-		rr.Hdr = h
-
-		off1, err := rr.Data.Unpack(msg[off:])
-		off += off1
-		if err != nil {
-			return rr, off, err
-		}
-		return rr, off, err
-	}
-
-	setPrivateRR := func(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-		rr := mkPrivateRR(h.Rrtype)
-		rr.Hdr = h
-
-		var l lex
-		text := make([]string, 0, 2) // could be 0..N elements, median is probably 1
-	Fetch:
-		for {
-			// TODO(miek): we could also be returning _QUOTE, this might or might not
-			// be an issue (basically parsing TXT becomes hard)
-			switch l, _ = c.Next(); l.value {
-			case zNewline, zEOF:
-				break Fetch
-			case zString:
-				text = append(text, l.token)
-			}
-		}
-
-		err := rr.Data.Parse(text)
-		if err != nil {
-			return nil, &ParseError{f, err.Error(), l}, ""
-		}
-
-		return rr, nil, ""
-	}
-
-	typeToparserFunc[rtype] = parserFunc{setPrivateRR, true}
 }
 
 // PrivateHandleRemove removes definitions required to support private RR type.
@@ -144,8 +109,6 @@ func PrivateHandleRemove(rtype uint16) {
 	if ok {
 		delete(TypeToRR, rtype)
 		delete(TypeToString, rtype)
-		delete(typeToparserFunc, rtype)
 		delete(StringToType, rtypestr)
-		delete(typeToUnpack, rtype)
 	}
 }

--- a/vendor/github.com/miekg/dns/reverse.go
+++ b/vendor/github.com/miekg/dns/reverse.go
@@ -17,6 +17,15 @@ func init() {
 	StringToRcode["NOTIMPL"] = RcodeNotImplemented
 }
 
+// StringToAlgorithm is the reverse of AlgorithmToString.
+var StringToAlgorithm = reverseInt8(AlgorithmToString)
+
+// StringToHash is a map of names to hash IDs.
+var StringToHash = reverseInt8(HashToString)
+
+// StringToCertType is the reverseof CertTypeToString.
+var StringToCertType = reverseInt16(CertTypeToString)
+
 // Reverse a map
 func reverseInt8(m map[uint8]string) map[string]uint8 {
 	n := make(map[string]uint8, len(m))

--- a/vendor/github.com/miekg/dns/sanitize.go
+++ b/vendor/github.com/miekg/dns/sanitize.go
@@ -15,10 +15,11 @@ func Dedup(rrs []RR, m map[string]RR) []RR {
 	for _, r := range rrs {
 		key := normalizedString(r)
 		keys = append(keys, &key)
-		if _, ok := m[key]; ok {
+		if mr, ok := m[key]; ok {
 			// Shortest TTL wins.
-			if m[key].Header().Ttl > r.Header().Ttl {
-				m[key].Header().Ttl = r.Header().Ttl
+			rh, mrh := r.Header(), mr.Header()
+			if mrh.Ttl > rh.Ttl {
+				mrh.Ttl = rh.Ttl
 			}
 			continue
 		}

--- a/vendor/github.com/miekg/dns/scan.go
+++ b/vendor/github.com/miekg/dns/scan.go
@@ -79,13 +79,12 @@ func (e *ParseError) Error() (s string) {
 }
 
 type lex struct {
-	token   string // text of the token
-	err     bool   // when true, token text has lexer error
-	value   uint8  // value: zString, _BLANK, etc.
-	torc    uint16 // type or class as parsed in the lexer, we only need to look this up in the grammar
-	line    int    // line in the file
-	column  int    // column in the file
-	comment string // any comment text seen
+	token  string // text of the token
+	err    bool   // when true, token text has lexer error
+	value  uint8  // value: zString, _BLANK, etc.
+	torc   uint16 // type or class as parsed in the lexer, we only need to look this up in the grammar
+	line   int    // line in the file
+	column int    // column in the file
 }
 
 // Token holds the token that are returned when a zone file is parsed.
@@ -244,8 +243,6 @@ type ZoneParser struct {
 	sub    *ZoneParser
 	osFile *os.File
 
-	com string
-
 	includeDepth uint8
 
 	includeAllowed bool
@@ -318,12 +315,19 @@ func (zp *ZoneParser) setParseError(err string, l lex) (RR, bool) {
 // Comment returns an optional text comment that occurred alongside
 // the RR.
 func (zp *ZoneParser) Comment() string {
-	return zp.com
+	if zp.parseErr != nil {
+		return ""
+	}
+
+	if zp.sub != nil {
+		return zp.sub.Comment()
+	}
+
+	return zp.c.Comment()
 }
 
 func (zp *ZoneParser) subNext() (RR, bool) {
 	if rr, ok := zp.sub.Next(); ok {
-		zp.com = zp.sub.com
 		return rr, true
 	}
 
@@ -347,8 +351,6 @@ func (zp *ZoneParser) subNext() (RR, bool) {
 // error. After Next returns (nil, false), the Err method will return
 // any error that occurred during parsing.
 func (zp *ZoneParser) Next() (RR, bool) {
-	zp.com = ""
-
 	if zp.parseErr != nil {
 		return nil, false
 	}
@@ -501,9 +503,8 @@ func (zp *ZoneParser) Next() (RR, bool) {
 				return zp.setParseError("expecting $TTL value, not this...", l)
 			}
 
-			if e, _ := slurpRemainder(zp.c, zp.file); e != nil {
-				zp.parseErr = e
-				return nil, false
+			if err := slurpRemainder(zp.c); err != nil {
+				return zp.setParseError(err.err, err.lex)
 			}
 
 			ttl, ok := stringToTTL(l.token)
@@ -525,9 +526,8 @@ func (zp *ZoneParser) Next() (RR, bool) {
 				return zp.setParseError("expecting $ORIGIN value, not this...", l)
 			}
 
-			if e, _ := slurpRemainder(zp.c, zp.file); e != nil {
-				zp.parseErr = e
-				return nil, false
+			if err := slurpRemainder(zp.c); err != nil {
+				return zp.setParseError(err.err, err.lex)
 			}
 
 			name, ok := toAbsoluteName(l.token, zp.origin)
@@ -648,26 +648,62 @@ func (zp *ZoneParser) Next() (RR, bool) {
 
 			st = zExpectRdata
 		case zExpectRdata:
-			r, e, c1 := setRR(*h, zp.c, zp.origin, zp.file)
-			if e != nil {
-				// If e.lex is nil than we have encounter a unknown RR type
-				// in that case we substitute our current lex token
-				if e.lex.token == "" && e.lex.value == 0 {
-					e.lex = l // Uh, dirty
-				}
-
-				zp.parseErr = e
-				return nil, false
+			var rr RR
+			if newFn, ok := TypeToRR[h.Rrtype]; ok && canParseAsRR(h.Rrtype) {
+				rr = newFn()
+				*rr.Header() = *h
+			} else {
+				rr = &RFC3597{Hdr: *h}
 			}
 
-			zp.com = c1
-			return r, true
+			_, isPrivate := rr.(*PrivateRR)
+			if !isPrivate && zp.c.Peek().token == "" {
+				// This is a dynamic update rr.
+
+				// TODO(tmthrgd): Previously slurpRemainder was only called
+				// for certain RR types, which may have been important.
+				if err := slurpRemainder(zp.c); err != nil {
+					return zp.setParseError(err.err, err.lex)
+				}
+
+				return rr, true
+			} else if l.value == zNewline {
+				return zp.setParseError("unexpected newline", l)
+			}
+
+			if err := rr.parse(zp.c, zp.origin); err != nil {
+				// err is a concrete *ParseError without the file field set.
+				// The setParseError call below will construct a new
+				// *ParseError with file set to zp.file.
+
+				// If err.lex is nil than we have encounter an unknown RR type
+				// in that case we substitute our current lex token.
+				if err.lex == (lex{}) {
+					return zp.setParseError(err.err, l)
+				}
+
+				return zp.setParseError(err.err, err.lex)
+			}
+
+			return rr, true
 		}
 	}
 
 	// If we get here, we and the h.Rrtype is still zero, we haven't parsed anything, this
 	// is not an error, because an empty zone file is still a zone file.
 	return nil, false
+}
+
+// canParseAsRR returns true if the record type can be parsed as a
+// concrete RR. It blacklists certain record types that must be parsed
+// according to RFC 3597 because they lack a presentation format.
+func canParseAsRR(rrtype uint16) bool {
+	switch rrtype {
+	case TypeANY, TypeNULL, TypeOPT, TypeTSIG:
+		return false
+	default:
+		return true
+	}
 }
 
 type zlexer struct {
@@ -678,9 +714,11 @@ type zlexer struct {
 	line   int
 	column int
 
-	com string
+	comBuf  string
+	comment string
 
-	l lex
+	l       lex
+	cachedL *lex
 
 	brace  int
 	quote  bool
@@ -746,13 +784,37 @@ func (zl *zlexer) readByte() (byte, bool) {
 	return c, true
 }
 
+func (zl *zlexer) Peek() lex {
+	if zl.nextL {
+		return zl.l
+	}
+
+	l, ok := zl.Next()
+	if !ok {
+		return l
+	}
+
+	if zl.nextL {
+		// Cache l. Next returns zl.cachedL then zl.l.
+		zl.cachedL = &l
+	} else {
+		// In this case l == zl.l, so we just tell Next to return zl.l.
+		zl.nextL = true
+	}
+
+	return l
+}
+
 func (zl *zlexer) Next() (lex, bool) {
 	l := &zl.l
-	if zl.nextL {
+	switch {
+	case zl.cachedL != nil:
+		l, zl.cachedL = zl.cachedL, nil
+		return *l, true
+	case zl.nextL:
 		zl.nextL = false
 		return *l, true
-	}
-	if l.err {
+	case l.err:
 		// Parsing errors should be sticky.
 		return lex{value: zEOF}, false
 	}
@@ -767,14 +829,15 @@ func (zl *zlexer) Next() (lex, bool) {
 		escape bool
 	)
 
-	if zl.com != "" {
-		comi = copy(com[:], zl.com)
-		zl.com = ""
+	if zl.comBuf != "" {
+		comi = copy(com[:], zl.comBuf)
+		zl.comBuf = ""
 	}
+
+	zl.comment = ""
 
 	for x, ok := zl.readByte(); ok; x, ok = zl.readByte() {
 		l.line, l.column = zl.line, zl.column
-		l.comment = ""
 
 		if stri >= len(str) {
 			l.token = "token length insufficient for parsing"
@@ -898,7 +961,7 @@ func (zl *zlexer) Next() (lex, bool) {
 			}
 
 			zl.commt = true
-			zl.com = ""
+			zl.comBuf = ""
 
 			if comi > 1 {
 				// A newline was previously seen inside a comment that
@@ -911,7 +974,7 @@ func (zl *zlexer) Next() (lex, bool) {
 			comi++
 
 			if stri > 0 {
-				zl.com = string(com[:comi])
+				zl.comBuf = string(com[:comi])
 
 				l.value = zString
 				l.token = string(str[:stri])
@@ -947,11 +1010,11 @@ func (zl *zlexer) Next() (lex, bool) {
 
 					l.value = zNewline
 					l.token = "\n"
-					l.comment = string(com[:comi])
+					zl.comment = string(com[:comi])
 					return *l, true
 				}
 
-				zl.com = string(com[:comi])
+				zl.comBuf = string(com[:comi])
 				break
 			}
 
@@ -977,9 +1040,9 @@ func (zl *zlexer) Next() (lex, bool) {
 
 				l.value = zNewline
 				l.token = "\n"
-				l.comment = zl.com
 
-				zl.com = ""
+				zl.comment = zl.comBuf
+				zl.comBuf = ""
 				zl.rrtype = false
 				zl.owner = true
 
@@ -1115,7 +1178,7 @@ func (zl *zlexer) Next() (lex, bool) {
 		// Send remainder of com
 		l.value = zNewline
 		l.token = "\n"
-		l.comment = string(com[:comi])
+		zl.comment = string(com[:comi])
 
 		if retL != (lex{}) {
 			zl.nextL = true
@@ -1126,13 +1189,20 @@ func (zl *zlexer) Next() (lex, bool) {
 	}
 
 	if zl.brace != 0 {
-		l.comment = "" // in case there was left over string and comment
 		l.token = "unbalanced brace"
 		l.err = true
 		return *l, true
 	}
 
 	return lex{value: zEOF}, false
+}
+
+func (zl *zlexer) Comment() string {
+	if zl.l.err {
+		return ""
+	}
+
+	return zl.comment
 }
 
 // Extract the class number from CLASSxx
@@ -1163,8 +1233,7 @@ func typeToInt(token string) (uint16, bool) {
 
 // stringToTTL parses things like 2w, 2m, etc, and returns the time in seconds.
 func stringToTTL(token string) (uint32, bool) {
-	s := uint32(0)
-	i := uint32(0)
+	var s, i uint32
 	for _, c := range token {
 		switch c {
 		case 's', 'S':
@@ -1252,7 +1321,7 @@ func toAbsoluteName(name, origin string) (absolute string, ok bool) {
 	}
 
 	// check if name is already absolute
-	if name[len(name)-1] == '.' {
+	if IsFqdn(name) {
 		return name, true
 	}
 
@@ -1292,24 +1361,21 @@ func locCheckEast(token string, longitude uint32) (uint32, bool) {
 	return longitude, false
 }
 
-// "Eat" the rest of the "line". Return potential comments
-func slurpRemainder(c *zlexer, f string) (*ParseError, string) {
+// "Eat" the rest of the "line"
+func slurpRemainder(c *zlexer) *ParseError {
 	l, _ := c.Next()
-	com := ""
 	switch l.value {
 	case zBlank:
 		l, _ = c.Next()
-		com = l.comment
 		if l.value != zNewline && l.value != zEOF {
-			return &ParseError{f, "garbage after rdata", l}, ""
+			return &ParseError{"", "garbage after rdata", l}
 		}
 	case zNewline:
-		com = l.comment
 	case zEOF:
 	default:
-		return &ParseError{f, "garbage after rdata", l}, ""
+		return &ParseError{"", "garbage after rdata", l}
 	}
-	return nil, com
+	return nil
 }
 
 // Parse a 64 bit-like ipv6 address: "0014:4fff:ff20:ee64"

--- a/vendor/github.com/miekg/dns/scan_rr.go
+++ b/vendor/github.com/miekg/dns/scan_rr.go
@@ -7,70 +7,35 @@ import (
 	"strings"
 )
 
-type parserFunc struct {
-	// Func defines the function that parses the tokens and returns the RR
-	// or an error. The last string contains any comments in the line as
-	// they returned by the lexer as well.
-	Func func(h RR_Header, c *zlexer, origin string, file string) (RR, *ParseError, string)
-	// Signals if the RR ending is of variable length, like TXT or records
-	// that have Hexadecimal or Base64 as their last element in the Rdata. Records
-	// that have a fixed ending or for instance A, AAAA, SOA and etc.
-	Variable bool
-}
-
-// Parse the rdata of each rrtype.
-// All data from the channel c is either zString or zBlank.
-// After the rdata there may come a zBlank and then a zNewline
-// or immediately a zNewline. If this is not the case we flag
-// an *ParseError: garbage after rdata.
-func setRR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	parserfunc, ok := typeToparserFunc[h.Rrtype]
-	if ok {
-		r, e, cm := parserfunc.Func(h, c, o, f)
-		if parserfunc.Variable {
-			return r, e, cm
-		}
-		if e != nil {
-			return nil, e, ""
-		}
-		e, cm = slurpRemainder(c, f)
-		if e != nil {
-			return nil, e, ""
-		}
-		return r, nil, cm
-	}
-	// RFC3957 RR (Unknown RR handling)
-	return setRFC3597(h, c, o, f)
-}
-
 // A remainder of the rdata with embedded spaces, return the parsed string (sans the spaces)
 // or an error
-func endingToString(c *zlexer, errstr, f string) (string, *ParseError, string) {
-	s := ""
+func endingToString(c *zlexer, errstr string) (string, *ParseError) {
+	var s string
 	l, _ := c.Next() // zString
 	for l.value != zNewline && l.value != zEOF {
 		if l.err {
-			return s, &ParseError{f, errstr, l}, ""
+			return s, &ParseError{"", errstr, l}
 		}
 		switch l.value {
 		case zString:
 			s += l.token
 		case zBlank: // Ok
 		default:
-			return "", &ParseError{f, errstr, l}, ""
+			return "", &ParseError{"", errstr, l}
 		}
 		l, _ = c.Next()
 	}
-	return s, nil, l.comment
+
+	return s, nil
 }
 
 // A remainder of the rdata with embedded spaces, split on unquoted whitespace
 // and return the parsed string slice or an error
-func endingToTxtSlice(c *zlexer, errstr, f string) ([]string, *ParseError, string) {
+func endingToTxtSlice(c *zlexer, errstr string) ([]string, *ParseError) {
 	// Get the remaining data until we see a zNewline
 	l, _ := c.Next()
 	if l.err {
-		return nil, &ParseError{f, errstr, l}, ""
+		return nil, &ParseError{"", errstr, l}
 	}
 
 	// Build the slice
@@ -79,7 +44,7 @@ func endingToTxtSlice(c *zlexer, errstr, f string) ([]string, *ParseError, strin
 	empty := false
 	for l.value != zNewline && l.value != zEOF {
 		if l.err {
-			return nil, &ParseError{f, errstr, l}, ""
+			return nil, &ParseError{"", errstr, l}
 		}
 		switch l.value {
 		case zString:
@@ -106,7 +71,7 @@ func endingToTxtSlice(c *zlexer, errstr, f string) ([]string, *ParseError, strin
 		case zBlank:
 			if quote {
 				// zBlank can only be seen in between txt parts.
-				return nil, &ParseError{f, errstr, l}, ""
+				return nil, &ParseError{"", errstr, l}
 			}
 		case zQuote:
 			if empty && quote {
@@ -115,115 +80,79 @@ func endingToTxtSlice(c *zlexer, errstr, f string) ([]string, *ParseError, strin
 			quote = !quote
 			empty = true
 		default:
-			return nil, &ParseError{f, errstr, l}, ""
+			return nil, &ParseError{"", errstr, l}
 		}
 		l, _ = c.Next()
 	}
+
 	if quote {
-		return nil, &ParseError{f, errstr, l}, ""
+		return nil, &ParseError{"", errstr, l}
 	}
-	return s, nil, l.comment
+
+	return s, nil
 }
 
-func setA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(A)
-	rr.Hdr = h
-
+func (rr *A) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	rr.A = net.ParseIP(l.token)
-	if rr.A == nil || l.err {
-		return nil, &ParseError{f, "bad A A", l}, ""
+	// IPv4 addresses cannot include ":".
+	// We do this rather than use net.IP's To4() because
+	// To4() treats IPv4-mapped IPv6 addresses as being
+	// IPv4.
+	isIPv4 := !strings.Contains(l.token, ":")
+	if rr.A == nil || !isIPv4 || l.err {
+		return &ParseError{"", "bad A A", l}
 	}
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setAAAA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(AAAA)
-	rr.Hdr = h
-
+func (rr *AAAA) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	rr.AAAA = net.ParseIP(l.token)
-	if rr.AAAA == nil || l.err {
-		return nil, &ParseError{f, "bad AAAA AAAA", l}, ""
+	// IPv6 addresses must include ":", and IPv4
+	// addresses cannot include ":".
+	isIPv6 := strings.Contains(l.token, ":")
+	if rr.AAAA == nil || !isIPv6 || l.err {
+		return &ParseError{"", "bad AAAA AAAA", l}
 	}
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setNS(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(NS)
-	rr.Hdr = h
-
+func (rr *NS) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.Ns = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad NS Ns", l}, ""
+		return &ParseError{"", "bad NS Ns", l}
 	}
 	rr.Ns = name
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setPTR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(PTR)
-	rr.Hdr = h
-
+func (rr *PTR) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.Ptr = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad PTR Ptr", l}, ""
+		return &ParseError{"", "bad PTR Ptr", l}
 	}
 	rr.Ptr = name
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setNSAPPTR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(NSAPPTR)
-	rr.Hdr = h
-
+func (rr *NSAPPTR) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.Ptr = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad NSAP-PTR Ptr", l}, ""
+		return &ParseError{"", "bad NSAP-PTR Ptr", l}
 	}
 	rr.Ptr = name
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setRP(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(RP)
-	rr.Hdr = h
-
+func (rr *RP) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.Mbox = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	mbox, mboxOk := toAbsoluteName(l.token, o)
 	if l.err || !mboxOk {
-		return nil, &ParseError{f, "bad RP Mbox", l}, ""
+		return &ParseError{"", "bad RP Mbox", l}
 	}
 	rr.Mbox = mbox
 
@@ -233,78 +162,51 @@ func setRP(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 
 	txt, txtOk := toAbsoluteName(l.token, o)
 	if l.err || !txtOk {
-		return nil, &ParseError{f, "bad RP Txt", l}, ""
+		return &ParseError{"", "bad RP Txt", l}
 	}
 	rr.Txt = txt
 
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setMR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(MR)
-	rr.Hdr = h
-
+func (rr *MR) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.Mr = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad MR Mr", l}, ""
+		return &ParseError{"", "bad MR Mr", l}
 	}
 	rr.Mr = name
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setMB(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(MB)
-	rr.Hdr = h
-
+func (rr *MB) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.Mb = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad MB Mb", l}, ""
+		return &ParseError{"", "bad MB Mb", l}
 	}
 	rr.Mb = name
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setMG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(MG)
-	rr.Hdr = h
-
+func (rr *MG) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.Mg = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad MG Mg", l}, ""
+		return &ParseError{"", "bad MG Mg", l}
 	}
 	rr.Mg = name
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setHINFO(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(HINFO)
-	rr.Hdr = h
-
-	chunks, e, c1 := endingToTxtSlice(c, "bad HINFO Fields", f)
+func (rr *HINFO) parse(c *zlexer, o string) *ParseError {
+	chunks, e := endingToTxtSlice(c, "bad HINFO Fields")
 	if e != nil {
-		return nil, e, c1
+		return e
 	}
 
 	if ln := len(chunks); ln == 0 {
-		return rr, nil, ""
+		return nil
 	} else if ln == 1 {
 		// Can we split it?
 		if out := strings.Fields(chunks[0]); len(out) > 1 {
@@ -317,22 +219,14 @@ func setHINFO(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	rr.Cpu = chunks[0]
 	rr.Os = strings.Join(chunks[1:], " ")
 
-	return rr, nil, ""
+	return nil
 }
 
-func setMINFO(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(MINFO)
-	rr.Hdr = h
-
+func (rr *MINFO) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.Rmail = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	rmail, rmailOk := toAbsoluteName(l.token, o)
 	if l.err || !rmailOk {
-		return nil, &ParseError{f, "bad MINFO Rmail", l}, ""
+		return &ParseError{"", "bad MINFO Rmail", l}
 	}
 	rr.Rmail = rmail
 
@@ -342,61 +236,38 @@ func setMINFO(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 
 	email, emailOk := toAbsoluteName(l.token, o)
 	if l.err || !emailOk {
-		return nil, &ParseError{f, "bad MINFO Email", l}, ""
+		return &ParseError{"", "bad MINFO Email", l}
 	}
 	rr.Email = email
 
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setMF(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(MF)
-	rr.Hdr = h
-
+func (rr *MF) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.Mf = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad MF Mf", l}, ""
+		return &ParseError{"", "bad MF Mf", l}
 	}
 	rr.Mf = name
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setMD(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(MD)
-	rr.Hdr = h
-
+func (rr *MD) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.Md = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad MD Md", l}, ""
+		return &ParseError{"", "bad MD Md", l}
 	}
 	rr.Md = name
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setMX(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(MX)
-	rr.Hdr = h
-
+func (rr *MX) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad MX Pref", l}, ""
+		return &ParseError{"", "bad MX Pref", l}
 	}
 	rr.Preference = uint16(i)
 
@@ -406,25 +277,18 @@ func setMX(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad MX Mx", l}, ""
+		return &ParseError{"", "bad MX Mx", l}
 	}
 	rr.Mx = name
 
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setRT(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(RT)
-	rr.Hdr = h
-
+func (rr *RT) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil {
-		return nil, &ParseError{f, "bad RT Preference", l}, ""
+		return &ParseError{"", "bad RT Preference", l}
 	}
 	rr.Preference = uint16(i)
 
@@ -434,25 +298,18 @@ func setRT(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad RT Host", l}, ""
+		return &ParseError{"", "bad RT Host", l}
 	}
 	rr.Host = name
 
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setAFSDB(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(AFSDB)
-	rr.Hdr = h
-
+func (rr *AFSDB) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad AFSDB Subtype", l}, ""
+		return &ParseError{"", "bad AFSDB Subtype", l}
 	}
 	rr.Subtype = uint16(i)
 
@@ -462,40 +319,26 @@ func setAFSDB(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad AFSDB Hostname", l}, ""
+		return &ParseError{"", "bad AFSDB Hostname", l}
 	}
 	rr.Hostname = name
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setX25(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(X25)
-	rr.Hdr = h
-
+func (rr *X25) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	if l.err {
-		return nil, &ParseError{f, "bad X25 PSDNAddress", l}, ""
+		return &ParseError{"", "bad X25 PSDNAddress", l}
 	}
 	rr.PSDNAddress = l.token
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setKX(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(KX)
-	rr.Hdr = h
-
+func (rr *KX) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad KX Pref", l}, ""
+		return &ParseError{"", "bad KX Pref", l}
 	}
 	rr.Preference = uint16(i)
 
@@ -505,61 +348,37 @@ func setKX(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad KX Exchanger", l}, ""
+		return &ParseError{"", "bad KX Exchanger", l}
 	}
 	rr.Exchanger = name
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setCNAME(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(CNAME)
-	rr.Hdr = h
-
+func (rr *CNAME) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.Target = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad CNAME Target", l}, ""
+		return &ParseError{"", "bad CNAME Target", l}
 	}
 	rr.Target = name
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setDNAME(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(DNAME)
-	rr.Hdr = h
-
+func (rr *DNAME) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.Target = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad DNAME Target", l}, ""
+		return &ParseError{"", "bad DNAME Target", l}
 	}
 	rr.Target = name
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setSOA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(SOA)
-	rr.Hdr = h
-
+func (rr *SOA) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.Ns = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	ns, nsOk := toAbsoluteName(l.token, o)
 	if l.err || !nsOk {
-		return nil, &ParseError{f, "bad SOA Ns", l}, ""
+		return &ParseError{"", "bad SOA Ns", l}
 	}
 	rr.Ns = ns
 
@@ -569,7 +388,7 @@ func setSOA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 
 	mbox, mboxOk := toAbsoluteName(l.token, o)
 	if l.err || !mboxOk {
-		return nil, &ParseError{f, "bad SOA Mbox", l}, ""
+		return &ParseError{"", "bad SOA Mbox", l}
 	}
 	rr.Mbox = mbox
 
@@ -582,16 +401,16 @@ func setSOA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	for i := 0; i < 5; i++ {
 		l, _ = c.Next()
 		if l.err {
-			return nil, &ParseError{f, "bad SOA zone parameter", l}, ""
+			return &ParseError{"", "bad SOA zone parameter", l}
 		}
 		if j, e := strconv.ParseUint(l.token, 10, 32); e != nil {
 			if i == 0 {
 				// Serial must be a number
-				return nil, &ParseError{f, "bad SOA zone parameter", l}, ""
+				return &ParseError{"", "bad SOA zone parameter", l}
 			}
 			// We allow other fields to be unitful duration strings
 			if v, ok = stringToTTL(l.token); !ok {
-				return nil, &ParseError{f, "bad SOA zone parameter", l}, ""
+				return &ParseError{"", "bad SOA zone parameter", l}
 
 			}
 		} else {
@@ -614,21 +433,14 @@ func setSOA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 			rr.Minttl = v
 		}
 	}
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setSRV(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(SRV)
-	rr.Hdr = h
-
+func (rr *SRV) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad SRV Priority", l}, ""
+		return &ParseError{"", "bad SRV Priority", l}
 	}
 	rr.Priority = uint16(i)
 
@@ -636,7 +448,7 @@ func setSRV(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	l, _ = c.Next() // zString
 	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad SRV Weight", l}, ""
+		return &ParseError{"", "bad SRV Weight", l}
 	}
 	rr.Weight = uint16(i)
 
@@ -644,7 +456,7 @@ func setSRV(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	l, _ = c.Next() // zString
 	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad SRV Port", l}, ""
+		return &ParseError{"", "bad SRV Port", l}
 	}
 	rr.Port = uint16(i)
 
@@ -654,24 +466,17 @@ func setSRV(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad SRV Target", l}, ""
+		return &ParseError{"", "bad SRV Target", l}
 	}
 	rr.Target = name
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setNAPTR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(NAPTR)
-	rr.Hdr = h
-
+func (rr *NAPTR) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad NAPTR Order", l}, ""
+		return &ParseError{"", "bad NAPTR Order", l}
 	}
 	rr.Order = uint16(i)
 
@@ -679,7 +484,7 @@ func setNAPTR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	l, _ = c.Next() // zString
 	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad NAPTR Preference", l}, ""
+		return &ParseError{"", "bad NAPTR Preference", l}
 	}
 	rr.Preference = uint16(i)
 
@@ -687,57 +492,57 @@ func setNAPTR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	c.Next()        // zBlank
 	l, _ = c.Next() // _QUOTE
 	if l.value != zQuote {
-		return nil, &ParseError{f, "bad NAPTR Flags", l}, ""
+		return &ParseError{"", "bad NAPTR Flags", l}
 	}
 	l, _ = c.Next() // Either String or Quote
 	if l.value == zString {
 		rr.Flags = l.token
 		l, _ = c.Next() // _QUOTE
 		if l.value != zQuote {
-			return nil, &ParseError{f, "bad NAPTR Flags", l}, ""
+			return &ParseError{"", "bad NAPTR Flags", l}
 		}
 	} else if l.value == zQuote {
 		rr.Flags = ""
 	} else {
-		return nil, &ParseError{f, "bad NAPTR Flags", l}, ""
+		return &ParseError{"", "bad NAPTR Flags", l}
 	}
 
 	// Service
 	c.Next()        // zBlank
 	l, _ = c.Next() // _QUOTE
 	if l.value != zQuote {
-		return nil, &ParseError{f, "bad NAPTR Service", l}, ""
+		return &ParseError{"", "bad NAPTR Service", l}
 	}
 	l, _ = c.Next() // Either String or Quote
 	if l.value == zString {
 		rr.Service = l.token
 		l, _ = c.Next() // _QUOTE
 		if l.value != zQuote {
-			return nil, &ParseError{f, "bad NAPTR Service", l}, ""
+			return &ParseError{"", "bad NAPTR Service", l}
 		}
 	} else if l.value == zQuote {
 		rr.Service = ""
 	} else {
-		return nil, &ParseError{f, "bad NAPTR Service", l}, ""
+		return &ParseError{"", "bad NAPTR Service", l}
 	}
 
 	// Regexp
 	c.Next()        // zBlank
 	l, _ = c.Next() // _QUOTE
 	if l.value != zQuote {
-		return nil, &ParseError{f, "bad NAPTR Regexp", l}, ""
+		return &ParseError{"", "bad NAPTR Regexp", l}
 	}
 	l, _ = c.Next() // Either String or Quote
 	if l.value == zString {
 		rr.Regexp = l.token
 		l, _ = c.Next() // _QUOTE
 		if l.value != zQuote {
-			return nil, &ParseError{f, "bad NAPTR Regexp", l}, ""
+			return &ParseError{"", "bad NAPTR Regexp", l}
 		}
 	} else if l.value == zQuote {
 		rr.Regexp = ""
 	} else {
-		return nil, &ParseError{f, "bad NAPTR Regexp", l}, ""
+		return &ParseError{"", "bad NAPTR Regexp", l}
 	}
 
 	// After quote no space??
@@ -747,25 +552,17 @@ func setNAPTR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad NAPTR Replacement", l}, ""
+		return &ParseError{"", "bad NAPTR Replacement", l}
 	}
 	rr.Replacement = name
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setTALINK(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(TALINK)
-	rr.Hdr = h
-
+func (rr *TALINK) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.PreviousName = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	previousName, previousNameOk := toAbsoluteName(l.token, o)
 	if l.err || !previousNameOk {
-		return nil, &ParseError{f, "bad TALINK PreviousName", l}, ""
+		return &ParseError{"", "bad TALINK PreviousName", l}
 	}
 	rr.PreviousName = previousName
 
@@ -775,16 +572,14 @@ func setTALINK(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 
 	nextName, nextNameOk := toAbsoluteName(l.token, o)
 	if l.err || !nextNameOk {
-		return nil, &ParseError{f, "bad TALINK NextName", l}, ""
+		return &ParseError{"", "bad TALINK NextName", l}
 	}
 	rr.NextName = nextName
 
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setLOC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(LOC)
-	rr.Hdr = h
+func (rr *LOC) parse(c *zlexer, o string) *ParseError {
 	// Non zero defaults for LOC record, see RFC 1876, Section 3.
 	rr.HorizPre = 165 // 10000
 	rr.VertPre = 162  // 10
@@ -793,12 +588,9 @@ func setLOC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 
 	// North
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
 	i, e := strconv.ParseUint(l.token, 10, 32)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad LOC Latitude", l}, ""
+		return &ParseError{"", "bad LOC Latitude", l}
 	}
 	rr.Latitude = 1000 * 60 * 60 * uint32(i)
 
@@ -810,14 +602,14 @@ func setLOC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	}
 	i, e = strconv.ParseUint(l.token, 10, 32)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad LOC Latitude minutes", l}, ""
+		return &ParseError{"", "bad LOC Latitude minutes", l}
 	}
 	rr.Latitude += 1000 * 60 * uint32(i)
 
 	c.Next() // zBlank
 	l, _ = c.Next()
 	if i, e := strconv.ParseFloat(l.token, 32); e != nil || l.err {
-		return nil, &ParseError{f, "bad LOC Latitude seconds", l}, ""
+		return &ParseError{"", "bad LOC Latitude seconds", l}
 	} else {
 		rr.Latitude += uint32(1000 * i)
 	}
@@ -828,14 +620,14 @@ func setLOC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 		goto East
 	}
 	// If still alive, flag an error
-	return nil, &ParseError{f, "bad LOC Latitude North/South", l}, ""
+	return &ParseError{"", "bad LOC Latitude North/South", l}
 
 East:
 	// East
 	c.Next() // zBlank
 	l, _ = c.Next()
 	if i, e := strconv.ParseUint(l.token, 10, 32); e != nil || l.err {
-		return nil, &ParseError{f, "bad LOC Longitude", l}, ""
+		return &ParseError{"", "bad LOC Longitude", l}
 	} else {
 		rr.Longitude = 1000 * 60 * 60 * uint32(i)
 	}
@@ -846,14 +638,14 @@ East:
 		goto Altitude
 	}
 	if i, e := strconv.ParseUint(l.token, 10, 32); e != nil || l.err {
-		return nil, &ParseError{f, "bad LOC Longitude minutes", l}, ""
+		return &ParseError{"", "bad LOC Longitude minutes", l}
 	} else {
 		rr.Longitude += 1000 * 60 * uint32(i)
 	}
 	c.Next() // zBlank
 	l, _ = c.Next()
 	if i, e := strconv.ParseFloat(l.token, 32); e != nil || l.err {
-		return nil, &ParseError{f, "bad LOC Longitude seconds", l}, ""
+		return &ParseError{"", "bad LOC Longitude seconds", l}
 	} else {
 		rr.Longitude += uint32(1000 * i)
 	}
@@ -864,19 +656,19 @@ East:
 		goto Altitude
 	}
 	// If still alive, flag an error
-	return nil, &ParseError{f, "bad LOC Longitude East/West", l}, ""
+	return &ParseError{"", "bad LOC Longitude East/West", l}
 
 Altitude:
 	c.Next() // zBlank
 	l, _ = c.Next()
 	if len(l.token) == 0 || l.err {
-		return nil, &ParseError{f, "bad LOC Altitude", l}, ""
+		return &ParseError{"", "bad LOC Altitude", l}
 	}
 	if l.token[len(l.token)-1] == 'M' || l.token[len(l.token)-1] == 'm' {
 		l.token = l.token[0 : len(l.token)-1]
 	}
 	if i, e := strconv.ParseFloat(l.token, 32); e != nil {
-		return nil, &ParseError{f, "bad LOC Altitude", l}, ""
+		return &ParseError{"", "bad LOC Altitude", l}
 	} else {
 		rr.Altitude = uint32(i*100.0 + 10000000.0 + 0.5)
 	}
@@ -891,19 +683,19 @@ Altitude:
 			case 0: // Size
 				e, m, ok := stringToCm(l.token)
 				if !ok {
-					return nil, &ParseError{f, "bad LOC Size", l}, ""
+					return &ParseError{"", "bad LOC Size", l}
 				}
 				rr.Size = e&0x0f | m<<4&0xf0
 			case 1: // HorizPre
 				e, m, ok := stringToCm(l.token)
 				if !ok {
-					return nil, &ParseError{f, "bad LOC HorizPre", l}, ""
+					return &ParseError{"", "bad LOC HorizPre", l}
 				}
 				rr.HorizPre = e&0x0f | m<<4&0xf0
 			case 2: // VertPre
 				e, m, ok := stringToCm(l.token)
 				if !ok {
-					return nil, &ParseError{f, "bad LOC VertPre", l}, ""
+					return &ParseError{"", "bad LOC VertPre", l}
 				}
 				rr.VertPre = e&0x0f | m<<4&0xf0
 			}
@@ -911,33 +703,26 @@ Altitude:
 		case zBlank:
 			// Ok
 		default:
-			return nil, &ParseError{f, "bad LOC Size, HorizPre or VertPre", l}, ""
+			return &ParseError{"", "bad LOC Size, HorizPre or VertPre", l}
 		}
 		l, _ = c.Next()
 	}
-	return rr, nil, ""
+	return nil
 }
 
-func setHIP(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(HIP)
-	rr.Hdr = h
-
+func (rr *HIP) parse(c *zlexer, o string) *ParseError {
 	// HitLength is not represented
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, l.comment
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad HIP PublicKeyAlgorithm", l}, ""
+		return &ParseError{"", "bad HIP PublicKeyAlgorithm", l}
 	}
 	rr.PublicKeyAlgorithm = uint8(i)
 
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	if len(l.token) == 0 || l.err {
-		return nil, &ParseError{f, "bad HIP Hit", l}, ""
+		return &ParseError{"", "bad HIP Hit", l}
 	}
 	rr.Hit = l.token // This can not contain spaces, see RFC 5205 Section 6.
 	rr.HitLength = uint8(len(rr.Hit)) / 2
@@ -945,7 +730,7 @@ func setHIP(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	if len(l.token) == 0 || l.err {
-		return nil, &ParseError{f, "bad HIP PublicKey", l}, ""
+		return &ParseError{"", "bad HIP PublicKey", l}
 	}
 	rr.PublicKey = l.token // This cannot contain spaces
 	rr.PublicKeyLength = uint16(base64.StdEncoding.DecodedLen(len(rr.PublicKey)))
@@ -958,33 +743,27 @@ func setHIP(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 		case zString:
 			name, nameOk := toAbsoluteName(l.token, o)
 			if l.err || !nameOk {
-				return nil, &ParseError{f, "bad HIP RendezvousServers", l}, ""
+				return &ParseError{"", "bad HIP RendezvousServers", l}
 			}
 			xs = append(xs, name)
 		case zBlank:
 			// Ok
 		default:
-			return nil, &ParseError{f, "bad HIP RendezvousServers", l}, ""
+			return &ParseError{"", "bad HIP RendezvousServers", l}
 		}
 		l, _ = c.Next()
 	}
+
 	rr.RendezvousServers = xs
-	return rr, nil, l.comment
+	return nil
 }
 
-func setCERT(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(CERT)
-	rr.Hdr = h
-
+func (rr *CERT) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, l.comment
-	}
-
 	if v, ok := StringToCertType[l.token]; ok {
 		rr.Type = v
 	} else if i, e := strconv.ParseUint(l.token, 10, 16); e != nil {
-		return nil, &ParseError{f, "bad CERT Type", l}, ""
+		return &ParseError{"", "bad CERT Type", l}
 	} else {
 		rr.Type = uint16(i)
 	}
@@ -992,7 +771,7 @@ func setCERT(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	l, _ = c.Next() // zString
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad CERT KeyTag", l}, ""
+		return &ParseError{"", "bad CERT KeyTag", l}
 	}
 	rr.KeyTag = uint16(i)
 	c.Next()        // zBlank
@@ -1000,42 +779,33 @@ func setCERT(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	if v, ok := StringToAlgorithm[l.token]; ok {
 		rr.Algorithm = v
 	} else if i, e := strconv.ParseUint(l.token, 10, 8); e != nil {
-		return nil, &ParseError{f, "bad CERT Algorithm", l}, ""
+		return &ParseError{"", "bad CERT Algorithm", l}
 	} else {
 		rr.Algorithm = uint8(i)
 	}
-	s, e1, c1 := endingToString(c, "bad CERT Certificate", f)
+	s, e1 := endingToString(c, "bad CERT Certificate")
 	if e1 != nil {
-		return nil, e1, c1
+		return e1
 	}
 	rr.Certificate = s
-	return rr, nil, c1
+	return nil
 }
 
-func setOPENPGPKEY(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(OPENPGPKEY)
-	rr.Hdr = h
-
-	s, e, c1 := endingToString(c, "bad OPENPGPKEY PublicKey", f)
+func (rr *OPENPGPKEY) parse(c *zlexer, o string) *ParseError {
+	s, e := endingToString(c, "bad OPENPGPKEY PublicKey")
 	if e != nil {
-		return nil, e, c1
+		return e
 	}
 	rr.PublicKey = s
-	return rr, nil, c1
+	return nil
 }
 
-func setCSYNC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(CSYNC)
-	rr.Hdr = h
-
+func (rr *CSYNC) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, l.comment
-	}
 	j, e := strconv.ParseUint(l.token, 10, 32)
 	if e != nil {
 		// Serial must be a number
-		return nil, &ParseError{f, "bad CSYNC serial", l}, ""
+		return &ParseError{"", "bad CSYNC serial", l}
 	}
 	rr.Serial = uint32(j)
 
@@ -1045,7 +815,7 @@ func setCSYNC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	j, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil {
 		// Serial must be a number
-		return nil, &ParseError{f, "bad CSYNC flags", l}, ""
+		return &ParseError{"", "bad CSYNC flags", l}
 	}
 	rr.Flags = uint16(j)
 
@@ -1063,45 +833,34 @@ func setCSYNC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 			tokenUpper := strings.ToUpper(l.token)
 			if k, ok = StringToType[tokenUpper]; !ok {
 				if k, ok = typeToInt(l.token); !ok {
-					return nil, &ParseError{f, "bad CSYNC TypeBitMap", l}, ""
+					return &ParseError{"", "bad CSYNC TypeBitMap", l}
 				}
 			}
 			rr.TypeBitMap = append(rr.TypeBitMap, k)
 		default:
-			return nil, &ParseError{f, "bad CSYNC TypeBitMap", l}, ""
+			return &ParseError{"", "bad CSYNC TypeBitMap", l}
 		}
 		l, _ = c.Next()
 	}
-	return rr, nil, l.comment
+	return nil
 }
 
-func setSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	r, e, s := setRRSIG(h, c, o, f)
-	if r != nil {
-		return &SIG{*r.(*RRSIG)}, e, s
-	}
-	return nil, e, s
+func (rr *SIG) parse(c *zlexer, o string) *ParseError {
+	return rr.RRSIG.parse(c, o)
 }
 
-func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(RRSIG)
-	rr.Hdr = h
-
+func (rr *RRSIG) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, l.comment
-	}
-
 	tokenUpper := strings.ToUpper(l.token)
 	if t, ok := StringToType[tokenUpper]; !ok {
 		if strings.HasPrefix(tokenUpper, "TYPE") {
 			t, ok = typeToInt(l.token)
 			if !ok {
-				return nil, &ParseError{f, "bad RRSIG Typecovered", l}, ""
+				return &ParseError{"", "bad RRSIG Typecovered", l}
 			}
 			rr.TypeCovered = t
 		} else {
-			return nil, &ParseError{f, "bad RRSIG Typecovered", l}, ""
+			return &ParseError{"", "bad RRSIG Typecovered", l}
 		}
 	} else {
 		rr.TypeCovered = t
@@ -1111,7 +870,7 @@ func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	l, _ = c.Next()
 	i, err := strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
-		return nil, &ParseError{f, "bad RRSIG Algorithm", l}, ""
+		return &ParseError{"", "bad RRSIG Algorithm", l}
 	}
 	rr.Algorithm = uint8(i)
 
@@ -1119,7 +878,7 @@ func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	l, _ = c.Next()
 	i, err = strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
-		return nil, &ParseError{f, "bad RRSIG Labels", l}, ""
+		return &ParseError{"", "bad RRSIG Labels", l}
 	}
 	rr.Labels = uint8(i)
 
@@ -1127,7 +886,7 @@ func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	l, _ = c.Next()
 	i, err = strconv.ParseUint(l.token, 10, 32)
 	if err != nil || l.err {
-		return nil, &ParseError{f, "bad RRSIG OrigTtl", l}, ""
+		return &ParseError{"", "bad RRSIG OrigTtl", l}
 	}
 	rr.OrigTtl = uint32(i)
 
@@ -1139,7 +898,7 @@ func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 			// TODO(miek): error out on > MAX_UINT32, same below
 			rr.Expiration = uint32(i)
 		} else {
-			return nil, &ParseError{f, "bad RRSIG Expiration", l}, ""
+			return &ParseError{"", "bad RRSIG Expiration", l}
 		}
 	} else {
 		rr.Expiration = i
@@ -1151,7 +910,7 @@ func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 		if i, err := strconv.ParseInt(l.token, 10, 64); err == nil {
 			rr.Inception = uint32(i)
 		} else {
-			return nil, &ParseError{f, "bad RRSIG Inception", l}, ""
+			return &ParseError{"", "bad RRSIG Inception", l}
 		}
 	} else {
 		rr.Inception = i
@@ -1161,7 +920,7 @@ func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	l, _ = c.Next()
 	i, err = strconv.ParseUint(l.token, 10, 16)
 	if err != nil || l.err {
-		return nil, &ParseError{f, "bad RRSIG KeyTag", l}, ""
+		return &ParseError{"", "bad RRSIG KeyTag", l}
 	}
 	rr.KeyTag = uint16(i)
 
@@ -1170,32 +929,24 @@ func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	rr.SignerName = l.token
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad RRSIG SignerName", l}, ""
+		return &ParseError{"", "bad RRSIG SignerName", l}
 	}
 	rr.SignerName = name
 
-	s, e, c1 := endingToString(c, "bad RRSIG Signature", f)
+	s, e := endingToString(c, "bad RRSIG Signature")
 	if e != nil {
-		return nil, e, c1
+		return e
 	}
 	rr.Signature = s
 
-	return rr, nil, c1
+	return nil
 }
 
-func setNSEC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(NSEC)
-	rr.Hdr = h
-
+func (rr *NSEC) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	rr.NextDomain = l.token
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, l.comment
-	}
-
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad NSEC NextDomain", l}, ""
+		return &ParseError{"", "bad NSEC NextDomain", l}
 	}
 	rr.NextDomain = name
 
@@ -1213,50 +964,43 @@ func setNSEC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 			tokenUpper := strings.ToUpper(l.token)
 			if k, ok = StringToType[tokenUpper]; !ok {
 				if k, ok = typeToInt(l.token); !ok {
-					return nil, &ParseError{f, "bad NSEC TypeBitMap", l}, ""
+					return &ParseError{"", "bad NSEC TypeBitMap", l}
 				}
 			}
 			rr.TypeBitMap = append(rr.TypeBitMap, k)
 		default:
-			return nil, &ParseError{f, "bad NSEC TypeBitMap", l}, ""
+			return &ParseError{"", "bad NSEC TypeBitMap", l}
 		}
 		l, _ = c.Next()
 	}
-	return rr, nil, l.comment
+	return nil
 }
 
-func setNSEC3(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(NSEC3)
-	rr.Hdr = h
-
+func (rr *NSEC3) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, l.comment
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad NSEC3 Hash", l}, ""
+		return &ParseError{"", "bad NSEC3 Hash", l}
 	}
 	rr.Hash = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad NSEC3 Flags", l}, ""
+		return &ParseError{"", "bad NSEC3 Flags", l}
 	}
 	rr.Flags = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad NSEC3 Iterations", l}, ""
+		return &ParseError{"", "bad NSEC3 Iterations", l}
 	}
 	rr.Iterations = uint16(i)
 	c.Next()
 	l, _ = c.Next()
 	if len(l.token) == 0 || l.err {
-		return nil, &ParseError{f, "bad NSEC3 Salt", l}, ""
+		return &ParseError{"", "bad NSEC3 Salt", l}
 	}
 	if l.token != "-" {
 		rr.SaltLength = uint8(len(l.token)) / 2
@@ -1266,7 +1010,7 @@ func setNSEC3(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	c.Next()
 	l, _ = c.Next()
 	if len(l.token) == 0 || l.err {
-		return nil, &ParseError{f, "bad NSEC3 NextDomain", l}, ""
+		return &ParseError{"", "bad NSEC3 NextDomain", l}
 	}
 	rr.HashLength = 20 // Fix for NSEC3 (sha1 160 bits)
 	rr.NextDomain = l.token
@@ -1285,44 +1029,37 @@ func setNSEC3(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 			tokenUpper := strings.ToUpper(l.token)
 			if k, ok = StringToType[tokenUpper]; !ok {
 				if k, ok = typeToInt(l.token); !ok {
-					return nil, &ParseError{f, "bad NSEC3 TypeBitMap", l}, ""
+					return &ParseError{"", "bad NSEC3 TypeBitMap", l}
 				}
 			}
 			rr.TypeBitMap = append(rr.TypeBitMap, k)
 		default:
-			return nil, &ParseError{f, "bad NSEC3 TypeBitMap", l}, ""
+			return &ParseError{"", "bad NSEC3 TypeBitMap", l}
 		}
 		l, _ = c.Next()
 	}
-	return rr, nil, l.comment
+	return nil
 }
 
-func setNSEC3PARAM(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(NSEC3PARAM)
-	rr.Hdr = h
-
+func (rr *NSEC3PARAM) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad NSEC3PARAM Hash", l}, ""
+		return &ParseError{"", "bad NSEC3PARAM Hash", l}
 	}
 	rr.Hash = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad NSEC3PARAM Flags", l}, ""
+		return &ParseError{"", "bad NSEC3PARAM Flags", l}
 	}
 	rr.Flags = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad NSEC3PARAM Iterations", l}, ""
+		return &ParseError{"", "bad NSEC3PARAM Iterations", l}
 	}
 	rr.Iterations = uint16(i)
 	c.Next()
@@ -1331,20 +1068,13 @@ func setNSEC3PARAM(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string
 		rr.SaltLength = uint8(len(l.token))
 		rr.Salt = l.token
 	}
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setEUI48(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(EUI48)
-	rr.Hdr = h
-
+func (rr *EUI48) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	if len(l.token) != 17 || l.err {
-		return nil, &ParseError{f, "bad EUI48 Address", l}, ""
+		return &ParseError{"", "bad EUI48 Address", l}
 	}
 	addr := make([]byte, 12)
 	dash := 0
@@ -1353,7 +1083,7 @@ func setEUI48(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 		addr[i+1] = l.token[i+1+dash]
 		dash++
 		if l.token[i+1+dash] != '-' {
-			return nil, &ParseError{f, "bad EUI48 Address", l}, ""
+			return &ParseError{"", "bad EUI48 Address", l}
 		}
 	}
 	addr[10] = l.token[15]
@@ -1361,23 +1091,16 @@ func setEUI48(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 
 	i, e := strconv.ParseUint(string(addr), 16, 48)
 	if e != nil {
-		return nil, &ParseError{f, "bad EUI48 Address", l}, ""
+		return &ParseError{"", "bad EUI48 Address", l}
 	}
 	rr.Address = i
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setEUI64(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(EUI64)
-	rr.Hdr = h
-
+func (rr *EUI64) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	if len(l.token) != 23 || l.err {
-		return nil, &ParseError{f, "bad EUI64 Address", l}, ""
+		return &ParseError{"", "bad EUI64 Address", l}
 	}
 	addr := make([]byte, 16)
 	dash := 0
@@ -1386,7 +1109,7 @@ func setEUI64(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 		addr[i+1] = l.token[i+1+dash]
 		dash++
 		if l.token[i+1+dash] != '-' {
-			return nil, &ParseError{f, "bad EUI64 Address", l}, ""
+			return &ParseError{"", "bad EUI64 Address", l}
 		}
 	}
 	addr[14] = l.token[21]
@@ -1394,200 +1117,152 @@ func setEUI64(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 
 	i, e := strconv.ParseUint(string(addr), 16, 64)
 	if e != nil {
-		return nil, &ParseError{f, "bad EUI68 Address", l}, ""
+		return &ParseError{"", "bad EUI68 Address", l}
 	}
-	rr.Address = uint64(i)
-	return rr, nil, ""
+	rr.Address = i
+	return slurpRemainder(c)
 }
 
-func setSSHFP(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(SSHFP)
-	rr.Hdr = h
-
+func (rr *SSHFP) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad SSHFP Algorithm", l}, ""
+		return &ParseError{"", "bad SSHFP Algorithm", l}
 	}
 	rr.Algorithm = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad SSHFP Type", l}, ""
+		return &ParseError{"", "bad SSHFP Type", l}
 	}
 	rr.Type = uint8(i)
 	c.Next() // zBlank
-	s, e1, c1 := endingToString(c, "bad SSHFP Fingerprint", f)
+	s, e1 := endingToString(c, "bad SSHFP Fingerprint")
 	if e1 != nil {
-		return nil, e1, c1
+		return e1
 	}
 	rr.FingerPrint = s
-	return rr, nil, ""
+	return nil
 }
 
-func setDNSKEYs(h RR_Header, c *zlexer, o, f, typ string) (RR, *ParseError, string) {
-	rr := new(DNSKEY)
-	rr.Hdr = h
-
+func (rr *DNSKEY) parseDNSKEY(c *zlexer, o, typ string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, l.comment
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad " + typ + " Flags", l}, ""
+		return &ParseError{"", "bad " + typ + " Flags", l}
 	}
 	rr.Flags = uint16(i)
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad " + typ + " Protocol", l}, ""
+		return &ParseError{"", "bad " + typ + " Protocol", l}
 	}
 	rr.Protocol = uint8(i)
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad " + typ + " Algorithm", l}, ""
+		return &ParseError{"", "bad " + typ + " Algorithm", l}
 	}
 	rr.Algorithm = uint8(i)
-	s, e1, c1 := endingToString(c, "bad "+typ+" PublicKey", f)
+	s, e1 := endingToString(c, "bad "+typ+" PublicKey")
 	if e1 != nil {
-		return nil, e1, c1
+		return e1
 	}
 	rr.PublicKey = s
-	return rr, nil, c1
+	return nil
 }
 
-func setKEY(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	r, e, s := setDNSKEYs(h, c, o, f, "KEY")
-	if r != nil {
-		return &KEY{*r.(*DNSKEY)}, e, s
-	}
-	return nil, e, s
+func (rr *DNSKEY) parse(c *zlexer, o string) *ParseError {
+	return rr.parseDNSKEY(c, o, "DNSKEY")
 }
 
-func setDNSKEY(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	r, e, s := setDNSKEYs(h, c, o, f, "DNSKEY")
-	return r, e, s
+func (rr *KEY) parse(c *zlexer, o string) *ParseError {
+	return rr.parseDNSKEY(c, o, "KEY")
 }
 
-func setCDNSKEY(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	r, e, s := setDNSKEYs(h, c, o, f, "CDNSKEY")
-	if r != nil {
-		return &CDNSKEY{*r.(*DNSKEY)}, e, s
-	}
-	return nil, e, s
+func (rr *CDNSKEY) parse(c *zlexer, o string) *ParseError {
+	return rr.parseDNSKEY(c, o, "CDNSKEY")
 }
 
-func setRKEY(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(RKEY)
-	rr.Hdr = h
-
+func (rr *RKEY) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, l.comment
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad RKEY Flags", l}, ""
+		return &ParseError{"", "bad RKEY Flags", l}
 	}
 	rr.Flags = uint16(i)
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad RKEY Protocol", l}, ""
+		return &ParseError{"", "bad RKEY Protocol", l}
 	}
 	rr.Protocol = uint8(i)
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad RKEY Algorithm", l}, ""
+		return &ParseError{"", "bad RKEY Algorithm", l}
 	}
 	rr.Algorithm = uint8(i)
-	s, e1, c1 := endingToString(c, "bad RKEY PublicKey", f)
+	s, e1 := endingToString(c, "bad RKEY PublicKey")
 	if e1 != nil {
-		return nil, e1, c1
+		return e1
 	}
 	rr.PublicKey = s
-	return rr, nil, c1
+	return nil
 }
 
-func setEID(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(EID)
-	rr.Hdr = h
-	s, e, c1 := endingToString(c, "bad EID Endpoint", f)
+func (rr *EID) parse(c *zlexer, o string) *ParseError {
+	s, e := endingToString(c, "bad EID Endpoint")
 	if e != nil {
-		return nil, e, c1
+		return e
 	}
 	rr.Endpoint = s
-	return rr, nil, c1
+	return nil
 }
 
-func setNIMLOC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(NIMLOC)
-	rr.Hdr = h
-	s, e, c1 := endingToString(c, "bad NIMLOC Locator", f)
+func (rr *NIMLOC) parse(c *zlexer, o string) *ParseError {
+	s, e := endingToString(c, "bad NIMLOC Locator")
 	if e != nil {
-		return nil, e, c1
+		return e
 	}
 	rr.Locator = s
-	return rr, nil, c1
+	return nil
 }
 
-func setGPOS(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(GPOS)
-	rr.Hdr = h
-
+func (rr *GPOS) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	_, e := strconv.ParseFloat(l.token, 64)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad GPOS Longitude", l}, ""
+		return &ParseError{"", "bad GPOS Longitude", l}
 	}
 	rr.Longitude = l.token
 	c.Next() // zBlank
 	l, _ = c.Next()
 	_, e = strconv.ParseFloat(l.token, 64)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad GPOS Latitude", l}, ""
+		return &ParseError{"", "bad GPOS Latitude", l}
 	}
 	rr.Latitude = l.token
 	c.Next() // zBlank
 	l, _ = c.Next()
 	_, e = strconv.ParseFloat(l.token, 64)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad GPOS Altitude", l}, ""
+		return &ParseError{"", "bad GPOS Altitude", l}
 	}
 	rr.Altitude = l.token
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setDSs(h RR_Header, c *zlexer, o, f, typ string) (RR, *ParseError, string) {
-	rr := new(DS)
-	rr.Hdr = h
-
+func (rr *DS) parseDS(c *zlexer, o, typ string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, l.comment
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad " + typ + " KeyTag", l}, ""
+		return &ParseError{"", "bad " + typ + " KeyTag", l}
 	}
 	rr.KeyTag = uint16(i)
 	c.Next() // zBlank
@@ -1596,7 +1271,7 @@ func setDSs(h RR_Header, c *zlexer, o, f, typ string) (RR, *ParseError, string) 
 		tokenUpper := strings.ToUpper(l.token)
 		i, ok := StringToAlgorithm[tokenUpper]
 		if !ok || l.err {
-			return nil, &ParseError{f, "bad " + typ + " Algorithm", l}, ""
+			return &ParseError{"", "bad " + typ + " Algorithm", l}
 		}
 		rr.Algorithm = i
 	} else {
@@ -1606,50 +1281,34 @@ func setDSs(h RR_Header, c *zlexer, o, f, typ string) (RR, *ParseError, string) 
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad " + typ + " DigestType", l}, ""
+		return &ParseError{"", "bad " + typ + " DigestType", l}
 	}
 	rr.DigestType = uint8(i)
-	s, e1, c1 := endingToString(c, "bad "+typ+" Digest", f)
+	s, e1 := endingToString(c, "bad "+typ+" Digest")
 	if e1 != nil {
-		return nil, e1, c1
+		return e1
 	}
 	rr.Digest = s
-	return rr, nil, c1
+	return nil
 }
 
-func setDS(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	r, e, s := setDSs(h, c, o, f, "DS")
-	return r, e, s
+func (rr *DS) parse(c *zlexer, o string) *ParseError {
+	return rr.parseDS(c, o, "DS")
 }
 
-func setDLV(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	r, e, s := setDSs(h, c, o, f, "DLV")
-	if r != nil {
-		return &DLV{*r.(*DS)}, e, s
-	}
-	return nil, e, s
+func (rr *DLV) parse(c *zlexer, o string) *ParseError {
+	return rr.parseDS(c, o, "DLV")
 }
 
-func setCDS(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	r, e, s := setDSs(h, c, o, f, "CDS")
-	if r != nil {
-		return &CDS{*r.(*DS)}, e, s
-	}
-	return nil, e, s
+func (rr *CDS) parse(c *zlexer, o string) *ParseError {
+	return rr.parseDS(c, o, "CDS")
 }
 
-func setTA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(TA)
-	rr.Hdr = h
-
+func (rr *TA) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, l.comment
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad TA KeyTag", l}, ""
+		return &ParseError{"", "bad TA KeyTag", l}
 	}
 	rr.KeyTag = uint16(i)
 	c.Next() // zBlank
@@ -1658,7 +1317,7 @@ func setTA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 		tokenUpper := strings.ToUpper(l.token)
 		i, ok := StringToAlgorithm[tokenUpper]
 		if !ok || l.err {
-			return nil, &ParseError{f, "bad TA Algorithm", l}, ""
+			return &ParseError{"", "bad TA Algorithm", l}
 		}
 		rr.Algorithm = i
 	} else {
@@ -1668,274 +1327,214 @@ func setTA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad TA DigestType", l}, ""
+		return &ParseError{"", "bad TA DigestType", l}
 	}
 	rr.DigestType = uint8(i)
-	s, err, c1 := endingToString(c, "bad TA Digest", f)
+	s, err := endingToString(c, "bad TA Digest")
 	if err != nil {
-		return nil, err, c1
+		return err
 	}
 	rr.Digest = s
-	return rr, nil, c1
+	return nil
 }
 
-func setTLSA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(TLSA)
-	rr.Hdr = h
-
+func (rr *TLSA) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, l.comment
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad TLSA Usage", l}, ""
+		return &ParseError{"", "bad TLSA Usage", l}
 	}
 	rr.Usage = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad TLSA Selector", l}, ""
+		return &ParseError{"", "bad TLSA Selector", l}
 	}
 	rr.Selector = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad TLSA MatchingType", l}, ""
+		return &ParseError{"", "bad TLSA MatchingType", l}
 	}
 	rr.MatchingType = uint8(i)
 	// So this needs be e2 (i.e. different than e), because...??t
-	s, e2, c1 := endingToString(c, "bad TLSA Certificate", f)
+	s, e2 := endingToString(c, "bad TLSA Certificate")
 	if e2 != nil {
-		return nil, e2, c1
+		return e2
 	}
 	rr.Certificate = s
-	return rr, nil, c1
+	return nil
 }
 
-func setSMIMEA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(SMIMEA)
-	rr.Hdr = h
-
+func (rr *SMIMEA) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, l.comment
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad SMIMEA Usage", l}, ""
+		return &ParseError{"", "bad SMIMEA Usage", l}
 	}
 	rr.Usage = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad SMIMEA Selector", l}, ""
+		return &ParseError{"", "bad SMIMEA Selector", l}
 	}
 	rr.Selector = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad SMIMEA MatchingType", l}, ""
+		return &ParseError{"", "bad SMIMEA MatchingType", l}
 	}
 	rr.MatchingType = uint8(i)
 	// So this needs be e2 (i.e. different than e), because...??t
-	s, e2, c1 := endingToString(c, "bad SMIMEA Certificate", f)
+	s, e2 := endingToString(c, "bad SMIMEA Certificate")
 	if e2 != nil {
-		return nil, e2, c1
+		return e2
 	}
 	rr.Certificate = s
-	return rr, nil, c1
+	return nil
 }
 
-func setRFC3597(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(RFC3597)
-	rr.Hdr = h
-
+func (rr *RFC3597) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	if l.token != "\\#" {
-		return nil, &ParseError{f, "bad RFC3597 Rdata", l}, ""
+		return &ParseError{"", "bad RFC3597 Rdata", l}
 	}
 
 	c.Next() // zBlank
 	l, _ = c.Next()
 	rdlength, e := strconv.Atoi(l.token)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad RFC3597 Rdata ", l}, ""
+		return &ParseError{"", "bad RFC3597 Rdata ", l}
 	}
 
-	s, e1, c1 := endingToString(c, "bad RFC3597 Rdata", f)
+	s, e1 := endingToString(c, "bad RFC3597 Rdata")
 	if e1 != nil {
-		return nil, e1, c1
+		return e1
 	}
 	if rdlength*2 != len(s) {
-		return nil, &ParseError{f, "bad RFC3597 Rdata", l}, ""
+		return &ParseError{"", "bad RFC3597 Rdata", l}
 	}
 	rr.Rdata = s
-	return rr, nil, c1
+	return nil
 }
 
-func setSPF(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(SPF)
-	rr.Hdr = h
-
-	s, e, c1 := endingToTxtSlice(c, "bad SPF Txt", f)
+func (rr *SPF) parse(c *zlexer, o string) *ParseError {
+	s, e := endingToTxtSlice(c, "bad SPF Txt")
 	if e != nil {
-		return nil, e, ""
+		return e
 	}
 	rr.Txt = s
-	return rr, nil, c1
+	return nil
 }
 
-func setAVC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(AVC)
-	rr.Hdr = h
-
-	s, e, c1 := endingToTxtSlice(c, "bad AVC Txt", f)
+func (rr *AVC) parse(c *zlexer, o string) *ParseError {
+	s, e := endingToTxtSlice(c, "bad AVC Txt")
 	if e != nil {
-		return nil, e, ""
+		return e
 	}
 	rr.Txt = s
-	return rr, nil, c1
+	return nil
 }
 
-func setTXT(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(TXT)
-	rr.Hdr = h
-
+func (rr *TXT) parse(c *zlexer, o string) *ParseError {
 	// no zBlank reading here, because all this rdata is TXT
-	s, e, c1 := endingToTxtSlice(c, "bad TXT Txt", f)
+	s, e := endingToTxtSlice(c, "bad TXT Txt")
 	if e != nil {
-		return nil, e, ""
+		return e
 	}
 	rr.Txt = s
-	return rr, nil, c1
+	return nil
 }
 
 // identical to setTXT
-func setNINFO(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(NINFO)
-	rr.Hdr = h
-
-	s, e, c1 := endingToTxtSlice(c, "bad NINFO ZSData", f)
+func (rr *NINFO) parse(c *zlexer, o string) *ParseError {
+	s, e := endingToTxtSlice(c, "bad NINFO ZSData")
 	if e != nil {
-		return nil, e, ""
+		return e
 	}
 	rr.ZSData = s
-	return rr, nil, c1
+	return nil
 }
 
-func setURI(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(URI)
-	rr.Hdr = h
-
+func (rr *URI) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad URI Priority", l}, ""
+		return &ParseError{"", "bad URI Priority", l}
 	}
 	rr.Priority = uint16(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad URI Weight", l}, ""
+		return &ParseError{"", "bad URI Weight", l}
 	}
 	rr.Weight = uint16(i)
 
 	c.Next() // zBlank
-	s, err, c1 := endingToTxtSlice(c, "bad URI Target", f)
+	s, err := endingToTxtSlice(c, "bad URI Target")
 	if err != nil {
-		return nil, err, ""
+		return err
 	}
 	if len(s) != 1 {
-		return nil, &ParseError{f, "bad URI Target", l}, ""
+		return &ParseError{"", "bad URI Target", l}
 	}
 	rr.Target = s[0]
-	return rr, nil, c1
+	return nil
 }
 
-func setDHCID(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
+func (rr *DHCID) parse(c *zlexer, o string) *ParseError {
 	// awesome record to parse!
-	rr := new(DHCID)
-	rr.Hdr = h
-
-	s, e, c1 := endingToString(c, "bad DHCID Digest", f)
+	s, e := endingToString(c, "bad DHCID Digest")
 	if e != nil {
-		return nil, e, c1
+		return e
 	}
 	rr.Digest = s
-	return rr, nil, c1
+	return nil
 }
 
-func setNID(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(NID)
-	rr.Hdr = h
-
+func (rr *NID) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad NID Preference", l}, ""
+		return &ParseError{"", "bad NID Preference", l}
 	}
 	rr.Preference = uint16(i)
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	u, err := stringToNodeID(l)
 	if err != nil || l.err {
-		return nil, err, ""
+		return err
 	}
 	rr.NodeID = u
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setL32(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(L32)
-	rr.Hdr = h
-
+func (rr *L32) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad L32 Preference", l}, ""
+		return &ParseError{"", "bad L32 Preference", l}
 	}
 	rr.Preference = uint16(i)
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	rr.Locator32 = net.ParseIP(l.token)
 	if rr.Locator32 == nil || l.err {
-		return nil, &ParseError{f, "bad L32 Locator", l}, ""
+		return &ParseError{"", "bad L32 Locator", l}
 	}
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setLP(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(LP)
-	rr.Hdr = h
-
+func (rr *LP) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad LP Preference", l}, ""
+		return &ParseError{"", "bad LP Preference", l}
 	}
 	rr.Preference = uint16(i)
 
@@ -1944,98 +1543,67 @@ func setLP(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	rr.Fqdn = l.token
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return nil, &ParseError{f, "bad LP Fqdn", l}, ""
+		return &ParseError{"", "bad LP Fqdn", l}
 	}
 	rr.Fqdn = name
 
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setL64(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(L64)
-	rr.Hdr = h
-
+func (rr *L64) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad L64 Preference", l}, ""
+		return &ParseError{"", "bad L64 Preference", l}
 	}
 	rr.Preference = uint16(i)
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	u, err := stringToNodeID(l)
 	if err != nil || l.err {
-		return nil, err, ""
+		return err
 	}
 	rr.Locator64 = u
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setUID(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(UID)
-	rr.Hdr = h
-
+func (rr *UID) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 32)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad UID Uid", l}, ""
+		return &ParseError{"", "bad UID Uid", l}
 	}
 	rr.Uid = uint32(i)
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setGID(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(GID)
-	rr.Hdr = h
-
+func (rr *GID) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 32)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad GID Gid", l}, ""
+		return &ParseError{"", "bad GID Gid", l}
 	}
 	rr.Gid = uint32(i)
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setUINFO(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(UINFO)
-	rr.Hdr = h
-
-	s, e, c1 := endingToTxtSlice(c, "bad UINFO Uinfo", f)
+func (rr *UINFO) parse(c *zlexer, o string) *ParseError {
+	s, e := endingToTxtSlice(c, "bad UINFO Uinfo")
 	if e != nil {
-		return nil, e, c1
+		return e
 	}
 	if ln := len(s); ln == 0 {
-		return rr, nil, c1
+		return nil
 	}
 	rr.Uinfo = s[0] // silently discard anything after the first character-string
-	return rr, nil, c1
+	return nil
 }
 
-func setPX(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(PX)
-	rr.Hdr = h
-
+func (rr *PX) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, ""
-	}
-
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return nil, &ParseError{f, "bad PX Preference", l}, ""
+		return &ParseError{"", "bad PX Preference", l}
 	}
 	rr.Preference = uint16(i)
 
@@ -2044,7 +1612,7 @@ func setPX(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	rr.Map822 = l.token
 	map822, map822Ok := toAbsoluteName(l.token, o)
 	if l.err || !map822Ok {
-		return nil, &ParseError{f, "bad PX Map822", l}, ""
+		return &ParseError{"", "bad PX Map822", l}
 	}
 	rr.Map822 = map822
 
@@ -2053,56 +1621,46 @@ func setPX(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	rr.Mapx400 = l.token
 	mapx400, mapx400Ok := toAbsoluteName(l.token, o)
 	if l.err || !mapx400Ok {
-		return nil, &ParseError{f, "bad PX Mapx400", l}, ""
+		return &ParseError{"", "bad PX Mapx400", l}
 	}
 	rr.Mapx400 = mapx400
 
-	return rr, nil, ""
+	return slurpRemainder(c)
 }
 
-func setCAA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(CAA)
-	rr.Hdr = h
-
+func (rr *CAA) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
-	if len(l.token) == 0 { // dynamic update rr.
-		return rr, nil, l.comment
-	}
-
 	i, err := strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
-		return nil, &ParseError{f, "bad CAA Flag", l}, ""
+		return &ParseError{"", "bad CAA Flag", l}
 	}
 	rr.Flag = uint8(i)
 
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	if l.value != zString {
-		return nil, &ParseError{f, "bad CAA Tag", l}, ""
+		return &ParseError{"", "bad CAA Tag", l}
 	}
 	rr.Tag = l.token
 
 	c.Next() // zBlank
-	s, e, c1 := endingToTxtSlice(c, "bad CAA Value", f)
+	s, e := endingToTxtSlice(c, "bad CAA Value")
 	if e != nil {
-		return nil, e, ""
+		return e
 	}
 	if len(s) != 1 {
-		return nil, &ParseError{f, "bad CAA Value", l}, ""
+		return &ParseError{"", "bad CAA Value", l}
 	}
 	rr.Value = s[0]
-	return rr, nil, c1
+	return nil
 }
 
-func setTKEY(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
-	rr := new(TKEY)
-	rr.Hdr = h
-
+func (rr *TKEY) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 
 	// Algorithm
 	if l.value != zString {
-		return nil, &ParseError{f, "bad TKEY algorithm", l}, ""
+		return &ParseError{"", "bad TKEY algorithm", l}
 	}
 	rr.Algorithm = l.token
 	c.Next() // zBlank
@@ -2111,13 +1669,13 @@ func setTKEY(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	l, _ = c.Next()
 	i, err := strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
-		return nil, &ParseError{f, "bad TKEY key length", l}, ""
+		return &ParseError{"", "bad TKEY key length", l}
 	}
 	rr.KeySize = uint16(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	if l.value != zString {
-		return nil, &ParseError{f, "bad TKEY key", l}, ""
+		return &ParseError{"", "bad TKEY key", l}
 	}
 	rr.Key = l.token
 	c.Next() // zBlank
@@ -2126,84 +1684,15 @@ func setTKEY(h RR_Header, c *zlexer, o, f string) (RR, *ParseError, string) {
 	l, _ = c.Next()
 	i, err = strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
-		return nil, &ParseError{f, "bad TKEY otherdata length", l}, ""
+		return &ParseError{"", "bad TKEY otherdata length", l}
 	}
 	rr.OtherLen = uint16(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	if l.value != zString {
-		return nil, &ParseError{f, "bad TKEY otherday", l}, ""
+		return &ParseError{"", "bad TKEY otherday", l}
 	}
 	rr.OtherData = l.token
 
-	return rr, nil, ""
-}
-
-var typeToparserFunc = map[uint16]parserFunc{
-	TypeAAAA:       {setAAAA, false},
-	TypeAFSDB:      {setAFSDB, false},
-	TypeA:          {setA, false},
-	TypeCAA:        {setCAA, true},
-	TypeCDS:        {setCDS, true},
-	TypeCDNSKEY:    {setCDNSKEY, true},
-	TypeCERT:       {setCERT, true},
-	TypeCNAME:      {setCNAME, false},
-	TypeCSYNC:      {setCSYNC, true},
-	TypeDHCID:      {setDHCID, true},
-	TypeDLV:        {setDLV, true},
-	TypeDNAME:      {setDNAME, false},
-	TypeKEY:        {setKEY, true},
-	TypeDNSKEY:     {setDNSKEY, true},
-	TypeDS:         {setDS, true},
-	TypeEID:        {setEID, true},
-	TypeEUI48:      {setEUI48, false},
-	TypeEUI64:      {setEUI64, false},
-	TypeGID:        {setGID, false},
-	TypeGPOS:       {setGPOS, false},
-	TypeHINFO:      {setHINFO, true},
-	TypeHIP:        {setHIP, true},
-	TypeKX:         {setKX, false},
-	TypeL32:        {setL32, false},
-	TypeL64:        {setL64, false},
-	TypeLOC:        {setLOC, true},
-	TypeLP:         {setLP, false},
-	TypeMB:         {setMB, false},
-	TypeMD:         {setMD, false},
-	TypeMF:         {setMF, false},
-	TypeMG:         {setMG, false},
-	TypeMINFO:      {setMINFO, false},
-	TypeMR:         {setMR, false},
-	TypeMX:         {setMX, false},
-	TypeNAPTR:      {setNAPTR, false},
-	TypeNID:        {setNID, false},
-	TypeNIMLOC:     {setNIMLOC, true},
-	TypeNINFO:      {setNINFO, true},
-	TypeNSAPPTR:    {setNSAPPTR, false},
-	TypeNSEC3PARAM: {setNSEC3PARAM, false},
-	TypeNSEC3:      {setNSEC3, true},
-	TypeNSEC:       {setNSEC, true},
-	TypeNS:         {setNS, false},
-	TypeOPENPGPKEY: {setOPENPGPKEY, true},
-	TypePTR:        {setPTR, false},
-	TypePX:         {setPX, false},
-	TypeSIG:        {setSIG, true},
-	TypeRKEY:       {setRKEY, true},
-	TypeRP:         {setRP, false},
-	TypeRRSIG:      {setRRSIG, true},
-	TypeRT:         {setRT, false},
-	TypeSMIMEA:     {setSMIMEA, true},
-	TypeSOA:        {setSOA, false},
-	TypeSPF:        {setSPF, true},
-	TypeAVC:        {setAVC, true},
-	TypeSRV:        {setSRV, false},
-	TypeSSHFP:      {setSSHFP, true},
-	TypeTALINK:     {setTALINK, false},
-	TypeTA:         {setTA, true},
-	TypeTLSA:       {setTLSA, true},
-	TypeTXT:        {setTXT, true},
-	TypeUID:        {setUID, false},
-	TypeUINFO:      {setUINFO, true},
-	TypeURI:        {setURI, true},
-	TypeX25:        {setX25, false},
-	TypeTKEY:       {setTKEY, true},
+	return nil
 }

--- a/vendor/github.com/miekg/dns/server.go
+++ b/vendor/github.com/miekg/dns/server.go
@@ -3,7 +3,6 @@
 package dns
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/binary"
@@ -12,25 +11,11 @@ import (
 	"net"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
 // Default maximum number of TCP queries before we close the socket.
 const maxTCPQueries = 128
-
-// The maximum number of idle workers.
-//
-// This controls the maximum number of workers that are allowed to stay
-// idle waiting for incoming requests before being torn down.
-//
-// If this limit is reached, the server will just keep spawning new
-// workers (goroutines) for each incoming request. In this case, each
-// worker will only be used for a single request.
-const maxIdleWorkersCount = 10000
-
-// The maximum length of time a worker may idle for before being destroyed.
-const idleWorkerTimeout = 10 * time.Second
 
 // aLongTimeAgo is a non-zero time, far in the past, used for
 // immediate cancelation of network operations.
@@ -81,7 +66,6 @@ type ConnectionStater interface {
 }
 
 type response struct {
-	msg            []byte
 	closed         bool // connection has been closed
 	hijacked       bool // connection has been hijacked by handler
 	tsigTimersOnly bool
@@ -92,7 +76,6 @@ type response struct {
 	tcp            net.Conn          // i/o connection if TCP was used
 	udpSession     *SessionUDP       // oob data to get egress interface right
 	writer         Writer            // writer to output the raw DNS bits
-	wg             *sync.WaitGroup   // for gracefull shutdown
 }
 
 // HandleFailed returns a HandlerFunc that returns SERVFAIL for every request it gets.
@@ -162,11 +145,11 @@ type defaultReader struct {
 	*Server
 }
 
-func (dr *defaultReader) ReadTCP(conn net.Conn, timeout time.Duration) ([]byte, error) {
+func (dr defaultReader) ReadTCP(conn net.Conn, timeout time.Duration) ([]byte, error) {
 	return dr.readTCP(conn, timeout)
 }
 
-func (dr *defaultReader) ReadUDP(conn *net.UDPConn, timeout time.Duration) ([]byte, *SessionUDP, error) {
+func (dr defaultReader) ReadUDP(conn *net.UDPConn, timeout time.Duration) ([]byte, *SessionUDP, error) {
 	return dr.readUDP(conn, timeout)
 }
 
@@ -218,11 +201,6 @@ type Server struct {
 	// By default DefaultMsgAcceptFunc will be used.
 	MsgAcceptFunc MsgAcceptFunc
 
-	// UDP packet or TCP connection queue
-	queue chan *response
-	// Workers count
-	workersCount int32
-
 	// Shutdown handling
 	lock     sync.RWMutex
 	started  bool
@@ -240,51 +218,6 @@ func (srv *Server) isStarted() bool {
 	return started
 }
 
-func (srv *Server) worker(w *response) {
-	srv.serve(w)
-
-	for {
-		count := atomic.LoadInt32(&srv.workersCount)
-		if count > maxIdleWorkersCount {
-			return
-		}
-		if atomic.CompareAndSwapInt32(&srv.workersCount, count, count+1) {
-			break
-		}
-	}
-
-	defer atomic.AddInt32(&srv.workersCount, -1)
-
-	inUse := false
-	timeout := time.NewTimer(idleWorkerTimeout)
-	defer timeout.Stop()
-LOOP:
-	for {
-		select {
-		case w, ok := <-srv.queue:
-			if !ok {
-				break LOOP
-			}
-			inUse = true
-			srv.serve(w)
-		case <-timeout.C:
-			if !inUse {
-				break LOOP
-			}
-			inUse = false
-			timeout.Reset(idleWorkerTimeout)
-		}
-	}
-}
-
-func (srv *Server) spawnWorker(w *response) {
-	select {
-	case srv.queue <- w:
-	default:
-		go srv.worker(w)
-	}
-}
-
 func makeUDPBuffer(size int) func() interface{} {
 	return func() interface{} {
 		return make([]byte, size)
@@ -292,8 +225,6 @@ func makeUDPBuffer(size int) func() interface{} {
 }
 
 func (srv *Server) init() {
-	srv.queue = make(chan *response)
-
 	srv.shutdown = make(chan struct{})
 	srv.conns = make(map[net.Conn]struct{})
 
@@ -301,7 +232,10 @@ func (srv *Server) init() {
 		srv.UDPSize = MinMsgSize
 	}
 	if srv.MsgAcceptFunc == nil {
-		srv.MsgAcceptFunc = defaultMsgAcceptFunc
+		srv.MsgAcceptFunc = DefaultMsgAcceptFunc
+	}
+	if srv.Handler == nil {
+		srv.Handler = DefaultServeMux
 	}
 
 	srv.udpPool.New = makeUDPBuffer(srv.UDPSize)
@@ -328,7 +262,6 @@ func (srv *Server) ListenAndServe() error {
 	}
 
 	srv.init()
-	defer close(srv.queue)
 
 	switch srv.Net {
 	case "tcp", "tcp4", "tcp6":
@@ -383,7 +316,6 @@ func (srv *Server) ActivateAndServe() error {
 	}
 
 	srv.init()
-	defer close(srv.queue)
 
 	pConn := srv.PacketConn
 	l := srv.Listener
@@ -463,11 +395,10 @@ var testShutdownNotify *sync.Cond
 
 // getReadTimeout is a helper func to use system timeout if server did not intend to change it.
 func (srv *Server) getReadTimeout() time.Duration {
-	rtimeout := dnsTimeout
 	if srv.ReadTimeout != 0 {
-		rtimeout = srv.ReadTimeout
+		return srv.ReadTimeout
 	}
-	return rtimeout
+	return dnsTimeout
 }
 
 // serveTCP starts a TCP listener for the server.
@@ -500,11 +431,7 @@ func (srv *Server) serveTCP(l net.Listener) error {
 		srv.conns[rw] = struct{}{}
 		srv.lock.Unlock()
 		wg.Add(1)
-		srv.spawnWorker(&response{
-			tsigSecret: srv.TsigSecret,
-			tcp:        rw,
-			wg:         &wg,
-		})
+		go srv.serveTCPConn(&wg, rw)
 	}
 
 	return nil
@@ -518,7 +445,7 @@ func (srv *Server) serveUDP(l *net.UDPConn) error {
 		srv.NotifyStartedFunc()
 	}
 
-	reader := Reader(&defaultReader{srv})
+	reader := Reader(defaultReader{srv})
 	if srv.DecorateReader != nil {
 		reader = srv.DecorateReader(reader)
 	}
@@ -549,46 +476,22 @@ func (srv *Server) serveUDP(l *net.UDPConn) error {
 			continue
 		}
 		wg.Add(1)
-		srv.spawnWorker(&response{
-			msg:        m,
-			tsigSecret: srv.TsigSecret,
-			udp:        l,
-			udpSession: s,
-			wg:         &wg,
-		})
+		go srv.serveUDPPacket(&wg, m, l, s)
 	}
 
 	return nil
 }
 
-func (srv *Server) serve(w *response) {
+// Serve a new TCP connection.
+func (srv *Server) serveTCPConn(wg *sync.WaitGroup, rw net.Conn) {
+	w := &response{tsigSecret: srv.TsigSecret, tcp: rw}
 	if srv.DecorateWriter != nil {
 		w.writer = srv.DecorateWriter(w)
 	} else {
 		w.writer = w
 	}
 
-	if w.udp != nil {
-		// serve UDP
-		srv.serveDNS(w)
-
-		w.wg.Done()
-		return
-	}
-
-	defer func() {
-		if !w.hijacked {
-			w.Close()
-		}
-
-		srv.lock.Lock()
-		delete(srv.conns, w.tcp)
-		srv.lock.Unlock()
-
-		w.wg.Done()
-	}()
-
-	reader := Reader(&defaultReader{srv})
+	reader := Reader(defaultReader{srv})
 	if srv.DecorateReader != nil {
 		reader = srv.DecorateReader(reader)
 	}
@@ -606,14 +509,13 @@ func (srv *Server) serve(w *response) {
 	}
 
 	for q := 0; (q < limit || limit == -1) && srv.isStarted(); q++ {
-		var err error
-		w.msg, err = reader.ReadTCP(w.tcp, timeout)
+		m, err := reader.ReadTCP(w.tcp, timeout)
 		if err != nil {
 			// TODO(tmthrgd): handle error
 			break
 		}
-		srv.serveDNS(w)
-		if w.tcp == nil {
+		srv.serveDNS(m, w)
+		if w.closed {
 			break // Close() was called
 		}
 		if w.hijacked {
@@ -623,17 +525,33 @@ func (srv *Server) serve(w *response) {
 		// idle timeout.
 		timeout = idleTimeout
 	}
-}
 
-func (srv *Server) disposeBuffer(w *response) {
-	if w.udp != nil && cap(w.msg) == srv.UDPSize {
-		srv.udpPool.Put(w.msg[:srv.UDPSize])
+	if !w.hijacked {
+		w.Close()
 	}
-	w.msg = nil
+
+	srv.lock.Lock()
+	delete(srv.conns, w.tcp)
+	srv.lock.Unlock()
+
+	wg.Done()
 }
 
-func (srv *Server) serveDNS(w *response) {
-	dh, off, err := unpackMsgHdr(w.msg, 0)
+// Serve a new UDP request.
+func (srv *Server) serveUDPPacket(wg *sync.WaitGroup, m []byte, u *net.UDPConn, s *SessionUDP) {
+	w := &response{tsigSecret: srv.TsigSecret, udp: u, udpSession: s}
+	if srv.DecorateWriter != nil {
+		w.writer = srv.DecorateWriter(w)
+	} else {
+		w.writer = w
+	}
+
+	srv.serveDNS(m, w)
+	wg.Done()
+}
+
+func (srv *Server) serveDNS(m []byte, w *response) {
+	dh, off, err := unpackMsgHdr(m, 0)
 	if err != nil {
 		// Let client hang, they are sending crap; any reply can be used to amplify.
 		return
@@ -642,26 +560,32 @@ func (srv *Server) serveDNS(w *response) {
 	req := new(Msg)
 	req.setHdr(dh)
 
-	switch srv.MsgAcceptFunc(dh) {
+	switch action := srv.MsgAcceptFunc(dh); action {
 	case MsgAccept:
-	case MsgIgnore:
-		return
-	case MsgReject:
+		if req.unpack(dh, m, off) == nil {
+			break
+		}
+
+		fallthrough
+	case MsgReject, MsgRejectNotImplemented:
+		opcode := req.Opcode
 		req.SetRcodeFormatError(req)
+		req.Zero = false
+		if action == MsgRejectNotImplemented {
+			req.Opcode = opcode
+			req.Rcode = RcodeNotImplemented
+		}
+
 		// Are we allowed to delete any OPT records here?
 		req.Ns, req.Answer, req.Extra = nil, nil, nil
 
 		w.WriteMsg(req)
-		srv.disposeBuffer(w)
-		return
-	}
+		fallthrough
+	case MsgIgnore:
+		if w.udp != nil && cap(m) == srv.UDPSize {
+			srv.udpPool.Put(m[:srv.UDPSize])
+		}
 
-	if err := req.unpack(dh, w.msg, off); err != nil {
-		req.SetRcodeFormatError(req)
-		req.Ns, req.Answer, req.Extra = nil, nil, nil
-
-		w.WriteMsg(req)
-		srv.disposeBuffer(w)
 		return
 	}
 
@@ -669,7 +593,7 @@ func (srv *Server) serveDNS(w *response) {
 	if w.tsigSecret != nil {
 		if t := req.IsTsig(); t != nil {
 			if secret, ok := w.tsigSecret[t.Hdr.Name]; ok {
-				w.tsigStatus = TsigVerify(w.msg, secret, "", false)
+				w.tsigStatus = TsigVerify(m, secret, "", false)
 			} else {
 				w.tsigStatus = ErrSecret
 			}
@@ -678,14 +602,11 @@ func (srv *Server) serveDNS(w *response) {
 		}
 	}
 
-	srv.disposeBuffer(w)
-
-	handler := srv.Handler
-	if handler == nil {
-		handler = DefaultServeMux
+	if w.udp != nil && cap(m) == srv.UDPSize {
+		srv.udpPool.Put(m[:srv.UDPSize])
 	}
 
-	handler.ServeDNS(w, req) // Writes back to the client
+	srv.Handler.ServeDNS(w, req) // Writes back to the client
 }
 
 func (srv *Server) readTCP(conn net.Conn, timeout time.Duration) ([]byte, error) {
@@ -699,36 +620,16 @@ func (srv *Server) readTCP(conn net.Conn, timeout time.Duration) ([]byte, error)
 	}
 	srv.lock.RUnlock()
 
-	l := make([]byte, 2)
-	n, err := conn.Read(l)
-	if err != nil || n != 2 {
-		if err != nil {
-			return nil, err
-		}
-		return nil, ErrShortRead
+	var length uint16
+	if err := binary.Read(conn, binary.BigEndian, &length); err != nil {
+		return nil, err
 	}
-	length := binary.BigEndian.Uint16(l)
-	if length == 0 {
-		return nil, ErrShortRead
+
+	m := make([]byte, length)
+	if _, err := io.ReadFull(conn, m); err != nil {
+		return nil, err
 	}
-	m := make([]byte, int(length))
-	n, err = conn.Read(m[:int(length)])
-	if err != nil || n == 0 {
-		if err != nil {
-			return nil, err
-		}
-		return nil, ErrShortRead
-	}
-	i := n
-	for i < int(length) {
-		j, err := conn.Read(m[i:int(length)])
-		if err != nil {
-			return nil, err
-		}
-		i += j
-	}
-	n = i
-	m = m[:n]
+
 	return m, nil
 }
 
@@ -783,21 +684,16 @@ func (w *response) Write(m []byte) (int, error) {
 
 	switch {
 	case w.udp != nil:
-		n, err := WriteToSessionUDP(w.udp, m, w.udpSession)
-		return n, err
+		return WriteToSessionUDP(w.udp, m, w.udpSession)
 	case w.tcp != nil:
-		lm := len(m)
-		if lm < 2 {
-			return 0, io.ErrShortBuffer
-		}
-		if lm > MaxMsgSize {
+		if len(m) > MaxMsgSize {
 			return 0, &Error{err: "message too large"}
 		}
-		l := make([]byte, 2, 2+lm)
-		binary.BigEndian.PutUint16(l, uint16(lm))
-		m = append(l, m...)
 
-		n, err := io.Copy(w.tcp, bytes.NewReader(m))
+		l := make([]byte, 2)
+		binary.BigEndian.PutUint16(l, uint16(len(m)))
+
+		n, err := (&net.Buffers{l, m}).WriteTo(w.tcp)
 		return int(n), err
 	default:
 		panic("dns: internal error: udp and tcp both nil")

--- a/vendor/github.com/miekg/dns/sig0.go
+++ b/vendor/github.com/miekg/dns/sig0.go
@@ -21,13 +21,9 @@ func (rr *SIG) Sign(k crypto.Signer, m *Msg) ([]byte, error) {
 	if rr.KeyTag == 0 || len(rr.SignerName) == 0 || rr.Algorithm == 0 {
 		return nil, ErrKey
 	}
-	rr.Header().Rrtype = TypeSIG
-	rr.Header().Class = ClassANY
-	rr.Header().Ttl = 0
-	rr.Header().Name = "."
-	rr.OrigTtl = 0
-	rr.TypeCovered = 0
-	rr.Labels = 0
+
+	rr.Hdr = RR_Header{Name: ".", Rrtype: TypeSIG, Class: ClassANY, Ttl: 0}
+	rr.OrigTtl, rr.TypeCovered, rr.Labels = 0, 0, 0
 
 	buf := make([]byte, m.Len()+Len(rr))
 	mbuf, err := m.PackBuffer(buf)
@@ -107,7 +103,7 @@ func (rr *SIG) Verify(k *KEY, buf []byte) error {
 	anc := binary.BigEndian.Uint16(buf[6:])
 	auc := binary.BigEndian.Uint16(buf[8:])
 	adc := binary.BigEndian.Uint16(buf[10:])
-	offset := 12
+	offset := headerSize
 	var err error
 	for i := uint16(0); i < qdc && offset < buflen; i++ {
 		_, offset, err = UnpackDomainName(buf, offset)
@@ -185,10 +181,8 @@ func (rr *SIG) Verify(k *KEY, buf []byte) error {
 	case DSA:
 		pk := k.publicKeyDSA()
 		sig = sig[1:]
-		r := big.NewInt(0)
-		r.SetBytes(sig[:len(sig)/2])
-		s := big.NewInt(0)
-		s.SetBytes(sig[len(sig)/2:])
+		r := new(big.Int).SetBytes(sig[:len(sig)/2])
+		s := new(big.Int).SetBytes(sig[len(sig)/2:])
 		if pk != nil {
 			if dsa.Verify(pk, hashed, r, s) {
 				return nil
@@ -202,10 +196,8 @@ func (rr *SIG) Verify(k *KEY, buf []byte) error {
 		}
 	case ECDSAP256SHA256, ECDSAP384SHA384:
 		pk := k.publicKeyECDSA()
-		r := big.NewInt(0)
-		r.SetBytes(sig[:len(sig)/2])
-		s := big.NewInt(0)
-		s.SetBytes(sig[len(sig)/2:])
+		r := new(big.Int).SetBytes(sig[:len(sig)/2])
+		s := new(big.Int).SetBytes(sig[len(sig)/2:])
 		if pk != nil {
 			if ecdsa.Verify(pk, hashed, r, s) {
 				return nil

--- a/vendor/github.com/miekg/dns/smimea.go
+++ b/vendor/github.com/miekg/dns/smimea.go
@@ -14,10 +14,7 @@ func (r *SMIMEA) Sign(usage, selector, matchingType int, cert *x509.Certificate)
 	r.MatchingType = uint8(matchingType)
 
 	r.Certificate, err = CertificateToDANE(r.Selector, r.MatchingType, cert)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // Verify verifies a SMIMEA record against an SSL certificate. If it is OK

--- a/vendor/github.com/miekg/dns/tlsa.go
+++ b/vendor/github.com/miekg/dns/tlsa.go
@@ -14,10 +14,7 @@ func (r *TLSA) Sign(usage, selector, matchingType int, cert *x509.Certificate) (
 	r.MatchingType = uint8(matchingType)
 
 	r.Certificate, err = CertificateToDANE(r.Selector, r.MatchingType, cert)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // Verify verifies a TLSA record against an SSL certificate. If it is OK

--- a/vendor/github.com/miekg/dns/tsig.go
+++ b/vendor/github.com/miekg/dns/tsig.go
@@ -54,6 +54,10 @@ func (rr *TSIG) String() string {
 	return s
 }
 
+func (rr *TSIG) parse(c *zlexer, origin string) *ParseError {
+	panic("dns: internal error: parse should never be called on TSIG")
+}
+
 // The following values must be put in wireformat, so that the MAC can be calculated.
 // RFC 2845, section 3.4.2. TSIG Variables.
 type tsigWireFmt struct {
@@ -113,13 +117,13 @@ func TsigGenerate(m *Msg, secret, requestMAC string, timersOnly bool) ([]byte, s
 	var h hash.Hash
 	switch strings.ToLower(rr.Algorithm) {
 	case HmacMD5:
-		h = hmac.New(md5.New, []byte(rawsecret))
+		h = hmac.New(md5.New, rawsecret)
 	case HmacSHA1:
-		h = hmac.New(sha1.New, []byte(rawsecret))
+		h = hmac.New(sha1.New, rawsecret)
 	case HmacSHA256:
-		h = hmac.New(sha256.New, []byte(rawsecret))
+		h = hmac.New(sha256.New, rawsecret)
 	case HmacSHA512:
-		h = hmac.New(sha512.New, []byte(rawsecret))
+		h = hmac.New(sha512.New, rawsecret)
 	default:
 		return nil, "", ErrKeyAlg
 	}
@@ -134,12 +138,11 @@ func TsigGenerate(m *Msg, secret, requestMAC string, timersOnly bool) ([]byte, s
 	t.OrigId = m.Id
 
 	tbuf := make([]byte, Len(t))
-	if off, err := PackRR(t, tbuf, 0, nil, false); err == nil {
-		tbuf = tbuf[:off] // reset to actual size used
-	} else {
+	off, err := PackRR(t, tbuf, 0, nil, false)
+	if err != nil {
 		return nil, "", err
 	}
-	mbuf = append(mbuf, tbuf...)
+	mbuf = append(mbuf, tbuf[:off]...)
 	// Update the ArCount directly in the buffer.
 	binary.BigEndian.PutUint16(mbuf[10:], uint16(len(m.Extra)+1))
 

--- a/vendor/github.com/miekg/dns/types.go
+++ b/vendor/github.com/miekg/dns/types.go
@@ -205,9 +205,6 @@ var CertTypeToString = map[uint16]string{
 	CertOID:     "OID",
 }
 
-// StringToCertType is the reverseof CertTypeToString.
-var StringToCertType = reverseInt16(CertTypeToString)
-
 //go:generate go run types_generate.go
 
 // Question holds a DNS question. There can be multiple questions in the
@@ -240,6 +237,25 @@ type ANY struct {
 }
 
 func (rr *ANY) String() string { return rr.Hdr.String() }
+
+func (rr *ANY) parse(c *zlexer, origin string) *ParseError {
+	panic("dns: internal error: parse should never be called on ANY")
+}
+
+// NULL RR. See RFC 1035.
+type NULL struct {
+	Hdr  RR_Header
+	Data string `dns:"any"`
+}
+
+func (rr *NULL) String() string {
+	// There is no presentation format; prefix string with a comment.
+	return ";" + rr.Hdr.String() + rr.Data
+}
+
+func (rr *NULL) parse(c *zlexer, origin string) *ParseError {
+	panic("dns: internal error: parse should never be called on NULL")
+}
 
 // CNAME RR. See RFC 1034.
 type CNAME struct {
@@ -388,7 +404,7 @@ type RP struct {
 }
 
 func (rr *RP) String() string {
-	return rr.Hdr.String() + rr.Mbox + " " + sprintTxt([]string{rr.Txt})
+	return rr.Hdr.String() + sprintName(rr.Mbox) + " " + sprintName(rr.Txt)
 }
 
 // SOA RR. See RFC 1035.
@@ -829,8 +845,8 @@ type NSEC struct {
 
 func (rr *NSEC) String() string {
 	s := rr.Hdr.String() + sprintName(rr.NextDomain)
-	for i := 0; i < len(rr.TypeBitMap); i++ {
-		s += " " + Type(rr.TypeBitMap[i]).String()
+	for _, t := range rr.TypeBitMap {
+		s += " " + Type(t).String()
 	}
 	return s
 }
@@ -838,14 +854,7 @@ func (rr *NSEC) String() string {
 func (rr *NSEC) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.NextDomain, off+l, compression, false)
-	lastwindow := uint32(2 ^ 32 + 1)
-	for _, t := range rr.TypeBitMap {
-		window := t / 256
-		if uint32(window) != lastwindow {
-			l += 1 + 32
-		}
-		lastwindow = uint32(window)
-	}
+	l += typeBitMapLen(rr.TypeBitMap)
 	return l
 }
 
@@ -995,8 +1004,8 @@ func (rr *NSEC3) String() string {
 		" " + strconv.Itoa(int(rr.Iterations)) +
 		" " + saltToString(rr.Salt) +
 		" " + rr.NextDomain
-	for i := 0; i < len(rr.TypeBitMap); i++ {
-		s += " " + Type(rr.TypeBitMap[i]).String()
+	for _, t := range rr.TypeBitMap {
+		s += " " + Type(t).String()
 	}
 	return s
 }
@@ -1004,14 +1013,7 @@ func (rr *NSEC3) String() string {
 func (rr *NSEC3) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 6 + len(rr.Salt)/2 + 1 + len(rr.NextDomain) + 1
-	lastwindow := uint32(2 ^ 32 + 1)
-	for _, t := range rr.TypeBitMap {
-		window := t / 256
-		if uint32(window) != lastwindow {
-			l += 1 + 32
-		}
-		lastwindow = uint32(window)
-	}
+	l += typeBitMapLen(rr.TypeBitMap)
 	return l
 }
 
@@ -1050,10 +1052,16 @@ type TKEY struct {
 
 // TKEY has no official presentation format, but this will suffice.
 func (rr *TKEY) String() string {
-	s := "\n;; TKEY PSEUDOSECTION:\n"
-	s += rr.Hdr.String() + " " + rr.Algorithm + " " +
-		strconv.Itoa(int(rr.KeySize)) + " " + rr.Key + " " +
-		strconv.Itoa(int(rr.OtherLen)) + " " + rr.OtherData
+	s := ";" + rr.Hdr.String() +
+		" " + rr.Algorithm +
+		" " + TimeToString(rr.Inception) +
+		" " + TimeToString(rr.Expiration) +
+		" " + strconv.Itoa(int(rr.Mode)) +
+		" " + strconv.Itoa(int(rr.Error)) +
+		" " + strconv.Itoa(int(rr.KeySize)) +
+		" " + rr.Key +
+		" " + strconv.Itoa(int(rr.OtherLen)) +
+		" " + rr.OtherData
 	return s
 }
 
@@ -1313,8 +1321,8 @@ type CSYNC struct {
 func (rr *CSYNC) String() string {
 	s := rr.Hdr.String() + strconv.FormatInt(int64(rr.Serial), 10) + " " + strconv.Itoa(int(rr.Flags))
 
-	for i := 0; i < len(rr.TypeBitMap); i++ {
-		s += " " + Type(rr.TypeBitMap[i]).String()
+	for _, t := range rr.TypeBitMap {
+		s += " " + Type(t).String()
 	}
 	return s
 }
@@ -1322,14 +1330,7 @@ func (rr *CSYNC) String() string {
 func (rr *CSYNC) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 4 + 2
-	lastwindow := uint32(2 ^ 32 + 1)
-	for _, t := range rr.TypeBitMap {
-		window := t / 256
-		if uint32(window) != lastwindow {
-			l += 1 + 32
-		}
-		lastwindow = uint32(window)
-	}
+	l += typeBitMapLen(rr.TypeBitMap)
 	return l
 }
 

--- a/vendor/github.com/miekg/dns/types_generate.go
+++ b/vendor/github.com/miekg/dns/types_generate.go
@@ -189,14 +189,14 @@ func main() {
 				o("l += base64.StdEncoding.DecodedLen(len(rr.%s))\n")
 			case strings.HasPrefix(st.Tag(i), `dns:"size-hex:`): // this has an extra field where the length is stored
 				o("l += len(rr.%s)/2\n")
-			case strings.HasPrefix(st.Tag(i), `dns:"size-hex`):
-				fallthrough
 			case st.Tag(i) == `dns:"hex"`:
-				o("l += len(rr.%s)/2 + 1\n")
+				o("l += len(rr.%s)/2\n")
+			case st.Tag(i) == `dns:"any"`:
+				o("l += len(rr.%s)\n")
 			case st.Tag(i) == `dns:"a"`:
-				o("l += net.IPv4len // %s\n")
+				o("if len(rr.%s) != 0 { l += net.IPv4len }\n")
 			case st.Tag(i) == `dns:"aaaa"`:
-				o("l += net.IPv6len // %s\n")
+				o("if len(rr.%s) != 0 { l += net.IPv6len }\n")
 			case st.Tag(i) == `dns:"txt"`:
 				o("for _, t := range rr.%s { l += len(t) + 1 }\n")
 			case st.Tag(i) == `dns:"uint48"`:
@@ -241,6 +241,13 @@ func main() {
 				if strings.Contains(t, ".") {
 					splits := strings.Split(t, ".")
 					t = splits[len(splits)-1]
+				}
+				// For the EDNS0 interface (used in the OPT RR), we need to call the copy method on each element.
+				if t == "EDNS0" {
+					fmt.Fprintf(b, "%s := make([]%s, len(rr.%s));\nfor i,e := range rr.%s {\n %s[i] = e.copy()\n}\n",
+						f, t, f, f, f)
+					fields = append(fields, f)
+					continue
 				}
 				fmt.Fprintf(b, "%s := make([]%s, len(rr.%s)); copy(%s, rr.%s)\n",
 					f, t, f, f, f)

--- a/vendor/github.com/miekg/dns/udp_windows.go
+++ b/vendor/github.com/miekg/dns/udp_windows.go
@@ -20,15 +20,13 @@ func ReadFromSessionUDP(conn *net.UDPConn, b []byte) (int, *SessionUDP, error) {
 	if err != nil {
 		return n, nil, err
 	}
-	session := &SessionUDP{raddr.(*net.UDPAddr)}
-	return n, session, err
+	return n, &SessionUDP{raddr.(*net.UDPAddr)}, err
 }
 
 // WriteToSessionUDP acts just like net.UDPConn.WriteTo(), but uses a *SessionUDP instead of a net.Addr.
 // TODO(fastest963): Once go1.10 is released, use WriteMsgUDP.
 func WriteToSessionUDP(conn *net.UDPConn, b []byte, session *SessionUDP) (int, error) {
-	n, err := conn.WriteTo(b, session.raddr)
-	return n, err
+	return conn.WriteTo(b, session.raddr)
 }
 
 // TODO(fastest963): Once go1.10 is released and we can use *MsgUDP methods

--- a/vendor/github.com/miekg/dns/update.go
+++ b/vendor/github.com/miekg/dns/update.go
@@ -44,7 +44,8 @@ func (u *Msg) RRsetUsed(rr []RR) {
 		u.Answer = make([]RR, 0, len(rr))
 	}
 	for _, r := range rr {
-		u.Answer = append(u.Answer, &ANY{Hdr: RR_Header{Name: r.Header().Name, Ttl: 0, Rrtype: r.Header().Rrtype, Class: ClassANY}})
+		h := r.Header()
+		u.Answer = append(u.Answer, &ANY{Hdr: RR_Header{Name: h.Name, Ttl: 0, Rrtype: h.Rrtype, Class: ClassANY}})
 	}
 }
 
@@ -55,7 +56,8 @@ func (u *Msg) RRsetNotUsed(rr []RR) {
 		u.Answer = make([]RR, 0, len(rr))
 	}
 	for _, r := range rr {
-		u.Answer = append(u.Answer, &ANY{Hdr: RR_Header{Name: r.Header().Name, Ttl: 0, Rrtype: r.Header().Rrtype, Class: ClassNONE}})
+		h := r.Header()
+		u.Answer = append(u.Answer, &ANY{Hdr: RR_Header{Name: h.Name, Ttl: 0, Rrtype: h.Rrtype, Class: ClassNONE}})
 	}
 }
 
@@ -79,7 +81,8 @@ func (u *Msg) RemoveRRset(rr []RR) {
 		u.Ns = make([]RR, 0, len(rr))
 	}
 	for _, r := range rr {
-		u.Ns = append(u.Ns, &ANY{Hdr: RR_Header{Name: r.Header().Name, Ttl: 0, Rrtype: r.Header().Rrtype, Class: ClassANY}})
+		h := r.Header()
+		u.Ns = append(u.Ns, &ANY{Hdr: RR_Header{Name: h.Name, Ttl: 0, Rrtype: h.Rrtype, Class: ClassANY}})
 	}
 }
 
@@ -99,8 +102,9 @@ func (u *Msg) Remove(rr []RR) {
 		u.Ns = make([]RR, 0, len(rr))
 	}
 	for _, r := range rr {
-		r.Header().Class = ClassNONE
-		r.Header().Ttl = 0
+		h := r.Header()
+		h.Class = ClassNONE
+		h.Ttl = 0
 		u.Ns = append(u.Ns, r)
 	}
 }

--- a/vendor/github.com/miekg/dns/version.go
+++ b/vendor/github.com/miekg/dns/version.go
@@ -3,7 +3,7 @@ package dns
 import "fmt"
 
 // Version is current version of this library.
-var Version = V{1, 1, 1}
+var Version = V{1, 1, 15}
 
 // V holds the version of this library.
 type V struct {

--- a/vendor/github.com/miekg/dns/xfr.go
+++ b/vendor/github.com/miekg/dns/xfr.go
@@ -35,30 +35,36 @@ type Transfer struct {
 //	channel, err := transfer.In(message, master)
 //
 func (t *Transfer) In(q *Msg, a string) (env chan *Envelope, err error) {
+	switch q.Question[0].Qtype {
+	case TypeAXFR, TypeIXFR:
+	default:
+		return nil, &Error{"unsupported question type"}
+	}
+
 	timeout := dnsTimeout
 	if t.DialTimeout != 0 {
 		timeout = t.DialTimeout
 	}
+
 	if t.Conn == nil {
 		t.Conn, err = DialTimeout("tcp", a, timeout)
 		if err != nil {
 			return nil, err
 		}
 	}
+
 	if err := t.WriteMsg(q); err != nil {
 		return nil, err
 	}
+
 	env = make(chan *Envelope)
-	go func() {
-		if q.Question[0].Qtype == TypeAXFR {
-			go t.inAxfr(q, env)
-			return
-		}
-		if q.Question[0].Qtype == TypeIXFR {
-			go t.inIxfr(q, env)
-			return
-		}
-	}()
+	switch q.Question[0].Qtype {
+	case TypeAXFR:
+		go t.inAxfr(q, env)
+	case TypeIXFR:
+		go t.inIxfr(q, env)
+	}
+
 	return env, nil
 }
 
@@ -111,7 +117,7 @@ func (t *Transfer) inAxfr(q *Msg, c chan *Envelope) {
 }
 
 func (t *Transfer) inIxfr(q *Msg, c chan *Envelope) {
-	serial := uint32(0) // The first serial seen is the current server serial
+	var serial uint32 // The first serial seen is the current server serial
 	axfr := true
 	n := 0
 	qser := q.Ns[0].(*SOA).Serial
@@ -192,11 +198,14 @@ func (t *Transfer) Out(w ResponseWriter, q *Msg, ch chan *Envelope) error {
 		r.Authoritative = true
 		// assume it fits TODO(miek): fix
 		r.Answer = append(r.Answer, x.RR...)
+		if tsig := q.IsTsig(); tsig != nil && w.TsigStatus() == nil {
+			r.SetTsig(tsig.Hdr.Name, tsig.Algorithm, tsig.Fudge, time.Now().Unix())
+		}
 		if err := w.WriteMsg(r); err != nil {
 			return err
 		}
+		w.TsigTimersOnly(true)
 	}
-	w.TsigTimersOnly(true)
 	return nil
 }
 
@@ -237,24 +246,18 @@ func (t *Transfer) WriteMsg(m *Msg) (err error) {
 	if err != nil {
 		return err
 	}
-	if _, err = t.Write(out); err != nil {
-		return err
-	}
-	return nil
+	_, err = t.Write(out)
+	return err
 }
 
 func isSOAFirst(in *Msg) bool {
-	if len(in.Answer) > 0 {
-		return in.Answer[0].Header().Rrtype == TypeSOA
-	}
-	return false
+	return len(in.Answer) > 0 &&
+		in.Answer[0].Header().Rrtype == TypeSOA
 }
 
 func isSOALast(in *Msg) bool {
-	if len(in.Answer) > 0 {
-		return in.Answer[len(in.Answer)-1].Header().Rrtype == TypeSOA
-	}
-	return false
+	return len(in.Answer) > 0 &&
+		in.Answer[len(in.Answer)-1].Header().Rrtype == TypeSOA
 }
 
 const errXFR = "bad xfr rcode: %d"

--- a/vendor/github.com/miekg/dns/zduplicate.go
+++ b/vendor/github.com/miekg/dns/zduplicate.go
@@ -2,174 +2,62 @@
 
 package dns
 
-// isDuplicateRdata calls the rdata specific functions
-func isDuplicateRdata(r1, r2 RR) bool {
-	switch r1.Header().Rrtype {
-	case TypeA:
-		return isDuplicateA(r1.(*A), r2.(*A))
-	case TypeAAAA:
-		return isDuplicateAAAA(r1.(*AAAA), r2.(*AAAA))
-	case TypeAFSDB:
-		return isDuplicateAFSDB(r1.(*AFSDB), r2.(*AFSDB))
-	case TypeAVC:
-		return isDuplicateAVC(r1.(*AVC), r2.(*AVC))
-	case TypeCAA:
-		return isDuplicateCAA(r1.(*CAA), r2.(*CAA))
-	case TypeCERT:
-		return isDuplicateCERT(r1.(*CERT), r2.(*CERT))
-	case TypeCNAME:
-		return isDuplicateCNAME(r1.(*CNAME), r2.(*CNAME))
-	case TypeCSYNC:
-		return isDuplicateCSYNC(r1.(*CSYNC), r2.(*CSYNC))
-	case TypeDHCID:
-		return isDuplicateDHCID(r1.(*DHCID), r2.(*DHCID))
-	case TypeDNAME:
-		return isDuplicateDNAME(r1.(*DNAME), r2.(*DNAME))
-	case TypeDNSKEY:
-		return isDuplicateDNSKEY(r1.(*DNSKEY), r2.(*DNSKEY))
-	case TypeDS:
-		return isDuplicateDS(r1.(*DS), r2.(*DS))
-	case TypeEID:
-		return isDuplicateEID(r1.(*EID), r2.(*EID))
-	case TypeEUI48:
-		return isDuplicateEUI48(r1.(*EUI48), r2.(*EUI48))
-	case TypeEUI64:
-		return isDuplicateEUI64(r1.(*EUI64), r2.(*EUI64))
-	case TypeGID:
-		return isDuplicateGID(r1.(*GID), r2.(*GID))
-	case TypeGPOS:
-		return isDuplicateGPOS(r1.(*GPOS), r2.(*GPOS))
-	case TypeHINFO:
-		return isDuplicateHINFO(r1.(*HINFO), r2.(*HINFO))
-	case TypeHIP:
-		return isDuplicateHIP(r1.(*HIP), r2.(*HIP))
-	case TypeKX:
-		return isDuplicateKX(r1.(*KX), r2.(*KX))
-	case TypeL32:
-		return isDuplicateL32(r1.(*L32), r2.(*L32))
-	case TypeL64:
-		return isDuplicateL64(r1.(*L64), r2.(*L64))
-	case TypeLOC:
-		return isDuplicateLOC(r1.(*LOC), r2.(*LOC))
-	case TypeLP:
-		return isDuplicateLP(r1.(*LP), r2.(*LP))
-	case TypeMB:
-		return isDuplicateMB(r1.(*MB), r2.(*MB))
-	case TypeMD:
-		return isDuplicateMD(r1.(*MD), r2.(*MD))
-	case TypeMF:
-		return isDuplicateMF(r1.(*MF), r2.(*MF))
-	case TypeMG:
-		return isDuplicateMG(r1.(*MG), r2.(*MG))
-	case TypeMINFO:
-		return isDuplicateMINFO(r1.(*MINFO), r2.(*MINFO))
-	case TypeMR:
-		return isDuplicateMR(r1.(*MR), r2.(*MR))
-	case TypeMX:
-		return isDuplicateMX(r1.(*MX), r2.(*MX))
-	case TypeNAPTR:
-		return isDuplicateNAPTR(r1.(*NAPTR), r2.(*NAPTR))
-	case TypeNID:
-		return isDuplicateNID(r1.(*NID), r2.(*NID))
-	case TypeNIMLOC:
-		return isDuplicateNIMLOC(r1.(*NIMLOC), r2.(*NIMLOC))
-	case TypeNINFO:
-		return isDuplicateNINFO(r1.(*NINFO), r2.(*NINFO))
-	case TypeNS:
-		return isDuplicateNS(r1.(*NS), r2.(*NS))
-	case TypeNSAPPTR:
-		return isDuplicateNSAPPTR(r1.(*NSAPPTR), r2.(*NSAPPTR))
-	case TypeNSEC:
-		return isDuplicateNSEC(r1.(*NSEC), r2.(*NSEC))
-	case TypeNSEC3:
-		return isDuplicateNSEC3(r1.(*NSEC3), r2.(*NSEC3))
-	case TypeNSEC3PARAM:
-		return isDuplicateNSEC3PARAM(r1.(*NSEC3PARAM), r2.(*NSEC3PARAM))
-	case TypeOPENPGPKEY:
-		return isDuplicateOPENPGPKEY(r1.(*OPENPGPKEY), r2.(*OPENPGPKEY))
-	case TypePTR:
-		return isDuplicatePTR(r1.(*PTR), r2.(*PTR))
-	case TypePX:
-		return isDuplicatePX(r1.(*PX), r2.(*PX))
-	case TypeRKEY:
-		return isDuplicateRKEY(r1.(*RKEY), r2.(*RKEY))
-	case TypeRP:
-		return isDuplicateRP(r1.(*RP), r2.(*RP))
-	case TypeRRSIG:
-		return isDuplicateRRSIG(r1.(*RRSIG), r2.(*RRSIG))
-	case TypeRT:
-		return isDuplicateRT(r1.(*RT), r2.(*RT))
-	case TypeSMIMEA:
-		return isDuplicateSMIMEA(r1.(*SMIMEA), r2.(*SMIMEA))
-	case TypeSOA:
-		return isDuplicateSOA(r1.(*SOA), r2.(*SOA))
-	case TypeSPF:
-		return isDuplicateSPF(r1.(*SPF), r2.(*SPF))
-	case TypeSRV:
-		return isDuplicateSRV(r1.(*SRV), r2.(*SRV))
-	case TypeSSHFP:
-		return isDuplicateSSHFP(r1.(*SSHFP), r2.(*SSHFP))
-	case TypeTA:
-		return isDuplicateTA(r1.(*TA), r2.(*TA))
-	case TypeTALINK:
-		return isDuplicateTALINK(r1.(*TALINK), r2.(*TALINK))
-	case TypeTKEY:
-		return isDuplicateTKEY(r1.(*TKEY), r2.(*TKEY))
-	case TypeTLSA:
-		return isDuplicateTLSA(r1.(*TLSA), r2.(*TLSA))
-	case TypeTSIG:
-		return isDuplicateTSIG(r1.(*TSIG), r2.(*TSIG))
-	case TypeTXT:
-		return isDuplicateTXT(r1.(*TXT), r2.(*TXT))
-	case TypeUID:
-		return isDuplicateUID(r1.(*UID), r2.(*UID))
-	case TypeUINFO:
-		return isDuplicateUINFO(r1.(*UINFO), r2.(*UINFO))
-	case TypeURI:
-		return isDuplicateURI(r1.(*URI), r2.(*URI))
-	case TypeX25:
-		return isDuplicateX25(r1.(*X25), r2.(*X25))
-	}
-	return false
-}
-
 // isDuplicate() functions
 
-func isDuplicateA(r1, r2 *A) bool {
-	if len(r1.A) != len(r2.A) {
+func (r1 *A) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*A)
+	if !ok {
 		return false
 	}
-	for i := 0; i < len(r1.A); i++ {
-		if r1.A[i] != r2.A[i] {
-			return false
-		}
+	_ = r2
+	if !r1.A.Equal(r2.A) {
+		return false
 	}
 	return true
 }
 
-func isDuplicateAAAA(r1, r2 *AAAA) bool {
-	if len(r1.AAAA) != len(r2.AAAA) {
+func (r1 *AAAA) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*AAAA)
+	if !ok {
 		return false
 	}
-	for i := 0; i < len(r1.AAAA); i++ {
-		if r1.AAAA[i] != r2.AAAA[i] {
-			return false
-		}
+	_ = r2
+	if !r1.AAAA.Equal(r2.AAAA) {
+		return false
 	}
 	return true
 }
 
-func isDuplicateAFSDB(r1, r2 *AFSDB) bool {
+func (r1 *AFSDB) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*AFSDB)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Subtype != r2.Subtype {
 		return false
 	}
-	if !isDulicateName(r1.Hostname, r2.Hostname) {
+	if !isDuplicateName(r1.Hostname, r2.Hostname) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateAVC(r1, r2 *AVC) bool {
+func (r1 *ANY) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*ANY)
+	if !ok {
+		return false
+	}
+	_ = r2
+	return true
+}
+
+func (r1 *AVC) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*AVC)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if len(r1.Txt) != len(r2.Txt) {
 		return false
 	}
@@ -181,7 +69,12 @@ func isDuplicateAVC(r1, r2 *AVC) bool {
 	return true
 }
 
-func isDuplicateCAA(r1, r2 *CAA) bool {
+func (r1 *CAA) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*CAA)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Flag != r2.Flag {
 		return false
 	}
@@ -194,7 +87,12 @@ func isDuplicateCAA(r1, r2 *CAA) bool {
 	return true
 }
 
-func isDuplicateCERT(r1, r2 *CERT) bool {
+func (r1 *CERT) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*CERT)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Type != r2.Type {
 		return false
 	}
@@ -210,14 +108,24 @@ func isDuplicateCERT(r1, r2 *CERT) bool {
 	return true
 }
 
-func isDuplicateCNAME(r1, r2 *CNAME) bool {
-	if !isDulicateName(r1.Target, r2.Target) {
+func (r1 *CNAME) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*CNAME)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if !isDuplicateName(r1.Target, r2.Target) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateCSYNC(r1, r2 *CSYNC) bool {
+func (r1 *CSYNC) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*CSYNC)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Serial != r2.Serial {
 		return false
 	}
@@ -235,21 +143,36 @@ func isDuplicateCSYNC(r1, r2 *CSYNC) bool {
 	return true
 }
 
-func isDuplicateDHCID(r1, r2 *DHCID) bool {
+func (r1 *DHCID) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*DHCID)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Digest != r2.Digest {
 		return false
 	}
 	return true
 }
 
-func isDuplicateDNAME(r1, r2 *DNAME) bool {
-	if !isDulicateName(r1.Target, r2.Target) {
+func (r1 *DNAME) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*DNAME)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if !isDuplicateName(r1.Target, r2.Target) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateDNSKEY(r1, r2 *DNSKEY) bool {
+func (r1 *DNSKEY) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*DNSKEY)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Flags != r2.Flags {
 		return false
 	}
@@ -265,7 +188,12 @@ func isDuplicateDNSKEY(r1, r2 *DNSKEY) bool {
 	return true
 }
 
-func isDuplicateDS(r1, r2 *DS) bool {
+func (r1 *DS) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*DS)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.KeyTag != r2.KeyTag {
 		return false
 	}
@@ -281,35 +209,60 @@ func isDuplicateDS(r1, r2 *DS) bool {
 	return true
 }
 
-func isDuplicateEID(r1, r2 *EID) bool {
+func (r1 *EID) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*EID)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Endpoint != r2.Endpoint {
 		return false
 	}
 	return true
 }
 
-func isDuplicateEUI48(r1, r2 *EUI48) bool {
+func (r1 *EUI48) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*EUI48)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Address != r2.Address {
 		return false
 	}
 	return true
 }
 
-func isDuplicateEUI64(r1, r2 *EUI64) bool {
+func (r1 *EUI64) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*EUI64)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Address != r2.Address {
 		return false
 	}
 	return true
 }
 
-func isDuplicateGID(r1, r2 *GID) bool {
+func (r1 *GID) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*GID)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Gid != r2.Gid {
 		return false
 	}
 	return true
 }
 
-func isDuplicateGPOS(r1, r2 *GPOS) bool {
+func (r1 *GPOS) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*GPOS)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Longitude != r2.Longitude {
 		return false
 	}
@@ -322,7 +275,12 @@ func isDuplicateGPOS(r1, r2 *GPOS) bool {
 	return true
 }
 
-func isDuplicateHINFO(r1, r2 *HINFO) bool {
+func (r1 *HINFO) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*HINFO)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Cpu != r2.Cpu {
 		return false
 	}
@@ -332,7 +290,12 @@ func isDuplicateHINFO(r1, r2 *HINFO) bool {
 	return true
 }
 
-func isDuplicateHIP(r1, r2 *HIP) bool {
+func (r1 *HIP) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*HIP)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.HitLength != r2.HitLength {
 		return false
 	}
@@ -352,39 +315,49 @@ func isDuplicateHIP(r1, r2 *HIP) bool {
 		return false
 	}
 	for i := 0; i < len(r1.RendezvousServers); i++ {
-		if !isDulicateName(r1.RendezvousServers[i], r2.RendezvousServers[i]) {
+		if !isDuplicateName(r1.RendezvousServers[i], r2.RendezvousServers[i]) {
 			return false
 		}
 	}
 	return true
 }
 
-func isDuplicateKX(r1, r2 *KX) bool {
+func (r1 *KX) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*KX)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Preference != r2.Preference {
 		return false
 	}
-	if !isDulicateName(r1.Exchanger, r2.Exchanger) {
+	if !isDuplicateName(r1.Exchanger, r2.Exchanger) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateL32(r1, r2 *L32) bool {
+func (r1 *L32) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*L32)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Preference != r2.Preference {
 		return false
 	}
-	if len(r1.Locator32) != len(r2.Locator32) {
+	if !r1.Locator32.Equal(r2.Locator32) {
 		return false
-	}
-	for i := 0; i < len(r1.Locator32); i++ {
-		if r1.Locator32[i] != r2.Locator32[i] {
-			return false
-		}
 	}
 	return true
 }
 
-func isDuplicateL64(r1, r2 *L64) bool {
+func (r1 *L64) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*L64)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Preference != r2.Preference {
 		return false
 	}
@@ -394,7 +367,12 @@ func isDuplicateL64(r1, r2 *L64) bool {
 	return true
 }
 
-func isDuplicateLOC(r1, r2 *LOC) bool {
+func (r1 *LOC) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*LOC)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Version != r2.Version {
 		return false
 	}
@@ -419,72 +397,117 @@ func isDuplicateLOC(r1, r2 *LOC) bool {
 	return true
 }
 
-func isDuplicateLP(r1, r2 *LP) bool {
+func (r1 *LP) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*LP)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Preference != r2.Preference {
 		return false
 	}
-	if !isDulicateName(r1.Fqdn, r2.Fqdn) {
+	if !isDuplicateName(r1.Fqdn, r2.Fqdn) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateMB(r1, r2 *MB) bool {
-	if !isDulicateName(r1.Mb, r2.Mb) {
+func (r1 *MB) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*MB)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if !isDuplicateName(r1.Mb, r2.Mb) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateMD(r1, r2 *MD) bool {
-	if !isDulicateName(r1.Md, r2.Md) {
+func (r1 *MD) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*MD)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if !isDuplicateName(r1.Md, r2.Md) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateMF(r1, r2 *MF) bool {
-	if !isDulicateName(r1.Mf, r2.Mf) {
+func (r1 *MF) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*MF)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if !isDuplicateName(r1.Mf, r2.Mf) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateMG(r1, r2 *MG) bool {
-	if !isDulicateName(r1.Mg, r2.Mg) {
+func (r1 *MG) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*MG)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if !isDuplicateName(r1.Mg, r2.Mg) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateMINFO(r1, r2 *MINFO) bool {
-	if !isDulicateName(r1.Rmail, r2.Rmail) {
+func (r1 *MINFO) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*MINFO)
+	if !ok {
 		return false
 	}
-	if !isDulicateName(r1.Email, r2.Email) {
+	_ = r2
+	if !isDuplicateName(r1.Rmail, r2.Rmail) {
+		return false
+	}
+	if !isDuplicateName(r1.Email, r2.Email) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateMR(r1, r2 *MR) bool {
-	if !isDulicateName(r1.Mr, r2.Mr) {
+func (r1 *MR) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*MR)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if !isDuplicateName(r1.Mr, r2.Mr) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateMX(r1, r2 *MX) bool {
+func (r1 *MX) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*MX)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Preference != r2.Preference {
 		return false
 	}
-	if !isDulicateName(r1.Mx, r2.Mx) {
+	if !isDuplicateName(r1.Mx, r2.Mx) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateNAPTR(r1, r2 *NAPTR) bool {
+func (r1 *NAPTR) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*NAPTR)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Order != r2.Order {
 		return false
 	}
@@ -500,13 +523,18 @@ func isDuplicateNAPTR(r1, r2 *NAPTR) bool {
 	if r1.Regexp != r2.Regexp {
 		return false
 	}
-	if !isDulicateName(r1.Replacement, r2.Replacement) {
+	if !isDuplicateName(r1.Replacement, r2.Replacement) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateNID(r1, r2 *NID) bool {
+func (r1 *NID) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*NID)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Preference != r2.Preference {
 		return false
 	}
@@ -516,14 +544,24 @@ func isDuplicateNID(r1, r2 *NID) bool {
 	return true
 }
 
-func isDuplicateNIMLOC(r1, r2 *NIMLOC) bool {
+func (r1 *NIMLOC) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*NIMLOC)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Locator != r2.Locator {
 		return false
 	}
 	return true
 }
 
-func isDuplicateNINFO(r1, r2 *NINFO) bool {
+func (r1 *NINFO) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*NINFO)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if len(r1.ZSData) != len(r2.ZSData) {
 		return false
 	}
@@ -535,22 +573,37 @@ func isDuplicateNINFO(r1, r2 *NINFO) bool {
 	return true
 }
 
-func isDuplicateNS(r1, r2 *NS) bool {
-	if !isDulicateName(r1.Ns, r2.Ns) {
+func (r1 *NS) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*NS)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if !isDuplicateName(r1.Ns, r2.Ns) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateNSAPPTR(r1, r2 *NSAPPTR) bool {
-	if !isDulicateName(r1.Ptr, r2.Ptr) {
+func (r1 *NSAPPTR) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*NSAPPTR)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if !isDuplicateName(r1.Ptr, r2.Ptr) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateNSEC(r1, r2 *NSEC) bool {
-	if !isDulicateName(r1.NextDomain, r2.NextDomain) {
+func (r1 *NSEC) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*NSEC)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if !isDuplicateName(r1.NextDomain, r2.NextDomain) {
 		return false
 	}
 	if len(r1.TypeBitMap) != len(r2.TypeBitMap) {
@@ -564,7 +617,12 @@ func isDuplicateNSEC(r1, r2 *NSEC) bool {
 	return true
 }
 
-func isDuplicateNSEC3(r1, r2 *NSEC3) bool {
+func (r1 *NSEC3) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*NSEC3)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Hash != r2.Hash {
 		return false
 	}
@@ -597,7 +655,12 @@ func isDuplicateNSEC3(r1, r2 *NSEC3) bool {
 	return true
 }
 
-func isDuplicateNSEC3PARAM(r1, r2 *NSEC3PARAM) bool {
+func (r1 *NSEC3PARAM) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*NSEC3PARAM)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Hash != r2.Hash {
 		return false
 	}
@@ -616,34 +679,78 @@ func isDuplicateNSEC3PARAM(r1, r2 *NSEC3PARAM) bool {
 	return true
 }
 
-func isDuplicateOPENPGPKEY(r1, r2 *OPENPGPKEY) bool {
+func (r1 *NULL) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*NULL)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if r1.Data != r2.Data {
+		return false
+	}
+	return true
+}
+
+func (r1 *OPENPGPKEY) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*OPENPGPKEY)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.PublicKey != r2.PublicKey {
 		return false
 	}
 	return true
 }
 
-func isDuplicatePTR(r1, r2 *PTR) bool {
-	if !isDulicateName(r1.Ptr, r2.Ptr) {
+func (r1 *PTR) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*PTR)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if !isDuplicateName(r1.Ptr, r2.Ptr) {
 		return false
 	}
 	return true
 }
 
-func isDuplicatePX(r1, r2 *PX) bool {
+func (r1 *PX) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*PX)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Preference != r2.Preference {
 		return false
 	}
-	if !isDulicateName(r1.Map822, r2.Map822) {
+	if !isDuplicateName(r1.Map822, r2.Map822) {
 		return false
 	}
-	if !isDulicateName(r1.Mapx400, r2.Mapx400) {
+	if !isDuplicateName(r1.Mapx400, r2.Mapx400) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateRKEY(r1, r2 *RKEY) bool {
+func (r1 *RFC3597) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*RFC3597)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if r1.Rdata != r2.Rdata {
+		return false
+	}
+	return true
+}
+
+func (r1 *RKEY) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*RKEY)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Flags != r2.Flags {
 		return false
 	}
@@ -659,17 +766,27 @@ func isDuplicateRKEY(r1, r2 *RKEY) bool {
 	return true
 }
 
-func isDuplicateRP(r1, r2 *RP) bool {
-	if !isDulicateName(r1.Mbox, r2.Mbox) {
+func (r1 *RP) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*RP)
+	if !ok {
 		return false
 	}
-	if !isDulicateName(r1.Txt, r2.Txt) {
+	_ = r2
+	if !isDuplicateName(r1.Mbox, r2.Mbox) {
+		return false
+	}
+	if !isDuplicateName(r1.Txt, r2.Txt) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateRRSIG(r1, r2 *RRSIG) bool {
+func (r1 *RRSIG) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*RRSIG)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.TypeCovered != r2.TypeCovered {
 		return false
 	}
@@ -691,7 +808,7 @@ func isDuplicateRRSIG(r1, r2 *RRSIG) bool {
 	if r1.KeyTag != r2.KeyTag {
 		return false
 	}
-	if !isDulicateName(r1.SignerName, r2.SignerName) {
+	if !isDuplicateName(r1.SignerName, r2.SignerName) {
 		return false
 	}
 	if r1.Signature != r2.Signature {
@@ -700,17 +817,27 @@ func isDuplicateRRSIG(r1, r2 *RRSIG) bool {
 	return true
 }
 
-func isDuplicateRT(r1, r2 *RT) bool {
+func (r1 *RT) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*RT)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Preference != r2.Preference {
 		return false
 	}
-	if !isDulicateName(r1.Host, r2.Host) {
+	if !isDuplicateName(r1.Host, r2.Host) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateSMIMEA(r1, r2 *SMIMEA) bool {
+func (r1 *SMIMEA) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*SMIMEA)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Usage != r2.Usage {
 		return false
 	}
@@ -726,11 +853,16 @@ func isDuplicateSMIMEA(r1, r2 *SMIMEA) bool {
 	return true
 }
 
-func isDuplicateSOA(r1, r2 *SOA) bool {
-	if !isDulicateName(r1.Ns, r2.Ns) {
+func (r1 *SOA) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*SOA)
+	if !ok {
 		return false
 	}
-	if !isDulicateName(r1.Mbox, r2.Mbox) {
+	_ = r2
+	if !isDuplicateName(r1.Ns, r2.Ns) {
+		return false
+	}
+	if !isDuplicateName(r1.Mbox, r2.Mbox) {
 		return false
 	}
 	if r1.Serial != r2.Serial {
@@ -751,7 +883,12 @@ func isDuplicateSOA(r1, r2 *SOA) bool {
 	return true
 }
 
-func isDuplicateSPF(r1, r2 *SPF) bool {
+func (r1 *SPF) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*SPF)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if len(r1.Txt) != len(r2.Txt) {
 		return false
 	}
@@ -763,7 +900,12 @@ func isDuplicateSPF(r1, r2 *SPF) bool {
 	return true
 }
 
-func isDuplicateSRV(r1, r2 *SRV) bool {
+func (r1 *SRV) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*SRV)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Priority != r2.Priority {
 		return false
 	}
@@ -773,13 +915,18 @@ func isDuplicateSRV(r1, r2 *SRV) bool {
 	if r1.Port != r2.Port {
 		return false
 	}
-	if !isDulicateName(r1.Target, r2.Target) {
+	if !isDuplicateName(r1.Target, r2.Target) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateSSHFP(r1, r2 *SSHFP) bool {
+func (r1 *SSHFP) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*SSHFP)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Algorithm != r2.Algorithm {
 		return false
 	}
@@ -792,7 +939,12 @@ func isDuplicateSSHFP(r1, r2 *SSHFP) bool {
 	return true
 }
 
-func isDuplicateTA(r1, r2 *TA) bool {
+func (r1 *TA) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*TA)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.KeyTag != r2.KeyTag {
 		return false
 	}
@@ -808,18 +960,28 @@ func isDuplicateTA(r1, r2 *TA) bool {
 	return true
 }
 
-func isDuplicateTALINK(r1, r2 *TALINK) bool {
-	if !isDulicateName(r1.PreviousName, r2.PreviousName) {
+func (r1 *TALINK) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*TALINK)
+	if !ok {
 		return false
 	}
-	if !isDulicateName(r1.NextName, r2.NextName) {
+	_ = r2
+	if !isDuplicateName(r1.PreviousName, r2.PreviousName) {
+		return false
+	}
+	if !isDuplicateName(r1.NextName, r2.NextName) {
 		return false
 	}
 	return true
 }
 
-func isDuplicateTKEY(r1, r2 *TKEY) bool {
-	if !isDulicateName(r1.Algorithm, r2.Algorithm) {
+func (r1 *TKEY) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*TKEY)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if !isDuplicateName(r1.Algorithm, r2.Algorithm) {
 		return false
 	}
 	if r1.Inception != r2.Inception {
@@ -849,7 +1011,12 @@ func isDuplicateTKEY(r1, r2 *TKEY) bool {
 	return true
 }
 
-func isDuplicateTLSA(r1, r2 *TLSA) bool {
+func (r1 *TLSA) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*TLSA)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Usage != r2.Usage {
 		return false
 	}
@@ -865,8 +1032,13 @@ func isDuplicateTLSA(r1, r2 *TLSA) bool {
 	return true
 }
 
-func isDuplicateTSIG(r1, r2 *TSIG) bool {
-	if !isDulicateName(r1.Algorithm, r2.Algorithm) {
+func (r1 *TSIG) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*TSIG)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if !isDuplicateName(r1.Algorithm, r2.Algorithm) {
 		return false
 	}
 	if r1.TimeSigned != r2.TimeSigned {
@@ -896,7 +1068,12 @@ func isDuplicateTSIG(r1, r2 *TSIG) bool {
 	return true
 }
 
-func isDuplicateTXT(r1, r2 *TXT) bool {
+func (r1 *TXT) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*TXT)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if len(r1.Txt) != len(r2.Txt) {
 		return false
 	}
@@ -908,21 +1085,36 @@ func isDuplicateTXT(r1, r2 *TXT) bool {
 	return true
 }
 
-func isDuplicateUID(r1, r2 *UID) bool {
+func (r1 *UID) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*UID)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Uid != r2.Uid {
 		return false
 	}
 	return true
 }
 
-func isDuplicateUINFO(r1, r2 *UINFO) bool {
+func (r1 *UINFO) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*UINFO)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Uinfo != r2.Uinfo {
 		return false
 	}
 	return true
 }
 
-func isDuplicateURI(r1, r2 *URI) bool {
+func (r1 *URI) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*URI)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.Priority != r2.Priority {
 		return false
 	}
@@ -935,7 +1127,12 @@ func isDuplicateURI(r1, r2 *URI) bool {
 	return true
 }
 
-func isDuplicateX25(r1, r2 *X25) bool {
+func (r1 *X25) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*X25)
+	if !ok {
+		return false
+	}
+	_ = r2
 	if r1.PSDNAddress != r2.PSDNAddress {
 		return false
 	}

--- a/vendor/github.com/miekg/dns/zmsg.go
+++ b/vendor/github.com/miekg/dns/zmsg.go
@@ -4,3472 +4,2719 @@ package dns
 
 // pack*() functions
 
-func (rr *A) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *A) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packDataA(rr.A, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *AAAA) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *AAAA) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packDataAAAA(rr.AAAA, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *AFSDB) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *AFSDB) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Subtype, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Hostname, msg, off, compression, false)
+	off, err = packDomainName(rr.Hostname, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *ANY) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
-	return headerEnd, off, nil
+func (rr *ANY) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	return off, nil
 }
 
-func (rr *AVC) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *AVC) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packStringTxt(rr.Txt, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *CAA) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *CAA) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint8(rr.Flag, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packString(rr.Tag, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringOctet(rr.Value, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *CDNSKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *CDNSKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Flags, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Protocol, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Algorithm, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringBase64(rr.PublicKey, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *CDS) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *CDS) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.KeyTag, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Algorithm, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.DigestType, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringHex(rr.Digest, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *CERT) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *CERT) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Type, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.KeyTag, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Algorithm, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringBase64(rr.Certificate, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *CNAME) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *CNAME) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Target, msg, off, compression, compress)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Target, msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *CSYNC) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *CSYNC) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint32(rr.Serial, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.Flags, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packDataNsec(rr.TypeBitMap, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *DHCID) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *DHCID) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packStringBase64(rr.Digest, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *DLV) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *DLV) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.KeyTag, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Algorithm, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.DigestType, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringHex(rr.Digest, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *DNAME) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *DNAME) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Target, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Target, msg, off, compression, false)
-	if err != nil {
-		return headerEnd, off, err
-	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *DNSKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *DNSKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Flags, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Protocol, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Algorithm, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringBase64(rr.PublicKey, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *DS) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *DS) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.KeyTag, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Algorithm, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.DigestType, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringHex(rr.Digest, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *EID) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *EID) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packStringHex(rr.Endpoint, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *EUI48) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *EUI48) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint48(rr.Address, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *EUI64) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *EUI64) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint64(rr.Address, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *GID) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *GID) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint32(rr.Gid, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *GPOS) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *GPOS) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packString(rr.Longitude, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packString(rr.Latitude, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packString(rr.Altitude, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *HINFO) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *HINFO) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packString(rr.Cpu, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packString(rr.Os, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *HIP) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *HIP) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint8(rr.HitLength, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.PublicKeyAlgorithm, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.PublicKeyLength, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringHex(rr.Hit, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringBase64(rr.PublicKey, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packDataDomainNames(rr.RendezvousServers, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *KEY) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *KEY) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Flags, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Protocol, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Algorithm, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringBase64(rr.PublicKey, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *KX) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *KX) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Preference, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Exchanger, msg, off, compression, false)
+	off, err = packDomainName(rr.Exchanger, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *L32) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *L32) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Preference, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packDataA(rr.Locator32, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *L64) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *L64) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Preference, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint64(rr.Locator64, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *LOC) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *LOC) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint8(rr.Version, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Size, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.HorizPre, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.VertPre, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.Latitude, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.Longitude, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.Altitude, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *LP) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *LP) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Preference, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Fqdn, msg, off, compression, false)
+	off, err = packDomainName(rr.Fqdn, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *MB) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *MB) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Mb, msg, off, compression, compress)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Mb, msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *MD) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *MD) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Md, msg, off, compression, compress)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Md, msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *MF) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *MF) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Mf, msg, off, compression, compress)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Mf, msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *MG) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *MG) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Mg, msg, off, compression, compress)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Mg, msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *MINFO) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *MINFO) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Rmail, msg, off, compression, compress)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Rmail, msg, off, compression, compress)
+	off, err = packDomainName(rr.Email, msg, off, compression, compress)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Email, msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *MR) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *MR) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Mr, msg, off, compression, compress)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Mr, msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *MX) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *MX) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Preference, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Mx, msg, off, compression, compress)
+	off, err = packDomainName(rr.Mx, msg, off, compression, compress)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *NAPTR) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *NAPTR) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Order, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.Preference, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packString(rr.Flags, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packString(rr.Service, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packString(rr.Regexp, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Replacement, msg, off, compression, false)
+	off, err = packDomainName(rr.Replacement, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *NID) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *NID) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Preference, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint64(rr.NodeID, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *NIMLOC) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *NIMLOC) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packStringHex(rr.Locator, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *NINFO) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *NINFO) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packStringTxt(rr.ZSData, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *NS) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *NS) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Ns, msg, off, compression, compress)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Ns, msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *NSAPPTR) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *NSAPPTR) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Ptr, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Ptr, msg, off, compression, false)
-	if err != nil {
-		return headerEnd, off, err
-	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *NSEC) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *NSEC) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.NextDomain, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
-	}
-	off, _, err = packDomainName(rr.NextDomain, msg, off, compression, false)
-	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packDataNsec(rr.TypeBitMap, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *NSEC3) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *NSEC3) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint8(rr.Hash, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Flags, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.Iterations, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.SaltLength, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	// Only pack salt if value is not "-", i.e. empty
 	if rr.Salt != "-" {
 		off, err = packStringHex(rr.Salt, msg, off)
 		if err != nil {
-			return headerEnd, off, err
+			return off, err
 		}
 	}
 	off, err = packUint8(rr.HashLength, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringBase32(rr.NextDomain, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packDataNsec(rr.TypeBitMap, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *NSEC3PARAM) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *NSEC3PARAM) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint8(rr.Hash, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Flags, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.Iterations, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.SaltLength, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	// Only pack salt if value is not "-", i.e. empty
 	if rr.Salt != "-" {
 		off, err = packStringHex(rr.Salt, msg, off)
 		if err != nil {
-			return headerEnd, off, err
+			return off, err
 		}
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *OPENPGPKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *NULL) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packStringAny(rr.Data, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
+	return off, nil
+}
+
+func (rr *OPENPGPKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packStringBase64(rr.PublicKey, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *OPT) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *OPT) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packDataOpt(rr.Option, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *PTR) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *PTR) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Ptr, msg, off, compression, compress)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Ptr, msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *PX) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *PX) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Preference, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Map822, msg, off, compression, false)
+	off, err = packDomainName(rr.Map822, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Mapx400, msg, off, compression, false)
+	off, err = packDomainName(rr.Mapx400, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *RFC3597) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *RFC3597) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packStringHex(rr.Rdata, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *RKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *RKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Flags, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Protocol, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Algorithm, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringBase64(rr.PublicKey, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *RP) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *RP) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Mbox, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Mbox, msg, off, compression, false)
+	off, err = packDomainName(rr.Txt, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Txt, msg, off, compression, false)
-	if err != nil {
-		return headerEnd, off, err
-	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *RRSIG) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *RRSIG) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.TypeCovered, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Algorithm, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Labels, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.OrigTtl, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.Expiration, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.Inception, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.KeyTag, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.SignerName, msg, off, compression, false)
+	off, err = packDomainName(rr.SignerName, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringBase64(rr.Signature, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *RT) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *RT) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Preference, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Host, msg, off, compression, false)
+	off, err = packDomainName(rr.Host, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *SIG) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *SIG) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.TypeCovered, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Algorithm, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Labels, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.OrigTtl, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.Expiration, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.Inception, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.KeyTag, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.SignerName, msg, off, compression, false)
+	off, err = packDomainName(rr.SignerName, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringBase64(rr.Signature, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *SMIMEA) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *SMIMEA) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint8(rr.Usage, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Selector, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.MatchingType, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringHex(rr.Certificate, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *SOA) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *SOA) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Ns, msg, off, compression, compress)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Ns, msg, off, compression, compress)
+	off, err = packDomainName(rr.Mbox, msg, off, compression, compress)
 	if err != nil {
-		return headerEnd, off, err
-	}
-	off, _, err = packDomainName(rr.Mbox, msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.Serial, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.Refresh, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.Retry, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.Expire, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.Minttl, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *SPF) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *SPF) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packStringTxt(rr.Txt, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *SRV) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *SRV) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Priority, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.Weight, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.Port, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.Target, msg, off, compression, false)
+	off, err = packDomainName(rr.Target, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *SSHFP) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *SSHFP) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint8(rr.Algorithm, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Type, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringHex(rr.FingerPrint, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *TA) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *TA) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.KeyTag, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Algorithm, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.DigestType, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringHex(rr.Digest, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *TALINK) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *TALINK) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.PreviousName, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.PreviousName, msg, off, compression, false)
+	off, err = packDomainName(rr.NextName, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	off, _, err = packDomainName(rr.NextName, msg, off, compression, false)
-	if err != nil {
-		return headerEnd, off, err
-	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *TKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *TKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Algorithm, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
-	}
-	off, _, err = packDomainName(rr.Algorithm, msg, off, compression, false)
-	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.Inception, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint32(rr.Expiration, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.Mode, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.Error, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.KeySize, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringHex(rr.Key, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.OtherLen, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringHex(rr.OtherData, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *TLSA) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *TLSA) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint8(rr.Usage, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.Selector, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint8(rr.MatchingType, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringHex(rr.Certificate, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *TSIG) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
+func (rr *TSIG) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.Algorithm, msg, off, compression, false)
 	if err != nil {
-		return headerEnd, off, err
-	}
-	off, _, err = packDomainName(rr.Algorithm, msg, off, compression, false)
-	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint48(rr.TimeSigned, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.Fudge, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.MACSize, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringHex(rr.MAC, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.OrigId, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.Error, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.OtherLen, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringHex(rr.OtherData, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *TXT) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *TXT) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packStringTxt(rr.Txt, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *UID) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *UID) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint32(rr.Uid, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *UINFO) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *UINFO) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packString(rr.Uinfo, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *URI) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *URI) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Priority, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packUint16(rr.Weight, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
 	off, err = packStringOctet(rr.Target, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
-func (rr *X25) pack(msg []byte, off int, compression compressionMap, compress bool) (int, int, error) {
-	headerEnd, off, err := rr.Hdr.pack(msg, off, compression, compress)
-	if err != nil {
-		return headerEnd, off, err
-	}
+func (rr *X25) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packString(rr.PSDNAddress, msg, off)
 	if err != nil {
-		return headerEnd, off, err
+		return off, err
 	}
-	return headerEnd, off, nil
+	return off, nil
 }
 
 // unpack*() functions
 
-func unpackA(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(A)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *A) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.A, off, err = unpackDataA(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackAAAA(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(AAAA)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *AAAA) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.AAAA, off, err = unpackDataAAAA(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackAFSDB(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(AFSDB)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *AFSDB) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Subtype, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Hostname, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackANY(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(ANY)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *ANY) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
-	return rr, off, err
+	return off, nil
 }
 
-func unpackAVC(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(AVC)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *AVC) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Txt, off, err = unpackStringTxt(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackCAA(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(CAA)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *CAA) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Flag, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Tag, off, err = unpackString(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Value, off, err = unpackStringOctet(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackCDNSKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(CDNSKEY)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *CDNSKEY) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Flags, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Protocol, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.PublicKey, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackCDS(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(CDS)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *CDS) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.DigestType, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Digest, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackCERT(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(CERT)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *CERT) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Type, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Certificate, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackCNAME(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(CNAME)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *CNAME) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Target, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackCSYNC(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(CSYNC)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *CSYNC) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Serial, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Flags, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.TypeBitMap, off, err = unpackDataNsec(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackDHCID(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(DHCID)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *DHCID) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Digest, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackDLV(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(DLV)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *DLV) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.DigestType, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Digest, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackDNAME(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(DNAME)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *DNAME) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Target, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackDNSKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(DNSKEY)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *DNSKEY) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Flags, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Protocol, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.PublicKey, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackDS(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(DS)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *DS) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.DigestType, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Digest, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackEID(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(EID)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *EID) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Endpoint, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackEUI48(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(EUI48)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *EUI48) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Address, off, err = unpackUint48(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackEUI64(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(EUI64)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *EUI64) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Address, off, err = unpackUint64(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackGID(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(GID)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *GID) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Gid, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackGPOS(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(GPOS)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *GPOS) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Longitude, off, err = unpackString(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Latitude, off, err = unpackString(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Altitude, off, err = unpackString(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackHINFO(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(HINFO)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *HINFO) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Cpu, off, err = unpackString(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Os, off, err = unpackString(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackHIP(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(HIP)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *HIP) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.HitLength, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.PublicKeyAlgorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.PublicKeyLength, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Hit, off, err = unpackStringHex(msg, off, off+int(rr.HitLength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	rr.PublicKey, off, err = unpackStringBase64(msg, off, off+int(rr.PublicKeyLength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	rr.RendezvousServers, off, err = unpackDataDomainNames(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(KEY)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *KEY) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Flags, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Protocol, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.PublicKey, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackKX(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(KX)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *KX) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Exchanger, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackL32(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(L32)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *L32) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Locator32, off, err = unpackDataA(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackL64(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(L64)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *L64) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Locator64, off, err = unpackUint64(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackLOC(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(LOC)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *LOC) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Version, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Size, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.HorizPre, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.VertPre, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Latitude, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Longitude, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Altitude, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackLP(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(LP)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *LP) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Fqdn, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackMB(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(MB)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *MB) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Mb, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackMD(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(MD)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *MD) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Md, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackMF(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(MF)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *MF) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Mf, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackMG(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(MG)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *MG) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Mg, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackMINFO(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(MINFO)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *MINFO) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Rmail, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Email, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackMR(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(MR)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *MR) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Mr, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackMX(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(MX)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *MX) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Mx, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackNAPTR(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(NAPTR)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *NAPTR) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Order, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Flags, off, err = unpackString(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Service, off, err = unpackString(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Regexp, off, err = unpackString(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Replacement, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackNID(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(NID)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *NID) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.NodeID, off, err = unpackUint64(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackNIMLOC(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(NIMLOC)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *NIMLOC) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Locator, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackNINFO(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(NINFO)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *NINFO) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.ZSData, off, err = unpackStringTxt(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackNS(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(NS)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *NS) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Ns, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackNSAPPTR(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(NSAPPTR)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *NSAPPTR) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Ptr, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackNSEC(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(NSEC)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *NSEC) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.NextDomain, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.TypeBitMap, off, err = unpackDataNsec(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackNSEC3(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(NSEC3)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *NSEC3) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Hash, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Flags, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Iterations, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.SaltLength, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Salt, off, err = unpackStringHex(msg, off, off+int(rr.SaltLength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	rr.HashLength, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.NextDomain, off, err = unpackStringBase32(msg, off, off+int(rr.HashLength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	rr.TypeBitMap, off, err = unpackDataNsec(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackNSEC3PARAM(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(NSEC3PARAM)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *NSEC3PARAM) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Hash, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Flags, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Iterations, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.SaltLength, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Salt, off, err = unpackStringHex(msg, off, off+int(rr.SaltLength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackOPENPGPKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(OPENPGPKEY)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
+func (rr *NULL) unpack(msg []byte, off int) (off1 int, err error) {
+	rdStart := off
+	_ = rdStart
+
+	rr.Data, off, err = unpackStringAny(msg, off, rdStart+int(rr.Hdr.Rdlength))
+	if err != nil {
+		return off, err
 	}
-	var err error
+	return off, nil
+}
+
+func (rr *OPENPGPKEY) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.PublicKey, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackOPT(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(OPT)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *OPT) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Option, off, err = unpackDataOpt(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackPTR(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(PTR)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *PTR) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Ptr, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackPX(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(PX)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *PX) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Map822, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Mapx400, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackRFC3597(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(RFC3597)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *RFC3597) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Rdata, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackRKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(RKEY)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *RKEY) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Flags, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Protocol, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.PublicKey, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackRP(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(RP)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *RP) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Mbox, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Txt, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackRRSIG(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(RRSIG)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *RRSIG) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.TypeCovered, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Labels, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.OrigTtl, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Expiration, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Inception, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.SignerName, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Signature, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackRT(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(RT)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *RT) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Host, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackSIG(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(SIG)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *SIG) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.TypeCovered, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Labels, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.OrigTtl, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Expiration, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Inception, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.SignerName, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Signature, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackSMIMEA(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(SMIMEA)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *SMIMEA) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Usage, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Selector, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.MatchingType, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Certificate, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackSOA(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(SOA)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *SOA) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Ns, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Mbox, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Serial, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Refresh, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Retry, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Expire, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Minttl, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackSPF(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(SPF)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *SPF) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Txt, off, err = unpackStringTxt(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackSRV(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(SRV)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *SRV) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Priority, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Weight, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Port, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Target, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackSSHFP(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(SSHFP)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *SSHFP) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Type, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.FingerPrint, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackTA(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(TA)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *TA) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.DigestType, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Digest, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackTALINK(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(TALINK)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *TALINK) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.PreviousName, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.NextName, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackTKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(TKEY)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *TKEY) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Algorithm, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Inception, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Expiration, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Mode, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Error, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.KeySize, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Key, off, err = unpackStringHex(msg, off, off+int(rr.KeySize))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	rr.OtherLen, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.OtherData, off, err = unpackStringHex(msg, off, off+int(rr.OtherLen))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackTLSA(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(TLSA)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *TLSA) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Usage, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Selector, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.MatchingType, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Certificate, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackTSIG(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(TSIG)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *TSIG) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Algorithm, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.TimeSigned, off, err = unpackUint48(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Fudge, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.MACSize, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.MAC, off, err = unpackStringHex(msg, off, off+int(rr.MACSize))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	rr.OrigId, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Error, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.OtherLen, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.OtherData, off, err = unpackStringHex(msg, off, off+int(rr.OtherLen))
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackTXT(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(TXT)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *TXT) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Txt, off, err = unpackStringTxt(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackUID(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(UID)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *UID) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Uid, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackUINFO(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(UINFO)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *UINFO) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Uinfo, off, err = unpackString(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackURI(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(URI)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *URI) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.Priority, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Weight, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
 	if off == len(msg) {
-		return rr, off, nil
+		return off, nil
 	}
 	rr.Target, off, err = unpackStringOctet(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
+	return off, nil
 }
 
-func unpackX25(h RR_Header, msg []byte, off int) (RR, int, error) {
-	rr := new(X25)
-	rr.Hdr = h
-	if noRdata(h) {
-		return rr, off, nil
-	}
-	var err error
+func (rr *X25) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
 	rr.PSDNAddress, off, err = unpackString(msg, off)
 	if err != nil {
-		return rr, off, err
+		return off, err
 	}
-	return rr, off, err
-}
-
-var typeToUnpack = map[uint16]func(RR_Header, []byte, int) (RR, int, error){
-	TypeA:          unpackA,
-	TypeAAAA:       unpackAAAA,
-	TypeAFSDB:      unpackAFSDB,
-	TypeANY:        unpackANY,
-	TypeAVC:        unpackAVC,
-	TypeCAA:        unpackCAA,
-	TypeCDNSKEY:    unpackCDNSKEY,
-	TypeCDS:        unpackCDS,
-	TypeCERT:       unpackCERT,
-	TypeCNAME:      unpackCNAME,
-	TypeCSYNC:      unpackCSYNC,
-	TypeDHCID:      unpackDHCID,
-	TypeDLV:        unpackDLV,
-	TypeDNAME:      unpackDNAME,
-	TypeDNSKEY:     unpackDNSKEY,
-	TypeDS:         unpackDS,
-	TypeEID:        unpackEID,
-	TypeEUI48:      unpackEUI48,
-	TypeEUI64:      unpackEUI64,
-	TypeGID:        unpackGID,
-	TypeGPOS:       unpackGPOS,
-	TypeHINFO:      unpackHINFO,
-	TypeHIP:        unpackHIP,
-	TypeKEY:        unpackKEY,
-	TypeKX:         unpackKX,
-	TypeL32:        unpackL32,
-	TypeL64:        unpackL64,
-	TypeLOC:        unpackLOC,
-	TypeLP:         unpackLP,
-	TypeMB:         unpackMB,
-	TypeMD:         unpackMD,
-	TypeMF:         unpackMF,
-	TypeMG:         unpackMG,
-	TypeMINFO:      unpackMINFO,
-	TypeMR:         unpackMR,
-	TypeMX:         unpackMX,
-	TypeNAPTR:      unpackNAPTR,
-	TypeNID:        unpackNID,
-	TypeNIMLOC:     unpackNIMLOC,
-	TypeNINFO:      unpackNINFO,
-	TypeNS:         unpackNS,
-	TypeNSAPPTR:    unpackNSAPPTR,
-	TypeNSEC:       unpackNSEC,
-	TypeNSEC3:      unpackNSEC3,
-	TypeNSEC3PARAM: unpackNSEC3PARAM,
-	TypeOPENPGPKEY: unpackOPENPGPKEY,
-	TypeOPT:        unpackOPT,
-	TypePTR:        unpackPTR,
-	TypePX:         unpackPX,
-	TypeRKEY:       unpackRKEY,
-	TypeRP:         unpackRP,
-	TypeRRSIG:      unpackRRSIG,
-	TypeRT:         unpackRT,
-	TypeSIG:        unpackSIG,
-	TypeSMIMEA:     unpackSMIMEA,
-	TypeSOA:        unpackSOA,
-	TypeSPF:        unpackSPF,
-	TypeSRV:        unpackSRV,
-	TypeSSHFP:      unpackSSHFP,
-	TypeTA:         unpackTA,
-	TypeTALINK:     unpackTALINK,
-	TypeTKEY:       unpackTKEY,
-	TypeTLSA:       unpackTLSA,
-	TypeTSIG:       unpackTSIG,
-	TypeTXT:        unpackTXT,
-	TypeUID:        unpackUID,
-	TypeUINFO:      unpackUINFO,
-	TypeURI:        unpackURI,
-	TypeX25:        unpackX25,
+	return off, nil
 }

--- a/vendor/github.com/miekg/dns/ztypes.go
+++ b/vendor/github.com/miekg/dns/ztypes.go
@@ -54,6 +54,7 @@ var TypeToRR = map[uint16]func() RR{
 	TypeNSEC:       func() RR { return new(NSEC) },
 	TypeNSEC3:      func() RR { return new(NSEC3) },
 	TypeNSEC3PARAM: func() RR { return new(NSEC3PARAM) },
+	TypeNULL:       func() RR { return new(NULL) },
 	TypeOPENPGPKEY: func() RR { return new(OPENPGPKEY) },
 	TypeOPT:        func() RR { return new(OPT) },
 	TypePTR:        func() RR { return new(PTR) },
@@ -209,6 +210,7 @@ func (rr *NSAPPTR) Header() *RR_Header    { return &rr.Hdr }
 func (rr *NSEC) Header() *RR_Header       { return &rr.Hdr }
 func (rr *NSEC3) Header() *RR_Header      { return &rr.Hdr }
 func (rr *NSEC3PARAM) Header() *RR_Header { return &rr.Hdr }
+func (rr *NULL) Header() *RR_Header       { return &rr.Hdr }
 func (rr *OPENPGPKEY) Header() *RR_Header { return &rr.Hdr }
 func (rr *OPT) Header() *RR_Header        { return &rr.Hdr }
 func (rr *PTR) Header() *RR_Header        { return &rr.Hdr }
@@ -238,12 +240,16 @@ func (rr *X25) Header() *RR_Header        { return &rr.Hdr }
 // len() functions
 func (rr *A) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
-	l += net.IPv4len // A
+	if len(rr.A) != 0 {
+		l += net.IPv4len
+	}
 	return l
 }
 func (rr *AAAA) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
-	l += net.IPv6len // AAAA
+	if len(rr.AAAA) != 0 {
+		l += net.IPv6len
+	}
 	return l
 }
 func (rr *AFSDB) len(off int, compression map[string]struct{}) int {
@@ -306,12 +312,12 @@ func (rr *DS) len(off int, compression map[string]struct{}) int {
 	l += 2 // KeyTag
 	l++    // Algorithm
 	l++    // DigestType
-	l += len(rr.Digest)/2 + 1
+	l += len(rr.Digest) / 2
 	return l
 }
 func (rr *EID) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
-	l += len(rr.Endpoint)/2 + 1
+	l += len(rr.Endpoint) / 2
 	return l
 }
 func (rr *EUI48) len(off int, compression map[string]struct{}) int {
@@ -362,8 +368,10 @@ func (rr *KX) len(off int, compression map[string]struct{}) int {
 }
 func (rr *L32) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
-	l += 2           // Preference
-	l += net.IPv4len // Locator32
+	l += 2 // Preference
+	if len(rr.Locator32) != 0 {
+		l += net.IPv4len
+	}
 	return l
 }
 func (rr *L64) len(off int, compression map[string]struct{}) int {
@@ -444,7 +452,7 @@ func (rr *NID) len(off int, compression map[string]struct{}) int {
 }
 func (rr *NIMLOC) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
-	l += len(rr.Locator)/2 + 1
+	l += len(rr.Locator) / 2
 	return l
 }
 func (rr *NINFO) len(off int, compression map[string]struct{}) int {
@@ -473,6 +481,11 @@ func (rr *NSEC3PARAM) len(off int, compression map[string]struct{}) int {
 	l += len(rr.Salt) / 2
 	return l
 }
+func (rr *NULL) len(off int, compression map[string]struct{}) int {
+	l := rr.Hdr.len(off, compression)
+	l += len(rr.Data)
+	return l
+}
 func (rr *OPENPGPKEY) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += base64.StdEncoding.DecodedLen(len(rr.PublicKey))
@@ -492,7 +505,7 @@ func (rr *PX) len(off int, compression map[string]struct{}) int {
 }
 func (rr *RFC3597) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
-	l += len(rr.Rdata)/2 + 1
+	l += len(rr.Rdata) / 2
 	return l
 }
 func (rr *RKEY) len(off int, compression map[string]struct{}) int {
@@ -533,7 +546,7 @@ func (rr *SMIMEA) len(off int, compression map[string]struct{}) int {
 	l++ // Usage
 	l++ // Selector
 	l++ // MatchingType
-	l += len(rr.Certificate)/2 + 1
+	l += len(rr.Certificate) / 2
 	return l
 }
 func (rr *SOA) len(off int, compression map[string]struct{}) int {
@@ -566,7 +579,7 @@ func (rr *SSHFP) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l++ // Algorithm
 	l++ // Type
-	l += len(rr.FingerPrint)/2 + 1
+	l += len(rr.FingerPrint) / 2
 	return l
 }
 func (rr *TA) len(off int, compression map[string]struct{}) int {
@@ -574,7 +587,7 @@ func (rr *TA) len(off int, compression map[string]struct{}) int {
 	l += 2 // KeyTag
 	l++    // Algorithm
 	l++    // DigestType
-	l += len(rr.Digest)/2 + 1
+	l += len(rr.Digest) / 2
 	return l
 }
 func (rr *TALINK) len(off int, compression map[string]struct{}) int {
@@ -601,7 +614,7 @@ func (rr *TLSA) len(off int, compression map[string]struct{}) int {
 	l++ // Usage
 	l++ // Selector
 	l++ // MatchingType
-	l += len(rr.Certificate)/2 + 1
+	l += len(rr.Certificate) / 2
 	return l
 }
 func (rr *TSIG) len(off int, compression map[string]struct{}) int {
@@ -783,12 +796,17 @@ func (rr *NSEC3) copy() RR {
 func (rr *NSEC3PARAM) copy() RR {
 	return &NSEC3PARAM{rr.Hdr, rr.Hash, rr.Flags, rr.Iterations, rr.SaltLength, rr.Salt}
 }
+func (rr *NULL) copy() RR {
+	return &NULL{rr.Hdr, rr.Data}
+}
 func (rr *OPENPGPKEY) copy() RR {
 	return &OPENPGPKEY{rr.Hdr, rr.PublicKey}
 }
 func (rr *OPT) copy() RR {
 	Option := make([]EDNS0, len(rr.Option))
-	copy(Option, rr.Option)
+	for i, e := range rr.Option {
+		Option[i] = e.copy()
+	}
 	return &OPT{rr.Hdr, Option}
 }
 func (rr *PTR) copy() RR {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
-# github.com/letsencrypt/challtestsrv v1.1.0
+# github.com/letsencrypt/challtestsrv v1.2.0
 github.com/letsencrypt/challtestsrv
-# github.com/miekg/dns v1.1.1
+# github.com/miekg/dns v1.1.15
 github.com/miekg/dns
 # golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9
 golang.org/x/crypto/ed25519


### PR DESCRIPTION
Requires updating the `github.com/letsencrypt/challtestsrv` dependency to v1.2.0.