### PR TITLE
eliminating '-X POST' from curl command line examples.

### DIFF
--- a/cmd/pebble-challtestsrv/README.md
+++ b/cmd/pebble-challtestsrv/README.md
@@ -52,12 +52,12 @@ responses using the `-defaultIPv4` and `-defaultIPv6` command line flags.
 To change the default IPv4 address used for responses to `A` queries that do not
 match explicit mocks at runtime run:
 
-    curl -X POST -d '{"ip":"10.10.10.2"}' http://localhost:8055/set-default-ipv4
+    curl -d '{"ip":"10.10.10.2"}' http://localhost:8055/set-default-ipv4
 
 Similarly to change the default IPv6 address used for responses to `AAAA` queries
 that do not match explicit mocks run:
 
-    curl -X POST -d '{"ip":"::1"}' http://localhost:8055/set-default-ipv6
+    curl -d '{"ip":"::1"}' http://localhost:8055/set-default-ipv6
 
 To clear the default IPv4 or IPv6 address POST the same endpoints with an empty
 (`""`) IP.
@@ -67,59 +67,59 @@ To clear the default IPv4 or IPv6 address POST the same endpoints with an empty
 To add IPv4 addresses to be returned for `A` queries for
 `test-host.letsencrypt.org` run:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org", "addresses":["12.12.12.12", "13.13.13.13"]}' http://localhost:8055/add-a
+    curl -d '{"host":"test-host.letsencrypt.org", "addresses":["12.12.12.12", "13.13.13.13"]}' http://localhost:8055/add-a
 
 The mocked `A` responses can be removed by running:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/clear-a
+    curl -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/clear-a
 
 To add IPv6 addresses to be returned for `AAAA` queries for
 `test-host.letsencrypt.org` run:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org", "addresses":["2001:4860:4860::8888", "2001:4860:4860::8844"]}' http://localhost:8055/add-aaaa
+    curl -d '{"host":"test-host.letsencrypt.org", "addresses":["2001:4860:4860::8888", "2001:4860:4860::8844"]}' http://localhost:8055/add-aaaa
 
 The mocked `AAAA` responses can be removed by running:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/clear-aaaa
+    curl -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/clear-aaaa
 
 ##### Mocked CAA Responses
 
 To add a mocked CAA policy for `test-host.letsencrypt.org` that allows issuance
 by `letsencrypt.org` run:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org", "policies":[{"tag":"issue","value":"letsencrypt.org"}]}' http://localhost:8055/add-caa
+    curl -d '{"host":"test-host.letsencrypt.org", "policies":[{"tag":"issue","value":"letsencrypt.org"}]}' http://localhost:8055/add-caa
 
 To remove the mocked CAA policy for `test-host.letsencrypt.org` run:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/clear-caa
+    curl -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/clear-caa
 
 ##### Mocked CNAME Responses
 
 To add a mocked CNAME record for `_acme-challenge.test-host.letsencrypt.org` run:
 
-    curl -X POST -d '{"host":"_acme-challenge.test-host.letsencrypt.org", "target": "challenges.letsencrypt.org"}' http://localhost:8055/set-cname
+    curl -d '{"host":"_acme-challenge.test-host.letsencrypt.org", "target": "challenges.letsencrypt.org"}' http://localhost:8055/set-cname
 
 To remove a mocked CNAME record for `_acme-challenge.test-host.letsencrypt.org` run:
 
-    curl -X POST -d '{"host":"_acme-challenge.test-host.letsencrypt.org", "target": "challenges.letsencrypt.org"}' http://localhost:8055/clear-cname
+    curl -d '{"host":"_acme-challenge.test-host.letsencrypt.org", "target": "challenges.letsencrypt.org"}' http://localhost:8055/clear-cname
 
 ##### Mocked SERVFAIL Responses
 
 To configure the DNS server to return SERVFAIL for all queries for `test-host.letsencrypt.org` run:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/set-servfail
+    curl -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/set-servfail
 
 Subsequently any query types (A, AAAA, TXT) for the name will return a SERVFAIL response, overriding any A/AAAA/TXT/CNAME mocks that may also be configured.
 
 To remove the SERVFAIL configuration for `test-host.letsencrypt.org` run:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/clear-servfail
+    curl -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/clear-servfail
 
 #### HTTP-01
 
 To add an HTTP-01 challenge response for the token `"aaaa"` with the content `"bbbb"` run:
 
-    curl -X POST -d '{"token":"aaaa", "content":"bbbb"}' http://localhost:8055/add-http01
+    curl -d '{"token":"aaaa", "content":"bbbb"}' http://localhost:8055/add-http01
 
 Afterwards the challenge response will be available over HTTP at
 `http://localhost:5002/.well-known/acme-challenge/aaaa`, and HTTPS at
@@ -127,14 +127,14 @@ Afterwards the challenge response will be available over HTTP at
 
 The HTTP-01 challenge response for the `"aaaa"` token can be deleted by running:
 
