### PR TITLE
Fix(NOISSUE): Fix docker compose file example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,10 @@ Pebble releases are published as Docker images to the
 With a docker-compose file:
 
 ```yaml
-version: '3'
-
 services:
  pebble:
   image: ghcr.io/letsencrypt/pebble:latest
-  command: pebble -config /test/my-pebble-config.json
+  command: -config /test/my-pebble-config.json
   ports:
     - 14000:14000  # ACME port
     - 15000:15000  # Management port


### PR DESCRIPTION
In README.md is an example `docker-compose.yaml` file that can be improved in two points

- The "version" top level element is obsolete, see https://docs.docker.com/reference/compose-file/version-and-name/
- The "command" element contains a superflous "pebble" that prevents the following parameters from being parsed. (In the included docker-compose.yaml, the "command" element is already correct, see https://github.com/letsencrypt/pebble/blob/e08dd94e723a0e8d005d7c6149a8666e4bf5d877/docker-compose.yml#L5 for comparison.)