### PR TITLE
Randomize the account ID generated

### DIFF
--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"math/rand"
 	"reflect"
 	"strconv"
 	"strings"
@@ -37,7 +38,7 @@ func (e ExistingAccountError) Error() string {
 type MemoryStore struct {
 	sync.RWMutex
 
-	accountIDCounter int
+	accountRand *rand.Rand
 
 	accountsByID map[string]*core.Account
 
@@ -62,7 +63,7 @@ type MemoryStore struct {
 
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
-		accountIDCounter:        1,
+		accountRand:             rand.New(rand.NewSource(time.Now().UnixNano())),
 		accountsByID:            make(map[string]*core.Account),
 		accountsByKeyID:         make(map[string]*core.Account),
 		ordersByID:              make(map[string]*core.Order),
@@ -115,9 +116,6 @@ func (m *MemoryStore) AddAccount(acct *core.Account) (int, error) {
 	m.Lock()
 	defer m.Unlock()
 
-	acctID := strconv.Itoa(m.accountIDCounter)
-	m.accountIDCounter++
-
 	if acct.Key == nil {
 		return 0, fmt.Errorf("account must not have a nil Key")
 	}
@@ -127,8 +125,12 @@ func (m *MemoryStore) AddAccount(acct *core.Account) (int, error) {
 		return 0, err
 	}
 
-	if _, present := m.accountsByID[acctID]; present {
-		return 0, fmt.Errorf("account %q already exists", acctID)
+	var acctID string
+	for {
+		acctID = strconv.FormatInt(m.accountRand.Int63(), 16)
+		if _, present := m.accountsByID[acctID]; !present {
+			break
+		}
 	}
 
 	if _, present := m.accountsByKeyID[keyID]; present {


### PR DESCRIPTION
This also switches account IDs to hex, so there's no assumptions about them being integers.

Closes #340 