### PR TITLE
Copy over extensions (e.g. must-staple) from offered CSR into final cert

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -248,7 +248,7 @@ func (ca *CAImpl) newChain(intermediateKey crypto.Signer, intermediateSubject pk
 	return c
 }
 
-func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.PublicKey, accountID, notBefore, notAfter string) (*core.Certificate, error) {
+func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.PublicKey, accountID, notBefore, notAfter string, ext []pkix.Extension) (*core.Certificate, error) {
 	var cn string
 	if len(domains) > 0 {
 		cn = domains[0]
@@ -301,6 +301,8 @@ func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.Publ
 		SubjectKeyId:          subjectKeyID,
 		BasicConstraintsValid: true,
 		IsCA:                  false,
+
+		ExtraExtensions: ext,
 	}
 
 	if ca.ocspResponderURL != "" {
@@ -391,7 +393,7 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 
 	// issue a certificate for the csr
 	csr := order.ParsedCSR
-	cert, err := ca.newCertificate(csr.DNSNames, csr.IPAddresses, csr.PublicKey, order.AccountID, order.NotBefore, order.NotAfter)
+	cert, err := ca.newCertificate(csr.DNSNames, csr.IPAddresses, csr.PublicKey, order.AccountID, order.NotBefore, order.NotAfter, csr.Extensions)
 	if err != nil {
 		ca.log.Printf("Error: unable to issue order: %s", err.Error())
 		return


### PR DESCRIPTION
Just a tiny simple modification to Pebble so if the client requests a certain extension in the CSR, such as must-staple, it will end up in the certificate too.

This code doesn't check the requested extensions in the orders CSR, it just c/ps it.. My Golang skills aren't good enough for any of that and frankly I'm not going/willing to learn Go either. I just wanted this feature in Pebble so I could work on some must-staple features in certbot, so I implemented this.