### PR TITLE
Include argument to ignore the HTTPS-01 challenge in the documented {foo-challenge-only} suggestions

### DIFF
--- a/cmd/pebble-challtestsrv/README.md
+++ b/cmd/pebble-challtestsrv/README.md
@@ -34,9 +34,10 @@ Usage of pebble-challtestsrv:
 
 To disable a challenge type, set the bind address to `""`. E.g.:
 
-* To run HTTP-01 only: `pebble-challtestsrv -dns01 "" -tlsalpn01 ""`
-* To run DNS-01 only: `pebble-challtestsrv -http01 "" -tlsalpn01 ""`
-* To run TLS-ALPN-01 only: `pebble-challtestsrv -http01 "" -dns01 ""`
+* To run HTTP-01 only: `pebble-challtestsrv -https01 "" -dns01 "" -tlsalpn01 ""`
+* To run HTTPS-01 only: `pebble-challtestsrv -http01 "" -dns01 "" -tlsalpn01 ""`
+* To run DNS-01 only: `pebble-challtestsrv -http01 "" -https01 "" -tlsalpn01 ""`
+* To run TLS-ALPN-01 only: `pebble-challtestsrv -http01 "" -https01 "" -dns01 ""`
 
 ### Management Interface
 


### PR DESCRIPTION
The [documentation](https://github.com/letsencrypt/pebble/tree/4cce110cac5a66fb26db554a4fe6a22d8a96e541/cmd/pebble-challtestsrv) for `pebble-challtestsrv` makes these suggestions:

> - To run HTTP-01 only: pebble-challtestsrv -dns01 "" -tlsalpn01 ""
> - To run DNS-01 only: pebble-challtestsrv -http01 "" -tlsalpn01 ""
> - To run TLS-ALPN-01 only: pebble-challtestsrv -http01 "" -dns01 ""

However, these suggestions do not take the `-https01` argument into account. That leads to unexpected behavior. I.e. when I ran the command to run TLS-ALPN-01 _only_, I was surprised to see that the HTTPS challenge was still enabled.