### PR TITLE
ca: Pass OCSP Must-Staple from CSR into generated certificate

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -380,6 +380,17 @@ var ocspMustStapleExt = pkix.Extension{
 	Value: []byte{0x30, 0x03, 0x02, 0x01, 0x05},
 }
 
+// Returns whether the given extensions array contains an OCSP Must-Staple
+// extension.
+func extensionsContainsOCSPMustStaple(extensions []pkix.Extension) bool {
+	for _, ext := range extensions {
+		if ext.Id.Equal(ocspMustStapleExt.Id) && bytes.Equal(ext.Value, ocspMustStapleExt.Value) {
+			return true
+		}
+	}
+	return false
+}
+
 func (ca *CAImpl) CompleteOrder(order *core.Order) {
 	// Lock the order for reading
 	order.RLock()
@@ -425,15 +436,6 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 	order.Lock()
 	order.CertificateObject = cert
 	order.Unlock()
-}
-
-func extensionsContainsOCSPMustStaple(extensions []pkix.Extension) bool {
-	for _, ext := range extensions {
-		if ext.Id.Equal(ocspMustStapleExt.Id) && bytes.Equal(ext.Value, ocspMustStapleExt.Value) {
-			return true
-		}
-	}
-	return false
 }
 
 func (ca *CAImpl) GetNumberOfRootCerts() int {

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -252,7 +252,7 @@ func (ca *CAImpl) newChain(intermediateKey crypto.Signer, intermediateSubject pk
 	return c
 }
 
-func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.PublicKey, accountID, notBefore, notAfter string) (*core.Certificate, error) {
+func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.PublicKey, accountID, notBefore, notAfter string, extensions []pkix.Extension) (*core.Certificate, error) {
 	if len(domains) == 0 && len(ips) == 0 {
 		return nil, errors.New("must specify at least one domain name or IP address")
 	}
@@ -299,6 +299,7 @@ func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.Publ
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		SubjectKeyId:          subjectKeyID,
+		ExtraExtensions:       extensions,
 		BasicConstraintsValid: true,
 		IsCA:                  false,
 	}
@@ -399,7 +400,7 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 
 	// issue a certificate for the csr
 	csr := order.ParsedCSR
-	cert, err := ca.newCertificate(csr.DNSNames, csr.IPAddresses, csr.PublicKey, order.AccountID, order.NotBefore, order.NotAfter)
+	cert, err := ca.newCertificate(csr.DNSNames, csr.IPAddresses, csr.PublicKey, order.AccountID, order.NotBefore, order.NotAfter, csr.Extensions)
 	if err != nil {
 		ca.log.Printf("Error: unable to issue order: %s", err.Error())
 		return

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -1,0 +1,60 @@
+package ca
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"log"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/letsencrypt/pebble/v2/acme"
+	"github.com/letsencrypt/pebble/v2/core"
+	"github.com/letsencrypt/pebble/v2/db"
+)
+
+func TestOCSPMustStaple(t *testing.T) {
+	logger := log.New(os.Stdout, "Pebble ", log.LstdFlags)
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	db := db.NewMemoryStore()
+	ca := New(logger, db, "", 0, 1, 0)
+	csr := x509.CertificateRequest{
+		DNSNames:    []string{"test.org"},
+		IPAddresses: []net.IP{[]byte{10, 255, 0, 0}},
+		PublicKey:   &privateKey.PublicKey,
+		Extensions: []pkix.Extension{
+			{
+				Id:       asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24},
+				Critical: false,
+				Value:    []byte{0x30, 0x03, 0x02, 0x01, 0x05},
+			},
+		},
+	}
+	var uniquenames []acme.Identifier
+	uniquenames = append(uniquenames, acme.Identifier{Value: "13.12.13.12", Type: acme.IdentifierIP})
+	order := &core.Order{
+		ID:              "randomstring",
+		AccountID:       "accountid",
+		ParsedCSR:       &csr,
+		BeganProcessing: true,
+		Order: acme.Order{
+			Status:      acme.StatusPending,
+			Expires:     time.Now().AddDate(0, 0, 1).UTC().Format(time.RFC3339),
+			Identifiers: uniquenames,
+			NotBefore:   time.Now().UTC().Format(time.RFC3339),
+			NotAfter:    time.Now().AddDate(30, 0, 0).UTC().Format(time.RFC3339),
+		},
+		ExpiresDate: time.Now().AddDate(0, 0, 1).UTC(),
+	}
+
+	ca.CompleteOrder(order)
+	log.Printf("cert: %+v", order.CertificateObject.Cert)
+}

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -18,29 +19,27 @@ import (
 	"github.com/letsencrypt/pebble/v2/db"
 )
 
