### PR TITLE
wfe: surface errors related to JWS parsing

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -647,7 +647,7 @@ func (wfe *WebFrontEndImpl) parseJWS(body string) (*jose.JSONWebSignature, error
 		Signatures []interface{}
 	}
 	if err := json.Unmarshal([]byte(body), &unprotected); err != nil {
-		return nil, errors.New("Parse error reading JWS")
+		return nil, fmt.Errorf("Parse error reading JWS: %w", err)
 	}
 
 	// ACME v2 never uses values from the unprotected JWS header. Reject JWS that
@@ -666,7 +666,7 @@ func (wfe *WebFrontEndImpl) parseJWS(body string) (*jose.JSONWebSignature, error
 
 	parsedJWS, err := jose.ParseSigned(body)
 	if err != nil {
-		return nil, errors.New("Parse error reading JWS")
+		return nil, fmt.Errorf("Parse error reading JWS: %w", err)
 	}
 
 	if len(parsedJWS.Signatures) > 1 {


### PR DESCRIPTION
This is very much a matter of opinion, but given Pebble's role as a development server, I think it would help to expose more error detail where possible.

JWS can be particularly tedious to debug. I feel that this:

```json
{
   "type": "urn:ietf:params:acme:error:malformed",
   "detail": "Parse error reading JWS: square/go-jose: invalid embedded jwk, must be public key",
   "status": 400
}
```

is a better experience than:

```json
{
   "type": "urn:ietf:params:acme:error:malformed",
   "detail": "Parse error reading JWS",
   "status": 400
}
```