### PR TITLE
Add support for TCP and TLS to DNS-01 Challenge when using a custom DNS Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ In addition to defining a custom DNS resolver with `-dnsserver` you can also
 specify a protocol to use for the DNS-01 challenge. Options are
 * UDP (default)
 * TCP
-* TLS
+* TLS (no certificate verification)
+* TLS-CA (certificate verification)
 This option is not case-sensitive.
 
 ```

--- a/README.md
+++ b/README.md
@@ -198,6 +198,21 @@ will let you easily mock DNS data for Pebble. See the included
 README](https://github.com/letsencrypt/pebble/blob/master/cmd/pebble-challtestsrv/README.md)
 for more information.
 
+### DNS Protocol
+
+In addition to defining a custom DNS resolver with `-dnsserver` you can also
+specify a protocol to use for the DNS-01 challenge. Options are
+* UDP (default)
+* TCP
+* TLS
+This option is not case-sensitive.
+
+```
+pebble -dnsserver 10.10.10.10:5053 -dnsprotocol tcp
+pebble -dnsserver 8.8.8.8:53 -dnsprotocol tls
+pebble -dnsserver :5053 -dnsprotocol TCP 
+```
+
 ### Testing at full speed
 
 By default Pebble will sleep a random number of seconds (from 0 to 15) between

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -53,11 +53,12 @@ func main() {
 	resolverProtocol := flag.String(
 		"dnsprotocol",
 		"UDP",
-        "Define a protocol for the custom DNS server: UDP, TCP or TLS")
+		"Define a protocol for the custom DNS server: UDP, TCP or TLS")
 	flag.Parse()
 	if *configFile == "" {
 		flag.Usage()
-		os.Exit(1) }
+		os.Exit(1)
+	}
 
 	// Log to stdout
 	logger := log.New(os.Stdout, "Pebble ", log.LstdFlags)

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -30,7 +30,7 @@ type config struct {
 		DomainBlocklist []string
 
 		CertificateValidityPeriod uint64
-		RetryAfter struct {
+		RetryAfter                struct {
 			Authz int
 			Order int
 		}
@@ -50,11 +50,14 @@ func main() {
 		"dnsserver",
 		"",
 		"Define a custom DNS server address (ex: 192.168.0.56:5053 or 8.8.8.8:53).")
+	resolverProtocol := flag.String(
+		"dnsprotocol",
+		"UDP",
+        "Define a protocol for the custom DNS server: UDP, TCP or TLS")
 	flag.Parse()
 	if *configFile == "" {
 		flag.Usage()
-		os.Exit(1)
-	}
+		os.Exit(1) }
 
 	// Log to stdout
 	logger := log.New(os.Stdout, "Pebble ", log.LstdFlags)
@@ -77,7 +80,7 @@ func main() {
 
 	db := db.NewMemoryStore()
 	ca := ca.New(logger, db, c.Pebble.OCSPResponderURL, alternateRoots, chainLength, c.Pebble.CertificateValidityPeriod)
-	va := va.New(logger, c.Pebble.HTTPPort, c.Pebble.TLSPort, *strictMode, *resolverAddress)
+	va := va.New(logger, c.Pebble.HTTPPort, c.Pebble.TLSPort, *strictMode, *resolverAddress, *resolverProtocol)
 
 	for keyID, key := range c.Pebble.ExternalAccountMACKeys {
 		err := db.AddExternalAccountKeyByID(keyID, key)

--- a/va/va.go
+++ b/va/va.go
@@ -127,14 +127,14 @@ func New(
 	if customResolverAddr != "" {
 		va.log.Printf("Using custom DNS resolver for ACME challenges: %s", customResolverAddr)
 		va.dnsClient = new(dns.Client)
-        switch customResolverProtocol {
-        case "TCP", "Tcp", "tcp":
+		switch customResolverProtocol {
+		case "TCP", "Tcp", "tcp":
 			va.log.Print("Sending ACME DNS-01 challenges via TCP")
 			va.dnsClient.Net = "tcp"
-        case "TLS", "Tls", "tls":
+		case "TLS", "Tls", "tls":
 			va.log.Print("Sending ACME DNS-01 challenges via TLS")
 			va.dnsClient.Net = "tcp-tls"
-        }
+		}
 	} else {
 		va.log.Print("Using system DNS resolver for ACME challenges")
 	}

--- a/va/va.go
+++ b/va/va.go
@@ -134,7 +134,7 @@ func New(
 		case "TLS", "Tls", "tls":
 			va.log.Print("Sending ACME DNS-01 challenges via TLS, skipping certificate verification")
 			va.dnsClient.Net = "tcp-tls"
-            va.dnsClient.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+			va.dnsClient.TLSConfig = &tls.Config{InsecureSkipVerify: true}
 		case "TLS-CA", "Tls-CA", "tls-ca", "Tls-Ca":
 			va.log.Print("Sending ACME DNS-01 challenges via TLS, verifying certificates")
 			va.dnsClient.Net = "tcp-tls"

--- a/va/va.go
+++ b/va/va.go
@@ -132,7 +132,11 @@ func New(
 			va.log.Print("Sending ACME DNS-01 challenges via TCP")
 			va.dnsClient.Net = "tcp"
 		case "TLS", "Tls", "tls":
-			va.log.Print("Sending ACME DNS-01 challenges via TLS")
+			va.log.Print("Sending ACME DNS-01 challenges via TLS, skipping certificate verification")
+			va.dnsClient.Net = "tcp-tls"
+            va.dnsClient.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+		case "TLS-CA", "Tls-CA", "tls-ca", "Tls-Ca":
+			va.log.Print("Sending ACME DNS-01 challenges via TLS, verifying certificates")
 			va.dnsClient.Net = "tcp-tls"
 		}
 	} else {

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -31,7 +31,7 @@ func TestAuthzRace(t *testing.T) {
 
 	// This whole test can be removed if/when the MemoryStore becomes 100% by value
 	ms := db.NewMemoryStore()
-	va := New(log.New(os.Stdout, "Pebble/TestRace", log.LstdFlags), 14000, 15000, false, "")
+	va := New(log.New(os.Stdout, "Pebble/TestRace", log.LstdFlags), 14000, 15000, false, "", "UDP")
 
 	authz := &core.Authorization{
 		ID: "auth-id",


### PR DESCRIPTION
Closes #390 
I tried to use pebble with a local DNS Server that would only respond to DNS over TLS querys but pebble would always use UDP for the challenge. This change allows users to use TCP or TLS with custom DNS Servers by simplying changing the underlying dns.Client.Net option.
Note that this new `-dnsprotocol` option currently  doesn't do anything if it's used without `-dnsserver`.