### PR TITLE
README: Remove note about not supporting EAB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ clients are not hardcoding URLs.)
 ## Limitations
 
 Pebble is missing some ACME features (PRs are welcome!). It does not presently
-support subproblems, pre-authorization or external account binding. Pebble does
-not support revoking a certificate issued by a different ACME account by proving
-authorization of all of the certificate's domains.
+support subproblems, or pre-authorization. Pebble does not support revoking a 
+certificate issued by a different ACME account by proving authorization of all
+of the certificate's domains.
 
 Pebble does not perform all of the same input validation as Boulder. Some domain
 names that would be rejected by Boulder/Let's Encrypt may work with Pebble.


### PR DESCRIPTION
Since https://github.com/letsencrypt/pebble/pull/288 Pebble **does** support external account binding (EAB). This commit updates the "Limitations" section of the README accordingly.