-func TestOCSPMustStaple(t *testing.T) {
+var ocspId asn1.ObjectIdentifier = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}
+var ocspValue []byte = []byte{0x30, 0x03, 0x02, 0x01, 0x05}
+
+func makeCa() *CAImpl {
 	logger := log.New(os.Stdout, "Pebble ", log.LstdFlags)
+	db := db.NewMemoryStore()
+	return New(logger, db, "", 0, 1, 0)
+}
+
+func makeCertOrderWithExtensions(extensions []pkix.Extension) core.Order {
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		panic(err)
 	}
-	db := db.NewMemoryStore()
-	ca := New(logger, db, "", 0, 1, 0)
 	csr := x509.CertificateRequest{
-		DNSNames:    []string{"test.org"},
-		IPAddresses: []net.IP{[]byte{10, 255, 0, 0}},
+		DNSNames:    []string{"fake.domain"},
+		IPAddresses: []net.IP{[]byte{192, 0, 2, 1}},
 		PublicKey:   &privateKey.PublicKey,
-		Extensions: []pkix.Extension{
-			{
-				Id:       asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24},
-				Critical: false,
-				Value:    []byte{0x30, 0x03, 0x02, 0x01, 0x05},
-			},
-		},
+		Extensions:  extensions,
 	}
-	var uniquenames []acme.Identifier
-	uniquenames = append(uniquenames, acme.Identifier{Value: "13.12.13.12", Type: acme.IdentifierIP})
-	order := &core.Order{
+	return core.Order{
 		ID:              "randomstring",
 		AccountID:       "accountid",
 		ParsedCSR:       &csr,
@@ -48,13 +47,90 @@ func TestOCSPMustStaple(t *testing.T) {
 		Order: acme.Order{
 			Status:      acme.StatusPending,
 			Expires:     time.Now().AddDate(0, 0, 1).UTC().Format(time.RFC3339),
-			Identifiers: uniquenames,
+			Identifiers: []acme.Identifier{},
 			NotBefore:   time.Now().UTC().Format(time.RFC3339),
 			NotAfter:    time.Now().AddDate(30, 0, 0).UTC().Format(time.RFC3339),
 		},
 		ExpiresDate: time.Now().AddDate(0, 0, 1).UTC(),
 	}
+}
 
-	ca.CompleteOrder(order)
-	log.Printf("cert: %+v", order.CertificateObject.Cert)
+func getOCSPMustStapleExtension(cert *x509.Certificate) *pkix.Extension {
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(ocspId) && bytes.Equal(ext.Value, ocspValue) {
+			return &ext
+		}
+	}
+	return nil
+}
+
+func TestNoExtensions(t *testing.T) {
+	ca := makeCa()
+	order := makeCertOrderWithExtensions([]pkix.Extension{})
+	ca.CompleteOrder(&order)
+	foundOCSPExtension := getOCSPMustStapleExtension(order.CertificateObject.Cert)
+	if foundOCSPExtension != nil {
+		t.Error("Expected no OCSP Must-Staple extension in complete cert, but found one")
+	}
+}
+
+func TestSettingOCSPMustStapleExtension(t *testing.T) {
+	// Base case
+	ca := makeCa()
+	order := makeCertOrderWithExtensions([]pkix.Extension{
+		{
+			Id:       ocspId,
+			Critical: false,
+			Value:    ocspValue,
+		},
+	})
+	ca.CompleteOrder(&order)
+	foundOCSPExtension := getOCSPMustStapleExtension(order.CertificateObject.Cert)
+	if foundOCSPExtension == nil {
+		t.Error("Expected OCSP Must-Staple extension in complete cert, but didn't find it")
+	} else if foundOCSPExtension.Critical {
+		t.Error("Expected foundOCSPExtension.Critical to be false, but it was true")
+	}
+
+	// Test w/ improperly set Critical value
+	ca = makeCa()
+	order = makeCertOrderWithExtensions([]pkix.Extension{
+		{
+			Id:       ocspId,
+			Critical: true,
+			Value:    ocspValue,
+		},
+	})
+	ca.CompleteOrder(&order)
+	foundOCSPExtension = getOCSPMustStapleExtension(order.CertificateObject.Cert)
+	if foundOCSPExtension == nil {
+		t.Error("Expected OCSP Must-Staple extension in complete cert, but didn't find it")
+	} else if foundOCSPExtension.Critical {
+		t.Error("Expected foundOCSPExtension.Critical to be false, but it was true")
+	}
+
+	// Test w/ several extensions
+	ca = makeCa()
+	order = makeCertOrderWithExtensions([]pkix.Extension{
+		{
+			Id:       ocspId,
+			Critical: true,
+			Value:    ocspValue,
+		},
+		{
+			Id:       ocspId,
+			Critical: true,
+			Value:    ocspValue,
+		},
+	})
+	ca.CompleteOrder(&order)
+	numOCSPMustStapleExtensions := 0
+	for _, ext := range order.CertificateObject.Cert.Extensions {
+		if ext.Id.Equal(ocspId) && bytes.Equal(ext.Value, ocspValue) {
+			numOCSPMustStapleExtensions += 1
+		}
+	}
+	if numOCSPMustStapleExtensions != 1 {
+		t.Errorf("Expected exactly 1 OCSP Must-Staple extension, found %d", numOCSPMustStapleExtensions)
+	}
 }

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -19,8 +19,10 @@ import (
 	"github.com/letsencrypt/pebble/v2/db"
 )
 
