### PR TITLE
Add env var to set certificate lifetime

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -352,8 +352,9 @@ func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.Publ
 
 func New(log *log.Logger, db *db.MemoryStore, ocspResponderURL string, alternateRoots int, chainLength int) *CAImpl {
 	ca := &CAImpl{
-		log: log,
-		db:  db,
+		log:          log,
+		db:           db,
+		certLifetime: defaultCertLifetime,
 	}
 
 	if ocspResponderURL != "" {
@@ -374,7 +375,6 @@ func New(log *log.Logger, db *db.MemoryStore, ocspResponderURL string, alternate
 	}
 
 	// Get cert lifetime in days from the environment
-	ca.certLifetime = defaultCertLifetime
 	if val, err := strconv.ParseInt(os.Getenv(certLifetimeEnvVar), 10, 0); err == nil &&
 		val > 0 {
 		ca.certLifetime = int(val)

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -369,15 +369,15 @@ func New(log *log.Logger, db *db.MemoryStore, ocspResponderURL string, alternate
 		ca.chains[i] = ca.newChain(intermediateKey, intermediateSubject, subjectKeyID, chainLength)
 	}
 
-        // Get cert lifetime in days from the environment
-        ca.certLifetime = defaultCertLifetime
-        if val, err := strconv.ParseInt(os.Getenv(certLifetimeEnvVar), 10, 0); err == nil &&
-                val > 0 {
-                ca.certLifetime = int(val)
-                ca.log.Printf("Using user defined certificate lifetime of %d days", ca.certLifetime)
-        } else {
-                ca.log.Printf("Using default certificate lifetime of %d days", ca.certLifetime)
-        }
+	// Get cert lifetime in days from the environment
+	ca.certLifetime = defaultCertLifetime
+	if val, err := strconv.ParseInt(os.Getenv(certLifetimeEnvVar), 10, 0); err == nil &&
+		val > 0 {
+		ca.certLifetime = int(val)
+		ca.log.Printf("Using user defined certificate lifetime of %d days", ca.certLifetime)
+	} else {
+		ca.log.Printf("Using default certificate lifetime of %d days", ca.certLifetime)
+	}
 
 	return ca
 }

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -284,6 +284,10 @@ func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.Publ
 	}
 
 	certNotAfter := time.Now().AddDate(0, 0, ca.certLifetime)
+	maxNotAfter := time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC)
+	if certNotAfter.After(maxNotAfter) {
+		certNotAfter = maxNotAfter
+	}
 	if notAfter != "" {
 		certNotAfter, err = time.Parse(time.RFC3339, notAfter)
 		if err != nil {


### PR DESCRIPTION
This commit/PR adds the `PEBBLE_CERT_LIFETIME` environment variable to be able to set the end leaf certificate lifetime.

Currently, it uses the current 5 years as default, but does not have an upper limit. No idea what happens if the user sets `PEBBLE_CERT_LIFETIME` to something HUGE or very strange (like a non-integer variable), pebble probably crashes.

Mainly for personal use, but perhaps you might be interested :slightly_smiling_face: 

An alternative by using the configuration file instead of an environment variable can be found in #361