### PR TITLE
Explicitly set the certificate validity period in config

### DIFF
--- a/test/config/pebble-config-external-account-bindings.json
+++ b/test/config/pebble-config-external-account-bindings.json
@@ -15,6 +15,7 @@
     "externalAccountMACKeys": {
       "kid-1": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",
       "kid-2": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH"
-    }
+    },
+    "certificateValidityPeriod": 157766400
   }
 }

--- a/test/config/pebble-config.json
+++ b/test/config/pebble-config.json
@@ -12,6 +12,7 @@
     "retryAfter": {
         "authz": 3,
         "order": 5
-    }
+    },
+    "certificateValidityPeriod": 157766400
   }
 }


### PR DESCRIPTION
Several issues had been opened about overriding this value. We [expose the variable](https://github.com/letsencrypt/pebble/pull/361), but client developers unaccustomed with golang can now easily change the config value without digging through pebble source code to find that it exists.

- https://github.com/letsencrypt/pebble/issues/251
- https://github.com/letsencrypt/pebble/issues/319