### PR TITLE
Docker: expose ports 14000 and 15000 in the pebble image

### DIFF
--- a/docker/pebble/linux.Dockerfile
+++ b/docker/pebble/linux.Dockerfile
@@ -20,3 +20,6 @@ COPY --from=builder /go/bin/pebble /usr/bin/pebble
 COPY --from=builder /pebble-src/test/ /test/
 
 CMD [ "/usr/bin/pebble" ]
+
+EXPOSE 14000
+EXPOSE 15000

--- a/docker/pebble/windows.Dockerfile
+++ b/docker/pebble/windows.Dockerfile
@@ -16,3 +16,6 @@ COPY --from=builder /pebble-src/test/ /test/
 RUN powershell.exe -Command $path = $env:path + ';c:\gopath\bin'; Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $path
 
 CMD [ "/pebble" ]
+
+EXPOSE 14000
+EXPOSE 15000


### PR DESCRIPTION
Hello,

I exposed ports 14000 and 15000 in the pebble image. I believe this improves readability of Dockerfile and this will help me to run the image on GitlabCI. 

Does that make sense to you?

Thank you!