### PR TITLE
Reject extra command line args and fix README invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ With a Docker command:
 ```bash
 docker run -p 14000:14000 -p 15000:15000 -e "PEBBLE_VA_NOSLEEP=1" ghcr.io/letsencrypt/pebble
 # or
-docker run -p 14000:14000 -p 15000:15000 -e "PEBBLE_VA_NOSLEEP=1" --mount src=$(pwd)/my-pebble-config.json,target=/test/my-pebble-config.json,type=bind ghcr.io/letsencrypt/pebble pebble -config /test/my-pebble-config.json
+docker run -p 14000:14000 -p 15000:15000 -e "PEBBLE_VA_NOSLEEP=1" --mount src=$(pwd)/my-pebble-config.json,target=/test/my-pebble-config.json,type=bind ghcr.io/letsencrypt/pebble -config /test/my-pebble-config.json
 ```
 
 ### Default validation ports

--- a/cmd/pebble-challtestsrv/main.go
+++ b/cmd/pebble-challtestsrv/main.go
@@ -6,12 +6,14 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"strings"
 
 	"github.com/letsencrypt/challtestsrv"
+
 	"github.com/letsencrypt/pebble/v2/cmd"
 )
 
@@ -74,6 +76,12 @@ func main() {
 		"Default IPv6 address for mock DNS responses to AAAA queries")
 
 	flag.Parse()
+
+	if len(flag.Args()) > 0 {
+		fmt.Printf("invalid command line arguments: %s\n", strings.Join(flag.Args(), " "))
+		flag.Usage()
+		os.Exit(1)
+	}
 
 	httpOneAddresses := filterEmpty(strings.Split(*httpOneBind, ","))
 	httpsOneAddresses := filterEmpty(strings.Split(*httpsOneBind, ","))

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/letsencrypt/pebble/v2/ca"
 	"github.com/letsencrypt/pebble/v2/cmd"
@@ -58,6 +59,12 @@ func main() {
 		false,
 		"Print the software version")
 	flag.Parse()
+
+	if len(flag.Args()) > 0 {
+		fmt.Printf("invalid command line arguments: %s\n", strings.Join(flag.Args(), " "))
+		flag.Usage()
+		os.Exit(1)
+	}
 
 	if *versionFlag {
 		// Print the version and exit


### PR DESCRIPTION
Fixes #452 by rejecting the incorrect args, and fixes the readme to have a correct invocation.