### PR TITLE
Add Retry-After header when responding to Order and Authorization object

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -16,7 +16,6 @@ import (
 	"net"
 	"strings"
 	"time"
-	mathrand "math/rand"
 
 	"github.com/letsencrypt/pebble/v2/acme"
 	"github.com/letsencrypt/pebble/v2/core"
@@ -404,9 +403,6 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 		}
 		authz.RUnlock()
 	}
-
-	// In actual CAs, certificate issuance is not expected to be completed immediately
-	time.Sleep(time.Second * time.Duration(mathrand.Intn(10) + 1))
 
 	// issue a certificate for the csr
 	csr := order.ParsedCSR

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"strings"
 	"time"
+	mathrand "math/rand"
 
 	"github.com/letsencrypt/pebble/v2/acme"
 	"github.com/letsencrypt/pebble/v2/core"
@@ -403,6 +404,9 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 		}
 		authz.RUnlock()
 	}
+
+	// In actual CAs, certificate issuance is not expected to be completed immediately
+	time.Sleep(time.Second * time.Duration(mathrand.Intn(10) + 1))
 
 	// issue a certificate for the csr
 	csr := order.ParsedCSR

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -30,6 +30,10 @@ type config struct {
 		DomainBlocklist []string
 
 		CertificateValidityPeriod uint
+		RetryAfter struct {
+			Authz int
+			Order int
+		}
 	}
 }
 
@@ -85,7 +89,7 @@ func main() {
 		cmd.FailOnError(err, "Failed to add domain to block list")
 	}
 
-	wfeImpl := wfe.New(logger, db, va, ca, *strictMode, c.Pebble.ExternalAccountBindingRequired)
+	wfeImpl := wfe.New(logger, db, va, ca, *strictMode, c.Pebble.ExternalAccountBindingRequired, c.Pebble.RetryAfter.Authz, c.Pebble.RetryAfter.Order)
 	muxHandler := wfeImpl.Handler()
 
 	if c.Pebble.ManagementListenAddress != "" {

--- a/test/config/pebble-config-external-account-bindings.json
+++ b/test/config/pebble-config-external-account-bindings.json
@@ -7,6 +7,10 @@
     "httpPort": 5002,
     "tlsPort": 5001,
     "ocspResponderURL": "",
+    "retryAfter": {
+        "authz": 3,
+        "order": 5
+    }
     "externalAccountBindingRequired": true,
     "externalAccountMACKeys": {
       "kid-1": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",

--- a/test/config/pebble-config.json
+++ b/test/config/pebble-config.json
@@ -7,6 +7,10 @@
     "httpPort": 5002,
     "tlsPort": 5001,
     "ocspResponderURL": "",
-    "externalAccountBindingRequired": false
+    "externalAccountBindingRequired": false,
+    "retryAfter": {
+        "authz": 3,
+        "order": 5
+    }
   }
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -2094,7 +2094,10 @@ func (wfe *WebFrontEndImpl) Authz(
 			// Check for the existence of a challenge which state is processing, and add the
 			// Retry-After header if there is one.
 			for _, c := range authz.Challenges {
-				if c.Status == acme.StatusProcessing {
+				c.RLock()
+				challengeStatus := c.Status
+				c.RUnlock()
+				if challengeStatus == acme.StatusProcessing {
 					addRetryAfterHeader(response, wfe.retryAfterAuthz)
 					break
 				}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1792,7 +1792,7 @@ func (wfe *WebFrontEndImpl) Order(
 		}
 	}
 
-	if order.Status == acme.StatusProcessing{
+	if order.Status == acme.StatusProcessing {
 		addRetryAfterHeader(response, wfe.retryAfterOrder)
 	}
 
@@ -2091,17 +2091,13 @@ func (wfe *WebFrontEndImpl) Authz(
 		}
 
 		if authz.Status == acme.StatusPending {
-			// Check for the existence of a challenge which state is processing
-			processingChallenge := false
+			// Check for the existence of a challenge which state is processing, and add the
+			// Retry-After header if there is one.
 			for _, c := range authz.Challenges {
-				if (c.Status == acme.StatusProcessing) {
-					processingChallenge = true
+				if c.Status == acme.StatusProcessing {
+					addRetryAfterHeader(response, wfe.retryAfterAuthz)
 					break
 				}
-			}
-			// if exist, then add header
-			if processingChallenge {
-				addRetryAfterHeader(response, wfe.retryAfterAuthz)
 			}
 		}
 	}
@@ -2466,10 +2462,10 @@ func addNoCacheHeader(response http.ResponseWriter) {
 }
 
 func addRetryAfterHeader(response http.ResponseWriter, second int) {
-	if (second > 0){
-		if (rand.Intn(2) == 0){
+	if second > 0 {
+		if rand.Intn(2) == 0 {
 			response.Header().Add("Retry-After", strconv.Itoa(second))
-		}else{
+		} else {
 			// IMF-fixdate
 			// see https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1
 			gmt, _ := time.LoadLocation("GMT")


### PR DESCRIPTION
Address the issue #83
Fixed to add Retry-After header when responding to requests for Order and Authorization objects.

Although it is a static, The value of Retry-After is defined in the configuration file.
I would appreciate it if you could review this PR.