### PR TITLE
Add an option to listen on HTTP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,11 @@ store or to any production systems/codebases. The private key for this CA is
 intentionally made [publicly available in this
 repo](test/certs/pebble.minica.key.pem).**
 
+### Listening on HTTP
+
+In order to make Pebble accessible over HTTP, you can set the
+`listenHttp` setting of the `pebble-config.json` file.
+
 ### Management interface
 
 In order to ease the interaction of Pebble with testing systems, a specific HTTP

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -17,6 +17,7 @@ import (
 type config struct {
 	Pebble struct {
 		ListenAddress           string
+		ListenHTTP              bool
 		ManagementListenAddress string
 		HTTPPort                int
 		TLSPort                 int
@@ -110,10 +111,14 @@ func main() {
 	logger.Printf("Listening on: %s\n", c.Pebble.ListenAddress)
 	logger.Printf("ACME directory available at: https://%s%s",
 		c.Pebble.ListenAddress, wfe.DirectoryPath)
-	err = http.ListenAndServeTLS(
-		c.Pebble.ListenAddress,
-		c.Pebble.Certificate,
-		c.Pebble.PrivateKey,
-		muxHandler)
+	if c.Pebble.ListenHTTP {
+		err = http.ListenAndServe(c.Pebble.ListenAddress, muxHandler)
+	} else {
+		err = http.ListenAndServeTLS(
+			c.Pebble.ListenAddress,
+			c.Pebble.Certificate,
+			c.Pebble.PrivateKey,
+			muxHandler)
+	}
 	cmd.FailOnError(err, "Calling ListenAndServeTLS()")
 }

--- a/test/config/pebble-config.json
+++ b/test/config/pebble-config.json
@@ -1,6 +1,7 @@
 {
   "pebble": {
     "listenAddress": "0.0.0.0:14000",
+    "listenHttp": false,
     "managementListenAddress": "0.0.0.0:15000",
     "certificate": "test/certs/localhost/cert.pem",
     "privateKey": "test/certs/localhost/key.pem",


### PR DESCRIPTION
This is needed when deploying Pebble behind other proxies doing TLS
termination. In my use case, I've been deploying a test instance on a
PaaS hosting platform that provides the TLS termination in front of
Pebble, so I have to make it listen on HTTP only.