### PR TITLE
WIP: Adds external account binding support

### DIFF
--- a/acme/common.go
+++ b/acme/common.go
@@ -34,9 +34,10 @@ func (ident Identifier) Equals(other Identifier) bool {
 }
 
 type Account struct {
-	Status  string   `json:"status"`
-	Contact []string `json:"contact,omitempty"`
-	Orders  string   `json:"orders,omitempty"`
+	Status                 string   `json:"status"`
+	Contact                []string `json:"contact,omitempty"`
+	Orders                 string   `json:"orders,omitempty"`
+	ExternalAccountBinding *string  `json:"externalAccountBinding,omitempty"`
 }
 
 // An Order is created to request issuance for a CSR

--- a/acme/common.go
+++ b/acme/common.go
@@ -33,11 +33,18 @@ func (ident Identifier) Equals(other Identifier) bool {
 	return ident.Type == other.Type && ident.Value == other.Value
 }
 
+type JSONSigned struct {
+	Protected string `json:"protected"`
+	Payload   string `json:"payload"`
+	Sig       string `json:"signature"`
+}
+
 type Account struct {
-	Status                 string   `json:"status"`
-	Contact                []string `json:"contact,omitempty"`
-	Orders                 string   `json:"orders,omitempty"`
-	ExternalAccountBinding *string  `json:"externalAccountBinding,omitempty"`
+	Status  string   `json:"status"`
+	Contact []string `json:"contact,omitempty"`
+	Orders  string   `json:"orders,omitempty"`
+
+	ExternalAccountBinding *JSONSigned `json:"externalAccountBinding,omitempty"`
 }
 
 // An Order is created to request issuance for a CSR

--- a/acme/problems.go
+++ b/acme/problems.go
@@ -12,6 +12,7 @@ const (
 	badNonceErr            = errNS + "badNonce"
 	badCSRErr              = errNS + "badCSR"
 	agreementReqErr        = errNS + "agreementRequired"
+	externalAccountReqErr  = errNS + "externalAccountRequired"
 	connectionErr          = errNS + "connection"
 	unauthorizedErr        = errNS + "unauthorized"
 	invalidContactErr      = errNS + "invalidContact"
@@ -92,6 +93,14 @@ func Conflict(detail string) *ProblemDetails {
 func AgreementRequiredProblem(detail string) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       agreementReqErr,
+		Detail:     detail,
+		HTTPStatus: http.StatusForbidden,
+	}
+}
+
+func ExternalAccountRequiredProblem(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       externalAccountReqErr,
 		Detail:     detail,
 		HTTPStatus: http.StatusForbidden,
 	}

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -25,7 +25,7 @@ type config struct {
 		OCSPResponderURL        string
 		// Require External Account Binding for "newAccount" requests
 		ExternalAccountBindingRequired bool
-		ExternalAccountBindings        map[string]string
+		ExternalAccountMACKeys         map[string]string
 	}
 }
 
