### PR TITLE
Implement latest draft-ietf-acme-ari spec

### DIFF
--- a/acme/common.go
+++ b/acme/common.go
@@ -59,6 +59,9 @@ type Order struct {
 	NotAfter       string          `json:"notAfter,omitempty"`
 	Authorizations []string        `json:"authorizations"`
 	Certificate    string          `json:"certificate,omitempty"`
+
+	// https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-03#section-5
+	Replaces string `json:"replaces,omitempty"`
 }
 
 // An Authorization is created for each identifier in an order

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -438,6 +438,19 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 	order.Unlock()
 }
 
+func (ca *CAImpl) GetSubjectKeyIDs() core.SubjectKeyIDs {
+	skis := core.SubjectKeyIDs{}
+	for _, chain := range ca.chains {
+		skis = append(skis, chain.root.cert.Cert.SubjectKeyId)
+		for _, intermediate := range chain.intermediates {
+			skis = append(skis, intermediate.cert.Cert.SubjectKeyId)
+		}
+	}
+	ca.log.Printf("Found %d SKIs\n", len(skis))
+
+	return skis
+}
+
 func (ca *CAImpl) GetNumberOfRootCerts() int {
 	return len(ca.chains)
 }

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -148,9 +148,7 @@ func (ca *CAImpl) makeRootCert(
 		return nil, err
 	}
 
-	hexSerial := hex.EncodeToString(cert.SerialNumber.Bytes())
 	newCert := &core.Certificate{
-		ID:   hexSerial,
 		Cert: cert,
 		DER:  der,
 	}
@@ -180,7 +178,7 @@ func (ca *CAImpl) newRootIssuer(name string) (*issuer, error) {
 		return nil, err
 	}
 
