### PR TITLE
docker-compose: enable TLS 1.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@ services:
   pebble:
     image: letsencrypt/pebble:latest
     command: pebble -config /test/config/pebble-config.json -strict -dnsserver 10.30.50.3:8053
+    environment:
+      # TODO(@cpu): Delete this explicit GODEBUG env var once Pebble is built
+      # with Go 1.13.x which defaults TLS 1.3 to on
+      GODEBUG: "tls13=1"
     ports:
       - 14000:14000  # HTTPS ACME API
       - 15000:15000  # HTTPS Management API


### PR DESCRIPTION
While Pebble is still using Go 1.12.x set the GODEBUG env var for `pebble` to explicitly enable TLS 1.3. This will make it easier for folks to test that they will remain compatible when Boulder enables TLS 1.3 in the very near future.

Switching Pebble to Go 1.13.x (and default-on TLS 1.3) is blocked on AppVeyor adding Go 1.13.x to the Windows images (or replacing AppVeyor with another CI provider).