### PR TITLE
add 'processing' state to challenges

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -157,10 +157,6 @@ func New(
 }
 
 func (va VAImpl) ValidateChallenge(ident acme.Identifier, chal *core.Challenge, acct *core.Account) {
-	chal.Lock()
-	chal.Status = acme.StatusProcessing
-	chal.Unlock()
-
 	task := &vaTask{
 		Identifier: ident,
 		Challenge:  chal,

--- a/va/va.go
+++ b/va/va.go
@@ -157,6 +157,10 @@ func New(
 }
 
 func (va VAImpl) ValidateChallenge(ident acme.Identifier, chal *core.Challenge, acct *core.Account) {
+	chal.Lock()
+	chal.Status = acme.StatusProcessing
+	chal.Unlock()
+
 	task := &vaTask{
 		Identifier: ident,
 		Challenge:  chal,


### PR DESCRIPTION
For https://github.com/letsencrypt/pebble/pull/380#discussion_r867289222. 

Keeping track of when a challenge is in the `processing` state means we will be able to then include a `Retry-After` response header for authorizations, as described in:

>    To check on the status of an authorization, the client sends a POST-
   as-GET request to the authorization URL, and the server responds with
   the current authorization object.  In responding to poll requests
   while the validation is still in progress, the server MUST return a
   200 (OK) response and MAY include a Retry-After header field to
   suggest a polling interval to the client.

One extra side effect here is that clients will no longer be able to cause Pebble to queue up a `pending` challenge multiple times for processing by a VA. This seems like a good thing anyway.