### PR TITLE
Modernize

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,6 +25,11 @@ linters:
     - wsl
     - whitespace
     - gomnd
+    - typecheck
+    - godot
+    - errname
+    - nlreturn
+    - wrapcheck
 
 issues:
   exclude-use-default: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
     - $GOPATH/pkg/mod
 
 go:
-  - "1.16.x"
+  - "1.18.x"
 
 services:
   - docker
@@ -29,7 +29,7 @@ before_install:
 # `-mod=vendor` to use the vendored dependencies
 install:
   # Install `golangci-lint` using their installer script
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.6
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2
   # Install tools without `GO111MODULE` enabled so that we
   # don't download Pebble's deps and just put the tools in our
   # gobin.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,10 +22,6 @@ install:
   - venv\Scripts\activate.bat
   - cd ..
 
-before_build:
-  # Install `golangci-lint` using go get (installer not available for Windows)
-  - go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
-
 build_script:
   - go install -v -mod=vendor ./...
 
@@ -37,8 +33,6 @@ after_build:
   - copy %USERPROFILE%\go\bin\pebble-challtestsrv.exe deploy\pebble-challtestsrv_windows-amd64.exe
 
 test_script:
-  # Vet Go source code using the linter config (see .golang-ci.yml)
-  - golangci-lint run
   # Run project unit tests (with the race detector enabled)
   - go test -mod=vendor -v -race ./...
   # Perform a test issuance with chisel2.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
 
 before_build:
   # Install `golangci-lint` using go get (installer not available for Windows)
-  - go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.23.3
+  - go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
 
 build_script:
   - go install -v -mod=vendor ./...

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -17,9 +17,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/letsencrypt/pebble/acme"
-	"github.com/letsencrypt/pebble/core"
-	"github.com/letsencrypt/pebble/db"
+	"github.com/letsencrypt/pebble/v2/acme"
+	"github.com/letsencrypt/pebble/v2/core"
+	"github.com/letsencrypt/pebble/v2/db"
 )
 
 const (

--- a/cmd/pebble-challtestsrv/main.go
+++ b/cmd/pebble-challtestsrv/main.go
@@ -1,5 +1,5 @@
 // The pebble-challtestsrv command line tool exposes the
-// github.com/letsencrypt/pebble/challtestsrv package as
+// github.com/letsencrypt/pebble/v2/challtestsrv package as
 // a stand-alone binary with an HTTP management interface.
 package main
 
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/letsencrypt/challtestsrv"
-	"github.com/letsencrypt/pebble/cmd"
+	"github.com/letsencrypt/pebble/v2/cmd"
 )
 
 // managementServer is a small HTTP server that can control a challenge server,

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/letsencrypt/pebble/ca"
-	"github.com/letsencrypt/pebble/cmd"
-	"github.com/letsencrypt/pebble/db"
-	"github.com/letsencrypt/pebble/va"
-	"github.com/letsencrypt/pebble/wfe"
+	"github.com/letsencrypt/pebble/v2/ca"
+	"github.com/letsencrypt/pebble/v2/cmd"
+	"github.com/letsencrypt/pebble/v2/db"
+	"github.com/letsencrypt/pebble/v2/va"
+	"github.com/letsencrypt/pebble/v2/wfe"
 )
 
 type config struct {

--- a/core/types.go
+++ b/core/types.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/letsencrypt/pebble/acme"
+	"github.com/letsencrypt/pebble/v2/acme"
 	"gopkg.in/square/go-jose.v2"
 )
 

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -18,8 +18,8 @@ import (
 
 	"gopkg.in/square/go-jose.v2"
 
-	"github.com/letsencrypt/pebble/acme"
-	"github.com/letsencrypt/pebble/core"
+	"github.com/letsencrypt/pebble/v2/acme"
+	"github.com/letsencrypt/pebble/v2/core"
 )
 
 // ExistingAccountError is an error type indicating when an operation fails

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,4 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 )
 
-go 1.16
+go 1.17

--- a/va/va.go
+++ b/va/va.go
@@ -24,8 +24,8 @@ import (
 	"github.com/miekg/dns"
 
 	"github.com/letsencrypt/challtestsrv"
-	"github.com/letsencrypt/pebble/acme"
-	"github.com/letsencrypt/pebble/core"
+	"github.com/letsencrypt/pebble/v2/acme"
+	"github.com/letsencrypt/pebble/v2/core"
 )
 
 const (

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/letsencrypt/pebble/acme"
-	"github.com/letsencrypt/pebble/core"
-	"github.com/letsencrypt/pebble/db"
+	"github.com/letsencrypt/pebble/v2/acme"
+	"github.com/letsencrypt/pebble/v2/core"
+	"github.com/letsencrypt/pebble/v2/db"
 )
 
 func TestAuthzRace(t *testing.T) {

--- a/wfe/jose.go
+++ b/wfe/jose.go
@@ -9,7 +9,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/letsencrypt/pebble/acme"
+	"github.com/letsencrypt/pebble/v2/acme"
 
 	"gopkg.in/square/go-jose.v2"
 )

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -28,11 +28,11 @@ import (
 
 	"gopkg.in/square/go-jose.v2"
 
-	"github.com/letsencrypt/pebble/acme"
-	"github.com/letsencrypt/pebble/ca"
-	"github.com/letsencrypt/pebble/core"
-	"github.com/letsencrypt/pebble/db"
-	"github.com/letsencrypt/pebble/va"
+	"github.com/letsencrypt/pebble/v2/acme"
+	"github.com/letsencrypt/pebble/v2/ca"
+	"github.com/letsencrypt/pebble/v2/core"
+	"github.com/letsencrypt/pebble/v2/db"
+	"github.com/letsencrypt/pebble/v2/va"
 )
 
 const (


### PR DESCRIPTION
- Use Go 1.18.x in Travis, and set go.mod version to 1.17.
- Update golangci-lint to 1.45.2 and ignore new lints.
- Update import paths to include /v2/. This fixes a problem introduced by fixing
the go.mod module path to use /v2/.