### PR TITLE
CI: switch to Go 1.13, update linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,6 +20,10 @@ linters:
     - gocritic
     - gochecknoinits
     - gochecknoglobals
+    - godox
+    - funlen
+    - wsl
+    - whitespace
 
 issues:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ addons:
     - elpmaxe.letsencrypt.org
 
 go:
-  - "1.12.x"
-
-env:
-  - GO111MODULE=on
+  - "1.13.x"
 
 services:
   - docker
@@ -28,7 +25,7 @@ before_install:
 # `-mod=vendor` to use the vendored dependencies
 install:
   # Install `golangci-lint` using their installer script
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
   # Install tools without `GO111MODULE` enabled so that we
   # don't download Pebble's deps and just put the tools in our
   # gobin.
@@ -41,7 +38,6 @@ before_script:
   - GORACE="halt_on_error=1" pebble &
 
 script:
-  - go mod download
   # Vet Go source code using the linter config (see .golang-ci.yml)
   - golangci-lint run
   # Run project unit tests (with the race detector enabled and atomic

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ hosts:
   elpmaxe.letsencrypt.org: 127.0.0.1
 
 environment:
-  GO111MODULE: on
   PATH: C:\Python37;C:\msys64\mingw64\bin;%USERPROFILE%\go\bin;%PATH%
 
 # Declare artifacts that can become release assets on GitHub
@@ -24,7 +23,7 @@ install:
 
 before_build:
   # Install `golangci-lint` using go get (installer not available for Windows)
-  - go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.15.0
+  - go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.21.0
 
 build_script:
   - go install -v -mod=vendor ./...
@@ -37,7 +36,6 @@ after_build:
   - copy %USERPROFILE%\go\bin\pebble-challtestsrv.exe deploy\pebble-challtestsrv_windows-amd64.exe
 
 test_script:
-  - go mod download
   # Vet Go source code using the linter config (see .golang-ci.yml)
   - golangci-lint run
   # Run project unit tests (with the race detector enabled)

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	golang.org/x/sys v0.0.0-20181206074257-70b957f3b65e // indirect
 	gopkg.in/square/go-jose.v2 v2.1.9
 )
+
+go 1.13


### PR DESCRIPTION
Ignores a few new linters brought along with the golangci-lint update:

* godox - it was flagging TODO comments.
* funlen - too many long Pebble functions. Might be good to revisit this one in the future and add more targeted ignores.
* wsl - **very** opinionated about whitespace/"cuddling" lines.
* whitespace - Doesn't like functions leading with whitespace. I do, especially when the function signature is across multiple lines due to many args.... ¯\\\_(ツ)\_/¯
