### PR TITLE
Add management server handler to change certificate lifetime

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -281,6 +281,10 @@ func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.Publ
 	}
 
 	certNotAfter := time.Now().AddDate(0, 0, ca.certLifetime)
+	maxNotAfter := time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC)
+	if certNotAfter.After(maxNotAfter) {
+		certNotAfter = maxNotAfter
+	}
 	if notAfter != "" {
 		certNotAfter, err = time.Parse(time.RFC3339, notAfter)
 		if err != nil {

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -349,8 +349,9 @@ func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.Publ
 
 func New(log *log.Logger, db *db.MemoryStore, ocspResponderURL string, alternateRoots int, chainLength int) *CAImpl {
 	ca := &CAImpl{
-		log: log,
-		db:  db,
+		log:          log,
+		db:           db,
+		certLifetime: defaultCertLifetime,
 	}
 
 	if ocspResponderURL != "" {
@@ -369,7 +370,6 @@ func New(log *log.Logger, db *db.MemoryStore, ocspResponderURL string, alternate
 	for i := 0; i < len(ca.chains); i++ {
 		ca.chains[i] = ca.newChain(intermediateKey, intermediateSubject, subjectKeyID, chainLength)
 	}
-	ca.certLifetime = defaultCertLifetime
 	return ca
 }
 

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -495,7 +495,6 @@ func (wfe *WebFrontEndImpl) handleChangeCertLifetime(
 	request *http.Request) {
 
 	lifetimeStr := strings.TrimPrefix(request.URL.Path, certLifetime)
-	wfe.log.Printf("Setting certificate lifetime to %s days", lifetimeStr)
 	if lifetime, err := strconv.ParseInt(lifetimeStr, 10, 0); err == nil &&
 		lifetime > 0 {
 		result := struct {
@@ -507,6 +506,7 @@ func (wfe *WebFrontEndImpl) handleChangeCertLifetime(
 		}
 
 		if wfe.ca.ChangeCertificateLifetime(int(lifetime)) {
+			wfe.log.Printf("Certificate lifetime set to %s days", lifetimeStr)
 			err := wfe.writeJSONResponse(response, http.StatusOK, result)
 			if err != nil {
 				response.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Partly related to #353 and #361

This PR adds a new endpoint to the management interface: `/change-cert-lifetime/`

It takes an integer as value (i.e. `/change-cert-lifetime/123`) which will set the certificate lifetime to the value amount of days.

The output will show a JSON structure with "Old" and "New" containing the previous and new certificate lifetimes if successful. It will return a HTTP 400 if the requested value wasn't an integer > 0 and it will return a HTTP 500 if something else went wrong.