### PR TITLE
Compare Identifier.Type with acme.IndentifierIP

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1474,7 +1474,7 @@ func (wfe *WebFrontEndImpl) makeChallenges(authz *core.Authorization, request *h
 	} else {
 		// IP addresses get HTTP-01 and TLS-ALPN challenges
 		var enabledChallenges []string
-		if authz.Identifier.Value == acme.IdentifierIP {
+		if authz.Identifier.Type == acme.IdentifierIP {
 			enabledChallenges = []string{acme.ChallengeHTTP01, acme.ChallengeTLSALPN01}
 		} else {
 			// Non-wildcard, non-IP identifier authorizations get all of the enabled challenge types


### PR DESCRIPTION
To select the challenges for an identifier, the identifier's "Type" should be used to differentiate between "IP" and "non-IP".

Identifier.Value would be something like "10.10.10.10" while Identifier.Type should be "IP" as compared to the constant acme.IdentifierIP