### PR TITLE
Update Go version in Dockerfiles to 1.18

### DIFF
--- a/docker/pebble-challtestsrv/linux.Dockerfile
+++ b/docker/pebble-challtestsrv/linux.Dockerfile
@@ -1,20 +1,14 @@
-FROM golang:1.12-alpine as builder
+FROM golang:1.18-alpine as builder
 
-RUN apk --update upgrade \
-&& apk --no-cache --no-progress add git bash curl \
-&& rm -rf /var/cache/apk/*
-
-ENV CGO_ENABLED=0 GOFLAGS=-mod=vendor
+ENV CGO_ENABLED=0
 
 WORKDIR /pebble-src
 COPY . .
 
-RUN go install -v ./cmd/pebble-challtestsrv/...
+RUN go build -o /go/bin/pebble-challtestsrv ./cmd/pebble-challtestsrv
 
 ## main
-FROM alpine:3.8
-
-RUN apk update && apk add --no-cache --virtual ca-certificates
+FROM alpine:3.15.4
 
 COPY --from=builder /go/bin/pebble-challtestsrv /usr/bin/pebble-challtestsrv
 

--- a/docker/pebble-challtestsrv/windows.Dockerfile
+++ b/docker/pebble-challtestsrv/windows.Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.12-nanoserver-sac2016 as builder
+FROM golang:1.18-nanoserver-sac2016 as builder
 
-ENV CGO_ENABLED=0 GOFLAGS=-mod=vendor
+ENV CGO_ENABLED=0
 
 WORKDIR /pebble-src
 COPY . .

--- a/docker/pebble/linux.Dockerfile
+++ b/docker/pebble/linux.Dockerfile
@@ -1,20 +1,14 @@
-FROM golang:1.12-alpine as builder
+FROM golang:1.18-alpine as builder
 
-RUN apk --update upgrade \
-&& apk --no-cache --no-progress add git bash curl \
-&& rm -rf /var/cache/apk/*
-
-ENV CGO_ENABLED=0 GOFLAGS=-mod=vendor
+ENV CGO_ENABLED=0
 
 WORKDIR /pebble-src
 COPY . .
 
-RUN go install -v ./cmd/pebble/...
+RUN go build -o /go/bin/pebble ./cmd/pebble
 
 ## main
-FROM alpine:3.8
-
-RUN apk update && apk add --no-cache --virtual ca-certificates
+FROM alpine:3.15.4
 
 COPY --from=builder /go/bin/pebble /usr/bin/pebble
 COPY --from=builder /pebble-src/test/ /test/

--- a/docker/pebble/windows.Dockerfile
+++ b/docker/pebble/windows.Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.12-nanoserver-sac2016 as builder
+FROM golang:1.18-nanoserver-sac2016 as builder
 
-ENV CGO_ENABLED=0 GOFLAGS=-mod=vendor
+ENV CGO_ENABLED=0
 
 WORKDIR /pebble-src
 COPY . .


### PR DESCRIPTION
- Removed the `apk update` and package install steps because we didn't actually
  need those packages.
- Removed `GOFLAGS=-mod=vendor` because that now happens automatically when a
  vendor directory is present.