### PR TITLE
Add a blocklist for Order identifiers

### DIFF
--- a/acme/problems.go
+++ b/acme/problems.go
@@ -22,6 +22,7 @@ const (
 	alreadyRevokedErr      = errNS + "alreadyRevoked"
 	orderNotReadyErr       = errNS + "orderNotReady"
 	badPublicKeyErr        = errNS + "badPublicKey"
+	rejectedIdentifierErr  = errNS + "rejectedIdentifier"
 )
 
 type ProblemDetails struct {
@@ -181,6 +182,14 @@ func OrderNotReadyProblem(detail string) *ProblemDetails {
 func BadPublicKeyProblem(detail string) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       badPublicKeyErr,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+func RejectedIdentifierProblem(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       rejectedIdentifierErr,
 		Detail:     detail,
 		HTTPStatus: http.StatusBadRequest,
 	}

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -27,7 +27,7 @@ type config struct {
 		ExternalAccountBindingRequired bool
 		ExternalAccountMACKeys         map[string]string
 		// Configure policies to deny certain domains
-		BlockList []string
+		DomainBlocklist []string
 	}
 }
 
@@ -78,7 +78,7 @@ func main() {
 		cmd.FailOnError(err, "Failed to add key to external account bindings")
 	}
 
-	for _, domainName := range c.Pebble.BlockList {
+	for _, domainName := range c.Pebble.DomainBlocklist {
 		err := db.AddBlockedDomain(domainName)
 		cmd.FailOnError(err, "Failed to add domain to block list")
 	}

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -26,6 +26,8 @@ type config struct {
 		// Require External Account Binding for "newAccount" requests
 		ExternalAccountBindingRequired bool
 		ExternalAccountMACKeys         map[string]string
+		// Configure policies to deny certain domains
+		BlockList []string
 	}
 }
 
@@ -74,6 +76,11 @@ func main() {
 	for keyID, key := range c.Pebble.ExternalAccountMACKeys {
 		err := db.AddExternalAccountKeyByID(keyID, key)
 		cmd.FailOnError(err, "Failed to add key to external account bindings")
+	}
+
+	for _, domainName := range c.Pebble.BlockList {
+		err := db.AddBlockedDomain(domainName)
+		cmd.FailOnError(err, "Failed to add domain to block list")
 	}
 
 	wfeImpl := wfe.New(logger, db, va, ca, *strictMode, c.Pebble.ExternalAccountBindingRequired)

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -455,7 +455,7 @@ func (m *MemoryStore) AddBlockedDomain(name string) error {
 	return nil
 }
 
-// GetBlockedDomain will return true if a domain is on teh block list
+// GetBlockedDomain will return true if a domain is on the block list
 func (m *MemoryStore) GetBlockedDomain(name string) bool {
 	m.RLock()
 	defer m.RUnlock()

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -55,6 +55,8 @@ type MemoryStore struct {
 	revokedCertificatesByID map[string]*core.RevokedCertificate
 
 	externalAccountKeysByID map[string][]byte
+
+	blockListByDomain map[string]bool
 }
 
 func NewMemoryStore() *MemoryStore {
@@ -69,6 +71,7 @@ func NewMemoryStore() *MemoryStore {
 		certificatesByID:        make(map[string]*core.Certificate),
 		revokedCertificatesByID: make(map[string]*core.RevokedCertificate),
 		externalAccountKeysByID: make(map[string][]byte),
+		blockListByDomain:       make(map[string]bool),
 	}
 }
 
@@ -436,4 +439,26 @@ func (m *MemoryStore) GetExtenalAccountKeyByID(keyID string) ([]byte, bool) {
 	defer m.RUnlock()
 	key, ok := m.externalAccountKeysByID[keyID]
 	return key, ok
+}
+
+// AddBlockedDomain will add the domain name to the block list
+func (m *MemoryStore) AddBlockedDomain(name string) error {
+	if len(name) == 0 {
+		return errors.New("domain name must not be empty")
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	m.blockListByDomain[name] = true
+
+	return nil
+}
+
+// GetBlockedDomain will return true if a domain is on teh block list
+func (m *MemoryStore) GetBlockedDomain(name string) bool {
+	m.RLock()
+	defer m.RUnlock()
+	_, ok := m.blockListByDomain[name]
+	return ok
 }

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -57,7 +57,7 @@ type MemoryStore struct {
 
 	externalAccountKeysByID map[string][]byte
 
-	blockListByDomain []string
+	blockListByDomain [][]string
 }
 
 func NewMemoryStore() *MemoryStore {
@@ -72,7 +72,7 @@ func NewMemoryStore() *MemoryStore {
 		certificatesByID:        make(map[string]*core.Certificate),
 		revokedCertificatesByID: make(map[string]*core.RevokedCertificate),
 		externalAccountKeysByID: make(map[string][]byte),
-		blockListByDomain:       make([]string, 0),
+		blockListByDomain:       make([][]string, 0),
 	}
 }
 
@@ -457,7 +457,7 @@ func (m *MemoryStore) AddBlockedDomain(name string) error {
 		domainParts[i], domainParts[j] = domainParts[j], domainParts[i]
 	}
 
-	m.blockListByDomain = append(m.blockListByDomain, strings.Join(domainParts, "."))
+	m.blockListByDomain = append(m.blockListByDomain, domainParts)
 
 	return nil
 }
@@ -474,9 +474,7 @@ func (m *MemoryStore) IsDomainBlocked(name string) bool {
 		domainParts[i], domainParts[j] = domainParts[j], domainParts[i]
 	}
 
-	for _, blockedDomain := range m.blockListByDomain {
-		blockedParts := strings.Split(blockedDomain, ".")
-
+	for _, blockedParts := range m.blockListByDomain {
 		isMatch := true
 		for i := range blockedParts {
 			if blockedParts[i] != domainParts[i] {

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -448,8 +448,6 @@ func (m *MemoryStore) AddBlockedDomain(name string) error {
 		return errors.New("domain name must not be empty")
 	}
 
-	m.Lock()
-	defer m.Unlock()
 	domainParts := strings.Split(name, ".")
 
 	// reversing the order
@@ -457,6 +455,8 @@ func (m *MemoryStore) AddBlockedDomain(name string) error {
 		domainParts[i], domainParts[j] = domainParts[j], domainParts[i]
 	}
 
+	m.Lock()
+	defer m.Unlock()
 	m.blockListByDomain = append(m.blockListByDomain, domainParts)
 
 	return nil
@@ -464,9 +464,6 @@ func (m *MemoryStore) AddBlockedDomain(name string) error {
 
 // IsDomainBlocked will return true if a domain is on the block list
 func (m *MemoryStore) IsDomainBlocked(name string) bool {
-	m.RLock()
-	defer m.RUnlock()
-
 	domainParts := strings.Split(name, ".")
 
 	// reversing the order
@@ -474,6 +471,8 @@ func (m *MemoryStore) IsDomainBlocked(name string) bool {
 		domainParts[i], domainParts[j] = domainParts[j], domainParts[i]
 	}
 
+	m.RLock()
+	defer m.RUnlock()
 	for _, blockedParts := range m.blockListByDomain {
 		isMatch := true
 		for i := range blockedParts {

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -467,8 +467,24 @@ func (m *MemoryStore) IsDomainBlocked(name string) bool {
 	m.RLock()
 	defer m.RUnlock()
 
+	domainParts := strings.Split(name, ".")
+
+	// reversing the order
+	for i, j := 0, len(domainParts)-1; i < j; i, j = i+1, j-1 {
+		domainParts[i], domainParts[j] = domainParts[j], domainParts[i]
+	}
+
 	for _, blockedDomain := range m.blockListByDomain {
-		if strings.HasPrefix(name, blockedDomain) {
+		blockedParts := strings.Split(blockedDomain, ".")
+
+		isMatch := true
+		for i := range blockedParts {
+			if blockedParts[i] != domainParts[i] {
+				isMatch = false
+				break
+			}
+		}
+		if isMatch {
 			return true
 		}
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1425,12 +1425,6 @@ func (wfe *WebFrontEndImpl) verifyOrder(order *core.Order) *acme.ProblemDetails 
 }
 
 func (wfe *WebFrontEndImpl) validateDNSName(rawDomain string) *acme.ProblemDetails {
-	if wfe.db.IsDomainBlocked(rawDomain) {
-		return acme.RejectedIdentifierProblem(fmt.Sprintf(
-			"Order included an identifier for which issuance is forbidden by policy: %q",
-			rawDomain))
-	}
-
 	if rawDomain == "" {
 		return acme.MalformedProblem(fmt.Sprintf(
 			"Order included DNS identifier with empty value"))
@@ -1478,6 +1472,12 @@ func (wfe *WebFrontEndImpl) validateDNSName(rawDomain string) *acme.ProblemDetai
 					"wildcard isn't leftmost prefix %q",
 				rawDomain))
 		}
+	}
+
+	if wfe.db.IsDomainBlocked(rawDomain) {
+		return acme.RejectedIdentifierProblem(fmt.Sprintf(
+			"Order included an identifier for which issuance is forbidden by policy: %q",
+			rawDomain))
 	}
 
 	return nil


### PR DESCRIPTION
This adds a small version of the domain policies of boulder in the version of a block list which can deny certain domains (or IPs) with the `rejectedIdentifier` error.
This allows to tes the behaviour of having an order rejected by policy rules.

Let me know if it needs some changes, tests or documentation 😄  