-    curl -X POST -d '{"token":"aaaa"}' http://localhost:8055/del-http01
+    curl -d '{"token":"aaaa"}' http://localhost:8055/del-http01
 
 ##### Redirects
 
 To add a redirect from `/.well-known/acme-challenge/whatever` to
 `https://localhost:5003/ok` run:
 
-    curl -X POST -d '{"path":"/.well-known/whatever", "targetURL": "https://localhost:5003/ok"}' http://localhost:8055/add-redirect
+    curl -d '{"path":"/.well-known/whatever", "targetURL": "https://localhost:5003/ok"}' http://localhost:8055/add-redirect
 
 Afterwards HTTP requests to `http://localhost:5002/.well-known/whatever/` will
 be redirected to `https://localhost:5003/ok`. HTTPS requests that match the
@@ -143,18 +143,18 @@ path from HTTP to HTTPS.
 
 To remove the redirect run:
 
-    curl -X POST -d '{"path":"/.well-known/whatever"}' http://localhost:8055/del-redirect
+    curl -d '{"path":"/.well-known/whatever"}' http://localhost:8055/del-redirect
 
 #### DNS-01
 
 To add a DNS-01 challenge response for `_acme-challenge.test-host.letsencrypt.org` with
 the value `"foo"` run:
 
-    curl -X POST -d '{"host":"_acme-challenge.test-host.letsencrypt.org.", "value": "foo"}' http://localhost:8055/set-txt
+    curl -d '{"host":"_acme-challenge.test-host.letsencrypt.org.", "value": "foo"}' http://localhost:8055/set-txt
 
 To remove the mocked DNS-01 challenge response run:
 
-    curl -X POST -d '{"host":"_acme-challenge.test-host.letsencrypt.org."}' http://localhost:8055/clear-txt
+    curl -d '{"host":"_acme-challenge.test-host.letsencrypt.org."}' http://localhost:8055/clear-txt
 
 Note that a period character is required at the end of the host name here.
 
@@ -163,11 +163,11 @@ Note that a period character is required at the end of the host name here.
 To add a TLS-ALPN-01 challenge response certificate for the host
 `test-host.letsencrypt.org` with the key authorization `"foo"` run:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org", "content":"foo"}' http://localhost:8055/add-tlsalpn01
+    curl -d '{"host":"test-host.letsencrypt.org", "content":"foo"}' http://localhost:8055/add-tlsalpn01
 
 To remove the mocked TLS-ALPN-01 challenge response run:
 
-    curl -X POST -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/del-tlsalpn01
+    curl -d '{"host":"test-host.letsencrypt.org"}' http://localhost:8055/del-tlsalpn01
 
 #### Request History
 
@@ -176,7 +176,7 @@ challenge servers and exposes this information via JSON.
 
 To get the history of HTTP requests to `example.com` run:
 
-    curl -X POST -d '{"host":"example.com"}' http://localhost:8055/http-request-history
+    curl -d '{"host":"example.com"}' http://localhost:8055/http-request-history
 
 Each HTTP request event is an object of the form:
 ```
@@ -193,7 +193,7 @@ initial TLS hello.
 
 To get the history of DNS requests for `example.com` run:
 
-    curl -X POST -d '{"host":"example.com"}' http://localhost:8055/dns-request-history
+    curl -d '{"host":"example.com"}' http://localhost:8055/dns-request-history
 
 Each DNS request event is an object of the form:
 ```
@@ -208,7 +208,7 @@ Each DNS request event is an object of the form:
 
 To get the history of TLS-ALPN-01 requests for the SNI host `example.com` run:
 
-    curl -X POST -d '{"host":"example.com"}' http://localhost:8055/tlsalpn01-request-history
+    curl -d '{"host":"example.com"}' http://localhost:8055/tlsalpn01-request-history
 
 Each TLS-ALPN-01 request event is an object of the form:
 ```
@@ -225,12 +225,12 @@ supported next protocols from the initial TLS hello.
 
 To clear HTTP request history for `example.com` run:
 
-    curl -X POST -d '{"host":"example.com", "type":"http"}' http://localhost:8055/clear-request-history
+    curl -d '{"host":"example.com", "type":"http"}' http://localhost:8055/clear-request-history
 
 Similarly, to clear DNS request history for `example.com` run:
 
-    curl -X POST -d '{"host":"example.com", "type":"dns"}' http://localhost:8055/clear-request-history
+    curl -d '{"host":"example.com", "type":"dns"}' http://localhost:8055/clear-request-history
 
 And to clear TLS-ALPN-01 request history for `example.com` run:
 
-    curl -X POST -d '{"host":"example.com", "type":"tlsalpn"}' http://localhost:8055/clear-request-history
+    curl -d '{"host":"example.com", "type":"tlsalpn"}' http://localhost:8055/clear-request-history


### PR DESCRIPTION
Using `-X POST` is not a recommended curl use. It is more an urban legend. `-d data` alone is enough to make curl use the correct http method.