### PR TITLE
Add eab key example that enforces base64url

### DIFF
--- a/test/config/pebble-config-external-account-bindings.json
+++ b/test/config/pebble-config-external-account-bindings.json
@@ -14,7 +14,8 @@
     "externalAccountBindingRequired": true,
     "externalAccountMACKeys": {
       "kid-1": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",
-      "kid-2": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH"
+      "kid-2": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH",
+      "kid-3": "HjudV5qnbreN-n9WyFSH-t4HXuEx_XFen45zuxY-G1h6fr74V3cUM_dVlwQZBWmc"
     },
     "certificateValidityPeriod": 157766400
   }


### PR DESCRIPTION
The acme rfc states that clients should interpret supplied eab keys as base64url. To encourage that behavior, this commit adds a key to the example configuration that is only decodable by base64url.