-var ocspId asn1.ObjectIdentifier = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}
-var ocspValue = []byte{0x30, 0x03, 0x02, 0x01, 0x05}
+var (
+	ocspId    asn1.ObjectIdentifier = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}
+	ocspValue                       = []byte{0x30, 0x03, 0x02, 0x01, 0x05}
+)
 
 func makeCa() *CAImpl {
 	logger := log.New(os.Stdout, "Pebble ", log.LstdFlags)

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -20,8 +20,8 @@ import (
 )
 
 var (
-	ocspId    asn1.ObjectIdentifier = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}
-	ocspValue                       = []byte{0x30, 0x03, 0x02, 0x01, 0x05}
+	ocspID    = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}
+	ocspValue = []byte{0x30, 0x03, 0x02, 0x01, 0x05}
 )
 
 func makeCa() *CAImpl {
@@ -59,7 +59,7 @@ func makeCertOrderWithExtensions(extensions []pkix.Extension) core.Order {
 
 func getOCSPMustStapleExtension(cert *x509.Certificate) *pkix.Extension {
 	for _, ext := range cert.Extensions {
-		if ext.Id.Equal(ocspId) && bytes.Equal(ext.Value, ocspValue) {
+		if ext.Id.Equal(ocspID) && bytes.Equal(ext.Value, ocspValue) {
 			return &ext
 		}
 	}
@@ -81,7 +81,7 @@ func TestSettingOCSPMustStapleExtension(t *testing.T) {
 	ca := makeCa()
 	order := makeCertOrderWithExtensions([]pkix.Extension{
 		{
-			Id:       ocspId,
+			Id:       ocspID,
 			Critical: false,
 			Value:    ocspValue,
 		},
@@ -98,7 +98,7 @@ func TestSettingOCSPMustStapleExtension(t *testing.T) {
 	ca = makeCa()
 	order = makeCertOrderWithExtensions([]pkix.Extension{
 		{
-			Id:       ocspId,
+			Id:       ocspID,
 			Critical: true,
 			Value:    ocspValue,
 		},
@@ -115,12 +115,12 @@ func TestSettingOCSPMustStapleExtension(t *testing.T) {
 	ca = makeCa()
 	order = makeCertOrderWithExtensions([]pkix.Extension{
 		{
-			Id:       ocspId,
+			Id:       ocspID,
 			Critical: true,
 			Value:    ocspValue,
 		},
 		{
-			Id:       ocspId,
+			Id:       ocspID,
 			Critical: true,
 			Value:    ocspValue,
 		},
@@ -128,7 +128,7 @@ func TestSettingOCSPMustStapleExtension(t *testing.T) {
 	ca.CompleteOrder(&order)
 	numOCSPMustStapleExtensions := 0
 	for _, ext := range order.CertificateObject.Cert.Extensions {
-		if ext.Id.Equal(ocspId) && bytes.Equal(ext.Value, ocspValue) {
+		if ext.Id.Equal(ocspID) && bytes.Equal(ext.Value, ocspValue) {
 			numOCSPMustStapleExtensions++
 		}
 	}

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 var ocspId asn1.ObjectIdentifier = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}
-var ocspValue []byte = []byte{0x30, 0x03, 0x02, 0x01, 0x05}
+var ocspValue = []byte{0x30, 0x03, 0x02, 0x01, 0x05}
 
 func makeCa() *CAImpl {
 	logger := log.New(os.Stdout, "Pebble ", log.LstdFlags)
@@ -127,7 +127,7 @@ func TestSettingOCSPMustStapleExtension(t *testing.T) {
 	numOCSPMustStapleExtensions := 0
 	for _, ext := range order.CertificateObject.Cert.Extensions {
 		if ext.Id.Equal(ocspId) && bytes.Equal(ext.Value, ocspValue) {
-			numOCSPMustStapleExtensions += 1
+			numOCSPMustStapleExtensions++
 		}
 	}
 	if numOCSPMustStapleExtensions != 1 {

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -109,7 +109,7 @@ func TestSettingOCSPMustStapleExtension(t *testing.T) {
 		t.Error("Expected foundOCSPExtension.Critical to be false, but it was true")
 	}
 
-	// Test w/ several extensions
+	// Test w/ duplicate extensions
 	ca = makeCa()
 	order = makeCertOrderWithExtensions([]pkix.Extension{
 		{


### PR DESCRIPTION
This will allow for extensions such as OCSP stapling. Happy to add a test if desired, also I wasn't sure if it's expected to filter for specific extensions or to pass them wholesale onto the cert?

Fixes #433 