### PR TITLE
Also support signing CSRs with Ed25519 keys

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -127,6 +127,7 @@ var goodSignatureAlgorithms = map[x509.SignatureAlgorithm]bool{
 	x509.ECDSAWithSHA256: true,
 	x509.ECDSAWithSHA384: true,
 	x509.ECDSAWithSHA512: true,
+	x509.PureEd25519:     true,
 }
 
 // newAccountRequest is the ACME account information submitted by the client


### PR DESCRIPTION
**Background:**
We use pebble to test [cert-manager](https://github.com/cert-manager/cert-manager). We are still using an older pebble version that did not verify the CSR signature algorithm (before https://github.com/letsencrypt/pebble/pull/386). One of our tests makes sure that we can use ACME to obtain a Certificate for a Ed25519 CSR, we were surprised that this signature algorithm is no longer allowed by pebble.

**Proposed change:**
Add support for signing CSRs signed with Ed25519 keys.