### PR TITLE
wfe: reply with badCSR if the key is already used for an account (#285)

### DIFF
--- a/acme/problems.go
+++ b/acme/problems.go
@@ -10,6 +10,7 @@ const (
 	serverInternalErr      = errNS + "serverInternal"
 	malformedErr           = errNS + "malformed"
 	badNonceErr            = errNS + "badNonce"
+	badCSRErr              = errNS + "badCSR"
 	agreementReqErr        = errNS + "agreementRequired"
 	connectionErr          = errNS + "connection"
 	unauthorizedErr        = errNS + "unauthorized"
@@ -67,6 +68,14 @@ func MethodNotAllowed() *ProblemDetails {
 func BadNonceProblem(detail string) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       badNonceErr,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+func BadCSRProblem(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       badCSRErr,
 		Detail:     detail,
 		HTTPStatus: http.StatusBadRequest,
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1827,6 +1827,13 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(
 		}
 	}
 
+	// No account key signing RFC8555 Section 11.1
+	existsAcctForCSRKey, _ := wfe.getAcctByKey(parsedCSR.PublicKey)
+	if existsAcctForCSRKey != nil {
+		wfe.sendError(acme.BadCSRProblem("CSR contains a public key for a known account"), response)
+		return
+	}
+
 	// Lock and update the order with the parsed CSR and the began processing
 	// state.
 	existingOrder.Lock()


### PR DESCRIPTION
Fixes #285