### PR TITLE
Add PEBBLE_CHAIN_LENGTH.

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,11 @@ request to `https://localhost:15000/roots/0`, `https://localhost:15000/root-keys
 etc. These endpoints also send `Link` HTTP headers for all alternative root and
 intermediate certificates and keys.
 
+The length of certificate chains can be controlled using `PEBBLE_CHAIN_LENGTH`, which has
+a default and minimum value of `1` (leaf + 1 intermediate). For higher values, Pebble will
+include extra intermediate certificates between the leaf and the root. Extra intermediate
+certificates are *not* exposed via the management interface.
+
 #### Certificate Status
 
 The certificate (in PEM format) and its revocation status can be queried by sending

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -202,7 +202,7 @@ func (ca *CAImpl) newChain(intermediateKey crypto.Signer, intermediateSubject pk
 	// If numIntermediates is only 1, then no intermediates will be generated here.
 	prev := root
 	intermediates := make([]*issuer, numIntermediates)
-	for i := 0; i < numIntermediates-1; i++ {
+	for i := numIntermediates - 1; i > 0; i-- {
 		k, ski, err := makeKey()
 		if err != nil {
 			panic(fmt.Sprintf("Error creating new intermediate issuer: %v", err))
@@ -222,12 +222,7 @@ func (ca *CAImpl) newChain(intermediateKey crypto.Signer, intermediateSubject pk
 	if err != nil {
 		panic(fmt.Sprintf("Error creating new intermediate issuer: %s", err.Error()))
 	}
-	intermediates[numIntermediates-1] = intermediate
-
-	// Reverse the order of the intermediates, from leaf signer to root.
-	for i, j := 0, len(intermediates)-1; i < j; i, j = i+1, j-1 {
-		intermediates[i], intermediates[j] = intermediates[j], intermediates[i]
-	}
+	intermediates[0] = intermediate
 
 	return &chain{
 		root:          root,

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -179,7 +179,7 @@ func (ca *CAImpl) newIntermediateIssuer(root *issuer, intermediateKey crypto.Sig
 	if err != nil {
 		return nil, err
 	}
-	ca.log.Printf("Generated new intermediate issuer with serial %s and SKI %x\n", ic.ID, subjectKeyID)
+	ca.log.Printf("Generated new intermediate issuer %s with serial %s and SKI %x\n", ic.Cert.Subject, ic.ID, subjectKeyID)
 	return &issuer{
 		key:  intermediateKey,
 		cert: ic,
@@ -207,14 +207,14 @@ func (ca *CAImpl) newChain(intermediateKey crypto.Signer, intermediateSubject pk
 		if err != nil {
 			panic(fmt.Sprintf("Error creating new intermediate issuer: %v", err))
 		}
-		intermediate, err := ca.makeRootCert(k, pkix.Name{
+		intermediate, err := ca.newIntermediateIssuer(prev, k, pkix.Name{
 			CommonName: intermediateCAPrefix + hex.EncodeToString(makeSerial().Bytes()[:3]),
-		}, ski, prev)
+		}, ski)
 		if err != nil {
 			panic(fmt.Sprintf("Error creating new intermediate issuer: %s", err.Error()))
 		}
-		intermediates[i] = &issuer{key: k, cert: intermediate}
-		prev = intermediates[i]
+		intermediates[i] = intermediate
+		prev = intermediate
 	}
 
 	// The first issuer is the one which signs the leaf certificates

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -62,8 +62,13 @@ func main() {
 		alternateRoots = int(val)
 	}
 
+	chainLength := 1
+	if val, err := strconv.ParseInt(os.Getenv("PEBBLE_CHAIN_LENGTH"), 10, 0); err == nil && val >= 0 {
+		chainLength = int(val)
+	}
+
 	db := db.NewMemoryStore()
-	ca := ca.New(logger, db, c.Pebble.OCSPResponderURL, alternateRoots)
+	ca := ca.New(logger, db, c.Pebble.OCSPResponderURL, alternateRoots, chainLength)
 	va := va.New(logger, c.Pebble.HTTPPort, c.Pebble.TLSPort, *strictMode, *resolverAddress)
 
 	for keyID, key := range c.Pebble.ExternalAccountMACKeys {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -2398,14 +2398,14 @@ func (wfe *WebFrontEndImpl) Certificate(
 		return
 	}
 
-	if no >= len(cert.Issuers) {
+	if no >= len(cert.IssuerChains) {
 		response.WriteHeader(http.StatusNotFound)
 		return
 	}
 
 	// Add links to alternate roots
 	basePath := wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", certPath, serial))
-	addAlternateLinks(response, basePath, no, len(cert.Issuers))
+	addAlternateLinks(response, basePath, no, len(cert.IssuerChains))
 
 	response.Header().Set("Content-Type", "application/pem-certificate-chain; charset=utf-8")
 	response.WriteHeader(http.StatusOK)


### PR DESCRIPTION
This commit adds a way to control how long the certificate issuance
chains that Pebble uses are. The default and minimum value of 1 means
that there is one intermediate certificate in the final certificate
chain.

Fixes #318.

--- 

The resulting certificate chain (at a value of `2`) looks like this:

    $ cat b.pem | openssl crl2pkcs7 -nocrl -certfile /dev/stdin | openssl pkcs7 -print_certs -noout
    subject=CN = xfoobazx.com

    issuer=CN = Pebble Intermediate CA 2f1dd1


    subject=CN = Pebble Intermediate CA 2f1dd1

    issuer=CN = Pebble Intermediate CA 5a564f


    subject=CN = Pebble Intermediate CA 5a564f

    issuer=CN = Pebble Root CA 0335fe

The change is a little bit awkward because Pebble has been, in parts, written with an assumption about there being one intermediate.

The additional intermediates are not exposed via the management interface. It might be possible to make a non-breaking change to `:15000/intermediate-keys/`, but I haven't been able to think of a use-case for exposing them. 