### PR TITLE
Update module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/letsencrypt/pebble
+module github.com/letsencrypt/pebble/v2
 
 require (
 	github.com/letsencrypt/challtestsrv v1.2.0


### PR DESCRIPTION
I'm not sure to get how Go modules work but trying to use pebble as a dependency in another project fails:

```sh
$ go get -u github.com/letsencrypt/pebble/v2    
go get github.com/letsencrypt/pebble/v2: module github.com/letsencrypt/pebble@upgrade found (v1.0.1), but does not contain package github.com/letsencrypt/pebble/v2
```

According to https://github.com/golang/go/issues/35732 it looks like the path in the `go.mod` file needs to be synced with the published tags.