@@ -66,11 +66,9 @@ func main() {
 	ca := ca.New(logger, db, c.Pebble.OCSPResponderURL, alternateRoots)
 	va := va.New(logger, c.Pebble.HTTPPort, c.Pebble.TLSPort, *strictMode, *resolverAddress)
 
-	for keyID, key := range c.Pebble.ExternalAccountBindings {
-		err := db.AddExternalAccountKeyByKeyID(keyID, key)
-		if err != nil {
-			cmd.FailOnError(err, "Failed to add key to external account bindings")
-		}
+	for keyID, key := range c.Pebble.ExternalAccountMACKeys {
+		err := db.AddExternalAccountKeyByID(keyID, key)
+		cmd.FailOnError(err, "Failed to add key to external account bindings")
 	}
 
 	wfeImpl := wfe.New(logger, db, va, ca, *strictMode, c.Pebble.ExternalAccountBindingRequired)

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -23,6 +23,8 @@ type config struct {
 		Certificate             string
 		PrivateKey              string
 		OCSPResponderURL        string
+		// Require External Account Binding for "newAccount" requests
+		ExternalAccountBindingRequired bool
 	}
 }
 
@@ -63,7 +65,7 @@ func main() {
 	ca := ca.New(logger, db, c.Pebble.OCSPResponderURL, alternateRoots)
 	va := va.New(logger, c.Pebble.HTTPPort, c.Pebble.TLSPort, *strictMode, *resolverAddress)
 
-	wfeImpl := wfe.New(logger, db, va, ca, *strictMode)
+	wfeImpl := wfe.New(logger, db, va, ca, *strictMode, c.Pebble.ExternalAccountBindingRequired)
 	muxHandler := wfeImpl.Handler()
 
 	if c.Pebble.ManagementListenAddress != "" {

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -25,6 +25,7 @@ type config struct {
 		OCSPResponderURL        string
 		// Require External Account Binding for "newAccount" requests
 		ExternalAccountBindingRequired bool
+		ExternalAccountBindings        map[string]string
 	}
 }
 
@@ -64,6 +65,13 @@ func main() {
 	db := db.NewMemoryStore()
 	ca := ca.New(logger, db, c.Pebble.OCSPResponderURL, alternateRoots)
 	va := va.New(logger, c.Pebble.HTTPPort, c.Pebble.TLSPort, *strictMode, *resolverAddress)
+
+	for keyID, key := range c.Pebble.ExternalAccountBindings {
+		err := db.AddExternalAccountKeyByKeyID(keyID, key)
+		if err != nil {
+			cmd.FailOnError(err, "Failed to add key to external account bindings")
+		}
+	}
 
 	wfeImpl := wfe.New(logger, db, va, ca, *strictMode, c.Pebble.ExternalAccountBindingRequired)
 	muxHandler := wfeImpl.Handler()

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -51,19 +51,22 @@ type MemoryStore struct {
 
 	certificatesByID        map[string]*core.Certificate
 	revokedCertificatesByID map[string]*core.RevokedCertificate
+
+	externalAccountPublicKeysByKeyID map[string]crypto.PublicKey
 }
 
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
-		accountIDCounter:        1,
-		accountsByID:            make(map[string]*core.Account),
-		accountsByKeyID:         make(map[string]*core.Account),
-		ordersByID:              make(map[string]*core.Order),
-		ordersByAccountID:       make(map[string][]*core.Order),
-		authorizationsByID:      make(map[string]*core.Authorization),
-		challengesByID:          make(map[string]*core.Challenge),
-		certificatesByID:        make(map[string]*core.Certificate),
-		revokedCertificatesByID: make(map[string]*core.RevokedCertificate),
+		accountIDCounter:                 1,
+		accountsByID:                     make(map[string]*core.Account),
+		accountsByKeyID:                  make(map[string]*core.Account),
+		ordersByID:                       make(map[string]*core.Order),
+		ordersByAccountID:                make(map[string][]*core.Order),
+		authorizationsByID:               make(map[string]*core.Authorization),
+		challengesByID:                   make(map[string]*core.Challenge),
+		certificatesByID:                 make(map[string]*core.Certificate),
+		revokedCertificatesByID:          make(map[string]*core.RevokedCertificate),
+		externalAccountPublicKeysByKeyID: make(map[string]crypto.PublicKey),
 	}
 }
 
@@ -397,4 +400,11 @@ func (m *MemoryStore) GetRevokedCertificateBySerial(serialNumber *big.Int) *core
 	}
 
 	return nil
+}
+
+func (m *MemoryStore) GetExtenalAccountPublicKeyByKeyID(keyID string) (crypto.PublicKey, bool) {
+	m.RLock()
+	defer m.RUnlock()
+	pubKey, ok := m.externalAccountPublicKeysByKeyID[keyID]
+	return pubKey, ok
 }

