### PR TITLE
Fix compilation for 32bit

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -35,7 +35,7 @@ type CAImpl struct {
 
 	chains []*chain
 
-	certValidityPeriod uint
+	certValidityPeriod uint64
 }
 
 type chain struct {
@@ -347,7 +347,7 @@ func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.Publ
 	return newCert, nil
 }
 
-func New(log *log.Logger, db *db.MemoryStore, ocspResponderURL string, alternateRoots int, chainLength int, certificateValidityPeriod uint) *CAImpl {
+func New(log *log.Logger, db *db.MemoryStore, ocspResponderURL string, alternateRoots int, chainLength int, certificateValidityPeriod uint64) *CAImpl {
 	ca := &CAImpl{
 		log:                log,
 		db:                 db,

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -29,7 +29,7 @@ type config struct {
 		// Configure policies to deny certain domains
 		DomainBlocklist []string
 
-		CertificateValidityPeriod uint
+		CertificateValidityPeriod uint64
 	}
 }
 


### PR DESCRIPTION
Buiding 2.4.0 on alpine linux 32bit platforms gives the error:
`../../ca/ca.go:374:67: 9223372038 (untyped int constant) overflows uint`

So change relevant variables to uint64