-	ca.log.Printf("Generated new root issuer %s with serial %s and SKI %x\n", rc.Cert.Subject, rc.ID, subjectKeyID)
+	ca.log.Printf("Generated new root issuer %s with serial %s and SKI %x\n", rc.Cert.Subject, rc.Cert.SerialNumber.String(), subjectKeyID)
 	return &issuer{
 		key:  rk,
 		cert: rc,
@@ -196,7 +194,7 @@ func (ca *CAImpl) newIntermediateIssuer(root *issuer, intermediateKey crypto.Sig
 	if err != nil {
 		return nil, err
 	}
-	ca.log.Printf("Generated new intermediate issuer %s with serial %s and SKI %x\n", ic.Cert.Subject, ic.ID, subjectKeyID)
+	ca.log.Printf("Generated new intermediate issuer %s with serial %s and SKI %x\n", ic.Cert.Subject, ic.Cert.SerialNumber.String(), subjectKeyID)
 	return &issuer{
 		key:  intermediateKey,
 		cert: ic,
@@ -327,9 +325,7 @@ func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.Publ
 		issuers[i] = issuerChain
 	}
 
-	hexSerial := hex.EncodeToString(cert.SerialNumber.Bytes())
 	newCert := &core.Certificate{
-		ID:           hexSerial,
 		AccountID:    accountID,
 		Cert:         cert,
 		DER:          der,
@@ -430,7 +426,7 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 		ca.log.Printf("Error: unable to issue order: %s", err.Error())
 		return
 	}
-	ca.log.Printf("Issued certificate serial %s for order %s\n", cert.ID, order.ID)
+	ca.log.Printf("Issued certificate serial %s for order %s\n", cert.Cert.SerialNumber.String(), order.ID)
 
 	// Lock and update the order to store the issued certificate
 	order.Lock()

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -438,10 +438,10 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 	order.Unlock()
 }
 
-// GetIntermediateBySKID attempts to match the incoming Authority Key Idenfitier
-// (AKID) bytes to the Subject Key Identifier of an intermediate certificate. It
+// RecognizedSKID attempts to match the incoming Authority Key Idenfitier (AKID)
+// bytes to the Subject Key Identifier (SKID) of an intermediate certificate. It
 // returns an error if no match is found.
-func (ca *CAImpl) GetIntermediateBySKID(issuer []byte) error {
+func (ca *CAImpl) RecognizedSKID(issuer []byte) error {
 	if issuer == nil {
 		return errors.New("issuer bytes must not be nil")
 	}

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -446,7 +446,6 @@ func (ca *CAImpl) GetSubjectKeyIDs() core.SubjectKeyIDs {
 			skis = append(skis, intermediate.cert.Cert.SubjectKeyId)
 		}
 	}
-	ca.log.Printf("Found %d SKIs\n", len(skis))
 
 	return skis
 }

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -148,7 +148,9 @@ func (ca *CAImpl) makeRootCert(
 		return nil, err
 	}
 
+	hexSerial := hex.EncodeToString(cert.SerialNumber.Bytes())
 	newCert := &core.Certificate{
+		ID:   hexSerial,
 		Cert: cert,
 		DER:  der,
 	}
@@ -178,7 +180,7 @@ func (ca *CAImpl) newRootIssuer(name string) (*issuer, error) {
 		return nil, err
 	}
 
-	ca.log.Printf("Generated new root issuer %s with serial %s and SKI %x\n", rc.Cert.Subject, rc.Cert.SerialNumber.String(), subjectKeyID)
+	ca.log.Printf("Generated new root issuer %s with serial %s and SKI %x\n", rc.Cert.Subject, rc.ID, subjectKeyID)
 	return &issuer{
 		key:  rk,
 		cert: rc,
@@ -194,7 +196,7 @@ func (ca *CAImpl) newIntermediateIssuer(root *issuer, intermediateKey crypto.Sig
 	if err != nil {
 		return nil, err
 	}
-	ca.log.Printf("Generated new intermediate issuer %s with serial %s and SKI %x\n", ic.Cert.Subject, ic.Cert.SerialNumber.String(), subjectKeyID)
+	ca.log.Printf("Generated new intermediate issuer %s with serial %s and SKI %x\n", ic.Cert.Subject, ic.ID, subjectKeyID)
 	return &issuer{
 		key:  intermediateKey,
 		cert: ic,
@@ -325,7 +327,9 @@ func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.Publ
 		issuers[i] = issuerChain
 	}
 
+	hexSerial := hex.EncodeToString(cert.SerialNumber.Bytes())
 	newCert := &core.Certificate{
+		ID:           hexSerial,
 		AccountID:    accountID,
 		Cert:         cert,
 		DER:          der,
@@ -426,7 +430,7 @@ func (ca *CAImpl) CompleteOrder(order *core.Order) {
 		ca.log.Printf("Error: unable to issue order: %s", err.Error())
 		return
 	}
-	ca.log.Printf("Issued certificate serial %s for order %s\n", cert.Cert.SerialNumber.String(), order.ID)
+	ca.log.Printf("Issued certificate serial %s for order %s\n", cert.ID, order.ID)
 
 	// Lock and update the order to store the issued certificate
 	order.Lock()

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -95,7 +95,7 @@ func main() {
 
 	db := db.NewMemoryStore()
 	ca := ca.New(logger, db, c.Pebble.OCSPResponderURL, alternateRoots, chainLength, c.Pebble.CertificateValidityPeriod)
-	va := va.New(logger, c.Pebble.HTTPPort, c.Pebble.TLSPort, *strictMode, *resolverAddress)
+	va := va.New(logger, c.Pebble.HTTPPort, c.Pebble.TLSPort, *strictMode, *resolverAddress, db)
 
 	for keyID, key := range c.Pebble.ExternalAccountMACKeys {
 		err := db.AddExternalAccountKeyByID(keyID, key)

--- a/core/types.go
+++ b/core/types.go
@@ -8,6 +8,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"math/big"
 	"sync"
 	"time"
 
@@ -199,4 +200,69 @@ type ValidationRecord struct {
 	URL         string
 	Error       *acme.ProblemDetails
 	ValidatedAt time.Time
+}
+
+// SubjectKeyIDs is a convenience type that holds the Subject Key Identifier
+// value for each Pebble generated root and intermediate certificate.
+type SubjectKeyIDs [][]byte
+
+// CertID represents a unique identifier (CertID) for a certificate as per the
+// ACME protocol's "renewalInfo" resource, as specified in draft-ietf-acme-ari-
+// 03. The CertID is a composite string derived from the base64url-encoded
+// keyIdentifier of the certificate's Authority Key Identifier (AKI) and the
+// base64url-encoded serial number of the certificate, separated by a period.
+// For more details see:
+// https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-02#section-4.1.
+type CertID struct {
+	KeyIdentifier []byte
+	SerialNumber  *big.Int
+}
+
+// SuggestedWindow is a type exposed inside the RenewalInfo resource.
+type SuggestedWindow struct {
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+}
+
+// IsWithin returns true if the given time is within the suggested window,
+// inclusive of the start time and exclusive of the end time.
+func (window SuggestedWindow) IsWithin(now time.Time) bool {
+	return !now.Before(window.Start) && now.Before(window.End)
+}
+
+// RenewalInfo is a type which is exposed to clients which query the renewalInfo
+// endpoint specified in draft-aaron-ari.
+type RenewalInfo struct {
+	SuggestedWindow SuggestedWindow `json:"suggestedWindow"`
+}
+
+// RenewalInfoSimple constructs a `RenewalInfo` object and suggested window
+// using a very simple renewal calculation: calculate a point 2/3rds of the way
+// through the validity period, then give a 2-day window around that. Both the
+// `issued` and `expires` timestamps are expected to be UTC.
+func RenewalInfoSimple(issued time.Time, expires time.Time) *RenewalInfo {
+	validity := expires.Add(time.Second).Sub(issued)
+	renewalOffset := validity / time.Duration(3)
+	idealRenewal := expires.Add(-renewalOffset)
+	return &RenewalInfo{
+		SuggestedWindow: SuggestedWindow{
+			Start: idealRenewal.Add(-24 * time.Hour),
+			End:   idealRenewal.Add(24 * time.Hour),
+		},
+	}
+}
+
+// RenewalInfoImmediate constructs a `RenewalInfo` object with a suggested
+// window in the past. Per the draft-ietf-acme-ari-01 spec, clients should
+// attempt to renew immediately if the suggested window is in the past. The
+// passed `now` is assumed to be a timestamp representing the current moment in
+// time.
+func RenewalInfoImmediate(now time.Time) *RenewalInfo {
+	oneHourAgo := now.Add(-1 * time.Hour)
+	return &RenewalInfo{
+		SuggestedWindow: SuggestedWindow{
+			Start: oneHourAgo,
+			End:   oneHourAgo.Add(time.Minute * 30),
+		},
+	}
 }

--- a/core/types.go
+++ b/core/types.go
@@ -28,6 +28,8 @@ type Order struct {
 	AuthorizationObjects []*Authorization
 	BeganProcessing      bool
 	CertificateObject    *Certificate
+	// Indicates if the order has replaced via ARI.
+	IsReplaced bool
 }
 
 func (o *Order) GetStatus() (string, error) {

--- a/core/types.go
+++ b/core/types.go
@@ -28,7 +28,6 @@ type Order struct {
 	AuthorizationObjects []*Authorization
 	BeganProcessing      bool
 	CertificateObject    *Certificate
-	Replaces             string `json:"replaces,omitempty"`
 }
 
 func (o *Order) GetStatus() (string, error) {

--- a/core/types.go
+++ b/core/types.go
@@ -150,7 +150,6 @@ func (ch *Challenge) ExpectedKeyAuthorization(key *jose.JSONWebKey) string {
 }
 
 type Certificate struct {
-	ID           string
 	Cert         *x509.Certificate
 	DER          []byte
 	IssuerChains [][]*Certificate
@@ -166,7 +165,7 @@ func (c Certificate) PEM() []byte {
 	})
 	if err != nil {
 		panic(fmt.Sprintf("Unable to encode certificate %q to PEM: %s",
-			c.ID, err.Error()))
+			c.Cert.SerialNumber.String(), err.Error()))
 	}
 
 	return buf.Bytes()

--- a/core/types.go
+++ b/core/types.go
@@ -228,7 +228,7 @@ func (c CertID) SerialHex() string {
 // identifier and returns a CertID or an error.
 func NewCertID(serial []byte, akid []byte) (*CertID, error) {
 	if serial == nil || akid == nil {
-		return nil, fmt.Errorf("must send non-nil bytes")
+		return nil, errors.New("must send non-nil bytes")
 	}
 
 	return &CertID{

--- a/core/types.go
+++ b/core/types.go
@@ -28,6 +28,7 @@ type Order struct {
 	AuthorizationObjects []*Authorization
 	BeganProcessing      bool
 	CertificateObject    *Certificate
+	Replaces             string `json:"replaces,omitempty"`
 }
 
 func (o *Order) GetStatus() (string, error) {

--- a/core/types.go
+++ b/core/types.go
@@ -150,6 +150,7 @@ func (ch *Challenge) ExpectedKeyAuthorization(key *jose.JSONWebKey) string {
 }
 
 type Certificate struct {
+	ID           string
 	Cert         *x509.Certificate
 	DER          []byte
 	IssuerChains [][]*Certificate
@@ -165,7 +166,7 @@ func (c Certificate) PEM() []byte {
 	})
 	if err != nil {
 		panic(fmt.Sprintf("Unable to encode certificate %q to PEM: %s",
-			c.Cert.SerialNumber.String(), err.Error()))
+			c.ID, err.Error()))
 	}
 
 	return buf.Bytes()
@@ -217,6 +218,8 @@ type SubjectKeyIDs [][]byte
 type CertID struct {
 	KeyIdentifier []byte
 	SerialNumber  *big.Int
+	// ID is the pre-computed hex encoding of SerialNumber.
+	ID string
 }
 
 // SuggestedWindow is a type exposed inside the RenewalInfo resource.

--- a/core/types.go
+++ b/core/types.go
@@ -28,7 +28,7 @@ type Order struct {
 	AuthorizationObjects []*Authorization
 	BeganProcessing      bool
 	CertificateObject    *Certificate
-	// Indicates if the order has replaced via ARI.
+	// Indicates if the finalized order has been successfully replaced via ARI.
 	IsReplaced bool
 }
 

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -101,8 +101,8 @@ func (m *MemoryStore) UpdateReplacedOrder(serial *big.Int) error {
 		return acme.InternalErrorProblem(fmt.Sprintf("could not find an order for the given certificate: %s", err))
 	}
 
-	m.RLock()
-	defer m.RUnlock()
+	m.Lock()
+	defer m.Unlock()
 
 	originalOrder.IsReplaced = true
 	m.ordersByID[originalOrder.ID] = originalOrder
@@ -220,8 +220,8 @@ func (m *MemoryStore) GetOrderByID(id string) *core.Order {
 		if err != nil {
 			panic(err)
 		}
-		order.RLock()
-		defer order.RUnlock()
+		order.Lock()
+		defer order.Unlock()
 		order.Status = orderStatus
 		return order
 	}
@@ -239,8 +239,8 @@ func (m *MemoryStore) GetOrderByCertSerial(certID *big.Int) (*core.Order, error)
 	defer m.RUnlock()
 
 	for _, order := range m.ordersByID {
-		order.Lock()
-		defer order.Unlock()
+		order.RLock()
+		defer order.RUnlock()
 		if order.CertificateObject == nil || order.CertificateObject.Cert == nil {
 			continue
 		}
@@ -262,8 +262,8 @@ func (m *MemoryStore) GetOrdersByAccountID(accountID string) []*core.Order {
 			if err != nil {
 				panic(err)
 			}
-			order.RLock()
-			defer order.RUnlock()
+			order.Lock()
+			defer order.Unlock()
 			order.Status = orderStatus
 		}
 		return orders

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -212,6 +212,30 @@ func (m *MemoryStore) GetOrderByID(id string) *core.Order {
 	return nil
 }
 
+// GetOrderByCertSerial returns the order that resulted in the given certificate
+// serial. If no such order exists, an error will be returned.
+func (m *MemoryStore) GetOrderByCertSerial(certID *big.Int) (*core.Order, error) {
+	if certID == nil {
+		return nil, errors.New("certID was nil")
+	}
+
+	m.RLock()
+	defer m.RUnlock()
+
+	for _, order := range m.ordersByID {
+		order.Lock()
+		defer order.Unlock()
+		if order.CertificateObject.Cert == nil {
+			continue
+		}
+		if order.CertificateObject.Cert.SerialNumber.Cmp(certID) == 0 {
+			return order, nil
+		}
+	}
+
+	return nil, errors.New("could not find order resulting in the given certificate serial number")
+}
+
 func (m *MemoryStore) GetOrdersByAccountID(accountID string) []*core.Order {
 	m.RLock()
 	defer m.RUnlock()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/letsencrypt/pebble/v2
 
-go 1.22
+go 1.21
 
 require (
 	github.com/go-jose/go-jose/v4 v4.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/letsencrypt/pebble/v2
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-jose/go-jose/v4 v4.0.1

--- a/va/va.go
+++ b/va/va.go
@@ -109,7 +109,11 @@ type VAImpl struct {
 	strict             bool
 	customResolverAddr string
 	dnsClient          *dns.Client
-	db                 *db.MemoryStore
+
+	// The VA having a DB client is indeed strange. This is only used to
+	// facilitate va.setOrderError changing the ARI related order replacement
+	// field on failed orders.
+	db *db.MemoryStore
 }
 
 func New(

--- a/va/va.go
+++ b/va/va.go
@@ -27,6 +27,7 @@ import (
 	"github.com/letsencrypt/challtestsrv"
 	"github.com/letsencrypt/pebble/v2/acme"
 	"github.com/letsencrypt/pebble/v2/core"
+	"github.com/letsencrypt/pebble/v2/db"
 )
 
 const (
@@ -108,12 +109,14 @@ type VAImpl struct {
 	strict             bool
 	customResolverAddr string
 	dnsClient          *dns.Client
+	db                 *db.MemoryStore
 }
 
 func New(
 	log *log.Logger,
 	httpPort, tlsPort int,
 	strict bool, customResolverAddr string,
+	db *db.MemoryStore,
 ) *VAImpl {
 	va := &VAImpl{
 		log:                log,
@@ -124,6 +127,7 @@ func New(
 		sleepTime:          defaultSleepTime,
 		strict:             strict,
 		customResolverAddr: customResolverAddr,
+		db:                 db,
 	}
 
 	if customResolverAddr != "" {
@@ -209,10 +213,17 @@ func (va VAImpl) setAuthzValid(authz *core.Authorization, chal *core.Challenge) 
 
 // setOrderError updates an order with an error from an authorization
 // validation.
-func (va VAImpl) setOrderError(order *core.Order, err *acme.ProblemDetails) {
+func (va VAImpl) setOrderError(order *core.Order, prob *acme.ProblemDetails) {
 	order.Lock()
 	defer order.Unlock()
-	order.Error = err
+	order.Error = prob
+
+	// Mark the parent order as "not replaced yet" so a new replacement order
+	// can be attempted.
+	err := va.db.UpdateReplacedOrder(order.CertificateObject.ID, false)
+	if err != nil {
+		va.log.Printf("Error updating replacement order: %s", err)
+	}
 }
 
 // setAuthzInvalid updates an authorization and an associated challenge to be

--- a/va/va.go
+++ b/va/va.go
@@ -224,7 +224,7 @@ func (va VAImpl) setOrderError(order *core.Order, prob *acme.ProblemDetails) {
 
 	// Mark the parent order as "not replaced yet" so a new replacement order
 	// can be attempted.
-	err := va.db.UpdateReplacedOrder(order.CertificateObject.ID, false)
+	err := va.db.UpdateReplacedOrder(order.Replaces, false)
 	if err != nil {
 		va.log.Printf("Error updating replacement order: %s", err)
 	}

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -31,7 +31,7 @@ func TestAuthzRace(_ *testing.T) {
 
 	// This whole test can be removed if/when the MemoryStore becomes 100% by value
 	ms := db.NewMemoryStore()
-	va := New(log.New(os.Stdout, "Pebble/TestRace", log.LstdFlags), 14000, 15000, false, "")
+	va := New(log.New(os.Stdout, "Pebble/TestRace", log.LstdFlags), 14000, 15000, false, "", ms)
 
 	authz := &core.Authorization{
 		ID: "auth-id",

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -2171,7 +2171,11 @@ func (wfe *WebFrontEndImpl) FinalizeOrder(
 			wfe.sendError(acme.MalformedProblem(fmt.Sprintf("parsing ARI CertID failed: %s", err)), response)
 			return
 		}
-		wfe.db.UpdateReplacedOrder(certID.SerialNumber.String())
+		err = wfe.db.UpdateReplacedOrder(certID.SerialNumber.String())
+		if err != nil {
+			wfe.sendError(acme.InternalErrorProblem(fmt.Sprintf("Error updating replacement order: %s", err)), response)
+			return
+		}
 		wfe.log.Printf("Order %s has been marked as replaced in the DB", orderID)
 	}
 

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1992,7 +1992,7 @@ func (wfe *WebFrontEndImpl) Order(
 	}
 }
 
-func (wfe *WebFrontEndImpl) FinalizeOrder(
+func (wfe *WebFrontEndImpl) FinalizeOrder( //nolint:gocyclo,gocognit
 	_ context.Context,
 	response http.ResponseWriter,
 	request *http.Request,

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1913,7 +1913,7 @@ func (wfe *WebFrontEndImpl) parseCertID(path string) (*core.CertID, error) {
 		return nil, acme.MalformedProblem(fmt.Sprintf("Authority Key Identifier was not base64url-encoded or contained padding: %s", err))
 	}
 
-	err = wfe.ca.GetIntermediateBySKID(akid)
+	err = wfe.ca.RecognizedSKID(akid)
 	if err != nil {
 		return nil, acme.MalformedProblem(err.Error())
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -551,12 +551,16 @@ func (wfe *WebFrontEndImpl) Directory(
 	request *http.Request,
 ) {
 	directoryEndpoints := map[string]string{
-		"newNonce":    noncePath,
-		"newAccount":  newAccountPath,
-		"newOrder":    newOrderPath,
-		"revokeCert":  revokeCertPath,
-		"keyChange":   keyRolloverPath,
-		"renewalInfo": renewalInfoPath,
+		"newNonce":   noncePath,
+		"newAccount": newAccountPath,
+		"newOrder":   newOrderPath,
+		"revokeCert": revokeCertPath,
+		"keyChange":  keyRolloverPath,
+		// ARI-capable clients are expected to add the trailing slash per the
+		// draft. We explicitly strip the trailing slash here so that clients
+		// don't need to add trailing slash handling in their own code, saving
+		// them minimal amounts of complexity.
+		"renewalInfo": strings.TrimRight(renewalInfoPath, "/"),
 	}
 
 	// RFC 8555 §6.3 says the server's directory endpoint should support

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1864,7 +1864,7 @@ func (wfe *WebFrontEndImpl) RenewalInfo(_ context.Context, response http.Respons
 		return
 	}
 
-	renewalInfo, err := wfe.determineARIWindow(context.TODO(), certID)
+	renewalInfo, err := wfe.determineARIWindow(certID)
 	if err != nil {
 		wfe.sendError(acme.InternalErrorProblem(fmt.Sprintf("Error determining renewal window: %s", err)), response)
 		return
@@ -1878,7 +1878,7 @@ func (wfe *WebFrontEndImpl) RenewalInfo(_ context.Context, response http.Respons
 	}
 }
 
-func (wfe *WebFrontEndImpl) determineARIWindow(_ context.Context, id *core.CertID) (*core.RenewalInfo, error) {
+func (wfe *WebFrontEndImpl) determineARIWindow(id *core.CertID) (*core.RenewalInfo, error) {
 	if id == nil {
 		return nil, errors.New("CertID was nil")
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1666,7 +1666,7 @@ func (wfe *WebFrontEndImpl) validateReplacementOrder(newOrder *core.Order) *acme
 		return acme.InternalErrorProblem(fmt.Sprintf("could not find an order for the given certificate: %s", err))
 	}
 
-	if originalOrder.Replaces != "" {
+	if originalOrder.Replaces != "" || !originalOrder.IsReplaced {
 		return acme.Conflict(fmt.Sprintf("cannot indicate an order replaces certificate with serial %s, which already has a replacement order", certID.SerialNumber))
 	}
 

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1647,10 +1647,6 @@ func (wfe *WebFrontEndImpl) validateReplacementOrder(newOrder *core.Order) *acme
 		return acme.InternalErrorProblem("Order is nil")
 	}
 
-	// Lock the order for reading
-	newOrder.Lock()
-	defer newOrder.Unlock()
-
 	if newOrder.Replaces == "" {
 		wfe.log.Printf("ARI: order %q is not a replacement\n", newOrder.ID)
 		return nil


### PR DESCRIPTION
The draft spec version at the time of this PR was draft-ietf-acme-ari-03, but failed replacement order handling is from the [yet-to-be-released draft-ietf-acme-ari-04](https://github.com/aarongable/draft-acme-ari/blob/1813de294a6d813f4eba3f5c45b14ee5139ef66a/draft-ietf-acme-ari.md#L177).

* Add a `renewalInfo` entry to the directory object which provides the base URL for ARI requests.
* Add a new WFE handlefunc which parses incoming requests and returns reasonable `renewalInfo` for determining when the client should attempt renewal of a certificate.
* Add support for marking orders as `replaced`. Replacement orders can be chained, but there can be no duplicate replacement of orders, just like boulder.
* Restructured the asynchronous finalization anonymous go func to handle storing replaced orders. To be replaced, an order must previously have been finalized and have an issued certificate.