--- a/test/config/pebble-config-external-account-bindings.json
+++ b/test/config/pebble-config-external-account-bindings.json
@@ -1,0 +1,16 @@
+{
+  "pebble": {
+    "listenAddress": "0.0.0.0:14000",
+    "managementListenAddress": "0.0.0.0:15000",
+    "certificate": "test/certs/localhost/cert.pem",
+    "privateKey": "test/certs/localhost/key.pem",
+    "httpPort": 5002,
+    "tlsPort": 5001,
+    "ocspResponderURL": "",
+    "externalAccountBindingRequired": true,
+    "externalAccountBindings": {
+      "kid-1": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",
+      "kid-2": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH"
+    }
+  }
+}

--- a/test/config/pebble-config-external-account-bindings.json
+++ b/test/config/pebble-config-external-account-bindings.json
@@ -8,7 +8,7 @@
     "tlsPort": 5001,
     "ocspResponderURL": "",
     "externalAccountBindingRequired": true,
-    "externalAccountBindings": {
+    "externalAccountMACKeys": {
       "kid-1": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",
       "kid-2": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH"
     }

--- a/test/config/pebble-config.json
+++ b/test/config/pebble-config.json
@@ -6,6 +6,7 @@
     "privateKey": "test/certs/localhost/key.pem",
     "httpPort": 5002,
     "tlsPort": 5001,
-    "ocspResponderURL": ""
+    "ocspResponderURL": "",
+    "externalAccountBindingRequired": false
   }
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -2589,7 +2589,8 @@ func (wfe *WebFrontEndImpl) processRevocation(
 // object that was given in the request if successful. If no External Account
 // Binding was given then return nil however if it is required by the server
 // then error.
-func (wfe *WebFrontEndImpl) verifyEAB(newAcctReq newAccountRequest,
+func (wfe *WebFrontEndImpl) verifyEAB(
+	newAcctReq newAccountRequest,
 	outerPostData *authenticatedPOST) (*acme.JSONSigned, *acme.ProblemDetails) {
 	if newAcctReq.ExternalAccountBinding == nil {
 		if wfe.requireEAB {
@@ -2603,8 +2604,8 @@ func (wfe *WebFrontEndImpl) verifyEAB(newAcctReq newAccountRequest,
 	//1.  Verify that the value of the field is a well-formed JWS
 	eabBytes, err := json.Marshal(newAcctReq.ExternalAccountBinding)
 	if err != nil {
-		return nil, acme.MalformedProblem(
-			fmt.Sprintf("failed to decode external account binding: %s", err))
+		return nil, acme.InternalErrorProblem(
+			fmt.Sprintf("failed to encode external account binding JSON structure: %s", err))
 	}
 
 	eab, err := jose.ParseSigned(string(eabBytes))
@@ -2665,7 +2666,7 @@ func (wfe *WebFrontEndImpl) verifyEABPayloadHeader(innerJWS *jose.JSONWebSignatu
 		break
 	default:
 		return "", acme.BadPublicKeyProblem(
-			"the 'alg' field is not valid for external account binding")
+			fmt.Sprintf("the 'alg' field is set to %q, which is not valid for external account binding, valid values are: HS256, HS384 or HS512", header.Algorithm))
 	}
 	if len(header.Nonce) > 0 {
 		return "", acme.MalformedProblem(


### PR DESCRIPTION
Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>

This PR adds basic support for External Account Binding (EAB) as defined in the [ACME protocol](https://tools.ietf.org/html/rfc8555#section-7.3.4).

The pebble config takes an extra argument `requireExternalBinding` which will require new account ACME request to contain the `externalAccountBinding` object to be present. Pebble will then verify the contents of the object as per the spec.

The Pebble config takes an optional object of `externalAccountBindings` containing a string map to 
KIDs to MAC symmetric keys. These are stored statically in memory.

An extra config example has been made to show both options available (test/config/pebble-config-external-account-bindings.json).

This has been tested using https://github.com/go-acme/lego. The following command will successfully create a new account with Pebble using one of the keys defined in the example config.

```
lego --server https://localhost:14000/dir --domains foo.com  --email joshua.vanleeuwen@jetstack.io --http --kid kid-1 --hmac zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W --eab run
```

**The keys in the example config are public and should never be used in production**