### PR TITLE
authorization update

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -2017,6 +2017,14 @@ func (wfe *WebFrontEndImpl) Authz(
 	orderAcctID := authz.Order.AccountID
 	authz.Order.RUnlock()
 
+	// `pending` items should transition to `expired` if too old
+	// the context of this request is irrelevant
+	if authz.Status == acme.StatusPending {
+		if authz.ExpiresDate.Before(time.Now()) {
+			authz.Status = acme.StatusExpired
+		}
+	}
+
 	// If the postData is not a POST-as-GET, treat this as case A) and update
 	// the authorization based on the postData
 	if !postData.postAsGet {


### PR DESCRIPTION
This is a partial fix to #303

I am not sure if this is the correct place or way (does it persist?) to implement this. I would not be offended (and actually happy) if a maintainer were to better implement this PR.

This simply effects the correct state transition for the Authorization object (see https://tools.ietf.org/html/rfc8555#section-7.1.6) where the state is rendered to clients as `expired` after the expiry time.