### PR TITLE
remove superfluous calls to net/http.Response.WriteHeader

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1782,7 +1782,6 @@ func (wfe *WebFrontEndImpl) Order(
 	// authenticated account owns the order being requested
 	if account != nil {
 		if orderAccountID != account.ID {
-			response.WriteHeader(http.StatusForbidden)
 			wfe.sendError(acme.UnauthorizedProblem(
 				"Account that authenticated the request does not own the specified order"), response)
 			return
@@ -1821,7 +1820,6 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(
 	orderID := strings.TrimPrefix(request.URL.Path, orderFinalizePath)
 	existingOrder := wfe.db.GetOrderByID(orderID)
 	if existingOrder == nil {
-		response.WriteHeader(http.StatusNotFound)
 		wfe.sendError(acme.NotFoundProblem(fmt.Sprintf(
 			"No order %q found for account ID %q", orderID, existingAcct.ID)), response)
 		return
@@ -1839,7 +1837,6 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(
 	existingOrder.RUnlock()
 
 	if orderAccountID != existingAcct.ID {
-		response.WriteHeader(http.StatusForbidden)
 		wfe.sendError(acme.UnauthorizedProblem(
 			"Account that authenticated the request does not own the specified order"), response)
 		return
@@ -2077,7 +2074,6 @@ func (wfe *WebFrontEndImpl) Authz(
 		}
 
 		if orderAcctID != account.ID {
-			response.WriteHeader(http.StatusForbidden)
 			wfe.sendError(acme.UnauthorizedProblem(
 				"Account authorizing the request is not the owner of the authorization"),
 				response)
@@ -2134,7 +2130,6 @@ func (wfe *WebFrontEndImpl) Challenge(
 	defer chal.RUnlock()
 
 	if chal.Authz.Order.AccountID != account.ID {
-		response.WriteHeader(http.StatusUnauthorized)
 		wfe.sendError(acme.UnauthorizedProblem(
 			"Account authenticating request is not the owner of the challenge"), response)
 		return
@@ -2287,7 +2282,6 @@ func (wfe *WebFrontEndImpl) updateChallenge(
 	authz.RUnlock()
 
 	if orderAcctID != existingAcct.ID {
-		response.WriteHeader(http.StatusUnauthorized)
 		wfe.sendError(acme.UnauthorizedProblem(
 			"Account authenticating request is not the owner of the challenge"), response)
 		return
@@ -2408,7 +2402,6 @@ func (wfe *WebFrontEndImpl) Certificate(
 	}
 
 	if cert.AccountID != acct.ID {
-		response.WriteHeader(http.StatusUnauthorized)
 		wfe.sendError(acme.UnauthorizedProblem(
 			"Account authenticating request does not own certificate"), response)
 		return


### PR DESCRIPTION
WebFrontEndImpl.sendError is already responsible for sending the
HTTP status code related to these ACME problems.

---

While playing with Certbot's handling of ACME errors in https://github.com/certbot/certbot/pull/9255, I noticed some output like:

>2022/03/31 12:55:53 http: superfluous response.WriteHeader call from github.com/letsencrypt/pebble/wfe.(*WebFrontEndImpl).sendError (wfe.go:346)

Each of the removed calls match the HTTP status code that `sendError` would have sent anyway.
