### PR TITLE
Add subproblems

### DIFF
--- a/acme/problems.go
+++ b/acme/problems.go
@@ -26,9 +26,11 @@ const (
 )
 
 type ProblemDetails struct {
-	Type       string `json:"type,omitempty"`
-	Detail     string `json:"detail,omitempty"`
-	HTTPStatus int    `json:"status,omitempty"`
+	Type        string           `json:"type,omitempty"`
+	Detail      string           `json:"detail,omitempty"`
+	HTTPStatus  int              `json:"status,omitempty"`
+	Identifier  *Identifier      `json:"identifier,omitempty"`
+	Subproblems []ProblemDetails `json:"subproblems,omitempty"`
 }
 
 func (pd *ProblemDetails) Error() string {
@@ -187,10 +189,17 @@ func BadPublicKeyProblem(detail string) *ProblemDetails {
 	}
 }
 
-func RejectedIdentifierProblem(detail string) *ProblemDetails {
+func RejectedIdentifierProblem(ident Identifier, detail string) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       rejectedIdentifierErr,
 		Detail:     detail,
 		HTTPStatus: http.StatusBadRequest,
+		Subproblems: []ProblemDetails{
+			{
+				Type:       rejectedIdentifierErr,
+				Identifier: &ident,
+				Detail:     fmt.Sprintf("%s is a forbidden domain", ident.Value),
+			},
+		},
 	}
 }

--- a/test/config/pebble-config.json
+++ b/test/config/pebble-config.json
@@ -7,6 +7,7 @@
     "httpPort": 5002,
     "tlsPort": 5001,
     "ocspResponderURL": "",
-    "externalAccountBindingRequired": false
+    "externalAccountBindingRequired": false,
+    "domainBlocklist": ["blocked-domain.example"]
   }
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1417,14 +1417,15 @@ func (wfe *WebFrontEndImpl) verifyOrder(order *core.Order) *acme.ProblemDetails 
 				ident.Type, ident.Value))
 		}
 
-		if problem := wfe.validateDNSName(ident.Value); problem != nil {
+		if problem := wfe.validateDNSName(ident); problem != nil {
 			return problem
 		}
 	}
 	return nil
 }
 
-func (wfe *WebFrontEndImpl) validateDNSName(rawDomain string) *acme.ProblemDetails {
+func (wfe *WebFrontEndImpl) validateDNSName(ident acme.Identifier) *acme.ProblemDetails {
+	rawDomain := ident.Value
 	if rawDomain == "" {
 		return acme.MalformedProblem(fmt.Sprintf(
 			"Order included DNS identifier with empty value"))
@@ -1475,7 +1476,7 @@ func (wfe *WebFrontEndImpl) validateDNSName(rawDomain string) *acme.ProblemDetai
 	}
 
 	if wfe.db.IsDomainBlocked(rawDomain) {
-		return acme.RejectedIdentifierProblem(fmt.Sprintf(
+		return acme.RejectedIdentifierProblem(ident, fmt.Sprintf(
 			"Order included an identifier for which issuance is forbidden by policy: %q",
 			rawDomain))
 	}


### PR DESCRIPTION
- Add subproblem support (rfc8555#section-6.7.1)
- Use subproblems when rejecting identifiers in newOrder
- Block "blocked-domain.example" in the default configuration

---

Fixes #243.

Will be useful for https://github.com/certbot/certbot/pull/9272.