### PR TITLE
Create db.Store interface to abstract actions to DB

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -30,7 +30,7 @@ const (
 
 type CAImpl struct {
 	log              *log.Logger
-	db               *db.MemoryStore
+	db               db.Store
 	ocspResponderURL string
 
 	chains []*chain
@@ -347,7 +347,7 @@ func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.Publ
 	return newCert, nil
 }
 
-func New(log *log.Logger, db *db.MemoryStore, ocspResponderURL string, alternateRoots int, chainLength int, certificateValidityPeriod uint64) *CAImpl {
+func New(log *log.Logger, db db.Store, ocspResponderURL string, alternateRoots int, chainLength int, certificateValidityPeriod uint64) *CAImpl {
 	ca := &CAImpl{
 		log:                log,
 		db:                 db,

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -408,7 +408,7 @@ func (m *MemoryStore) AddExternalAccountKeyByID(keyID, key string) error {
 
 // GetExternalAccountKeyByID will return the raw, base64 URL unencoded key
 // value by its key ID pair.
-func (m *MemoryStore) GetExtenalAccountKeyByID(keyID string) ([]byte, bool) {
+func (m *MemoryStore) GetExternalAccountKeyByID(keyID string) ([]byte, bool) {
 	m.RLock()
 	defer m.RUnlock()
 	key, ok := m.externalAccountKeysByID[keyID]

--- a/db/store.go
+++ b/db/store.go
@@ -1,0 +1,77 @@
+package db
+
+import (
+	"crypto"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"github.com/letsencrypt/pebble/v2/acme"
+	"github.com/letsencrypt/pebble/v2/core"
+	"gopkg.in/square/go-jose.v2"
+	"math/big"
+)
+
+// ExistingAccountError is an error type indicating when an operation fails
+// because the MatchingAccount has a key conflict.
+type ExistingAccountError struct {
+	MatchingAccount *core.Account
+}
+
+func (e ExistingAccountError) Error() string {
+	return fmt.Sprintf("New public key is already in use by account %s", e.MatchingAccount.ID)
+}
+
+/*
+ * KeyToID produces a string with the hex representation of the SHA256 digest
+ * over a provided public key. We use this to associate public keys to
+ * acme.Account objects, and to ensure every account has a unique public key.
+ */
+func KeyToID(key crypto.PublicKey) (string, error) {
+	switch t := key.(type) {
+	case *jose.JSONWebKey:
+		if t == nil {
+			return "", fmt.Errorf("Cannot compute ID of nil key")
+		}
+		return KeyToID(t.Key)
+	case jose.JSONWebKey:
+		return KeyToID(t.Key)
+	default:
+		keyDER, err := x509.MarshalPKIXPublicKey(key)
+		if err != nil {
+			return "", err
+		}
+		spkiDigest := sha256.Sum256(keyDER)
+		return hex.EncodeToString(spkiDigest[:]), nil
+	}
+}
+
+// Pebble keeps all of its various objects (accounts, orders, etc)
+// in-memory, not persisted anywhere. MemoryStore implements this in-memory
+// "database"
+type Store interface {
+	GetAccountByID(id string) *core.Account
+	GetAccountByKey(key crypto.PublicKey) (*core.Account, error)
+	UpdateAccountByID(id string, acct *core.Account) error
+	AddAccount(acct *core.Account) (int, error)
+	ChangeAccountKey(acct *core.Account, newKey *jose.JSONWebKey) error
+	AddOrder(order *core.Order) (int, error)
+	GetOrderByID(id string) *core.Order
+	GetOrdersByAccountID(accountID string) []*core.Order
+	AddAuthorization(authz *core.Authorization) (int, error)
+	GetAuthorizationByID(id string) *core.Authorization
+	FindValidAuthorization(accountID string, identifier acme.Identifier) *core.Authorization
+	AddChallenge(chal *core.Challenge) (int, error)
+	GetChallengeByID(id string) *core.Challenge
+	AddCertificate(cert *core.Certificate) (int, error)
+	GetCertificateByID(id string) *core.Certificate
+	GetCertificateByDER(der []byte) *core.Certificate
+	GetRevokedCertificateByDER(der []byte) *core.RevokedCertificate
+	RevokeCertificate(cert *core.RevokedCertificate)
+	GetCertificateBySerial(serialNumber *big.Int) *core.Certificate
+	GetRevokedCertificateBySerial(serialNumber *big.Int) *core.RevokedCertificate
+	AddExternalAccountKeyByID(keyID, key string) error
+	GetExtenalAccountKeyByID(keyID string) ([]byte, bool)
+	AddBlockedDomain(name string) error
+	IsDomainBlocked(name string) bool
+}

--- a/db/store.go
+++ b/db/store.go
@@ -71,7 +71,7 @@ type Store interface {
 	GetCertificateBySerial(serialNumber *big.Int) *core.Certificate
 	GetRevokedCertificateBySerial(serialNumber *big.Int) *core.RevokedCertificate
 	AddExternalAccountKeyByID(keyID, key string) error
-	GetExtenalAccountKeyByID(keyID string) ([]byte, bool)
+	GetExternalAccountKeyByID(keyID string) ([]byte, bool)
 	AddBlockedDomain(name string) error
 	IsDomainBlocked(name string) bool
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -155,7 +155,7 @@ func (th *topHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 type WebFrontEndImpl struct {
 	log               *log.Logger
-	db                *db.MemoryStore
+	db                db.Store
 	nonce             *nonceMap
 	nonceErrPercent   int
 	authzReusePercent int
@@ -172,7 +172,7 @@ const ToSURL = "data:text/plain,Do%20what%20thou%20wilt"
 
 func New(
 	log *log.Logger,
-	db *db.MemoryStore,
+	db db.Store,
 	va *va.VAImpl,
 	ca *ca.CAImpl,
 	strict, requireEAB bool, retryAfterAuthz int, retryAfterOrder int) WebFrontEndImpl {

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -2787,7 +2787,7 @@ func (wfe *WebFrontEndImpl) verifyEAB(
 
 	//3.  Retrieve the MAC key corresponding to the key identifier in the
 	//    "kid" field
-	key, ok := wfe.db.GetExtenalAccountKeyByID(keyID)
+	key, ok := wfe.db.GetExternalAccountKeyByID(keyID)
 	if !ok {
 		return nil, acme.UnauthorizedProblem(
 			"the field 'kid' references a key that is not known to the ACME server")


### PR DESCRIPTION
I am trying to create a db.Store interface class to abstract the behavior of manipulating the DB. People can then implement it to solve their own problems (eg store RootCA/CA or reuse them?)
