### PR TITLE
docs: rm mention of subproblems being unimpl'd

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,8 @@ clients are not hardcoding URLs.)
 ## Limitations
 
 Pebble is missing some ACME features (PRs are welcome!). It does not presently
-support subproblems, or pre-authorization. Pebble does not support revoking a 
-certificate issued by a different ACME account by proving authorization of all
-of the certificate's domains.
+support pre-authorization or revoking a certificate issued by a different ACME
+account by proving authorization of all of the certificate's domains.
 
 Pebble does not perform all of the same input validation as Boulder. Some domain
 names that would be rejected by Boulder/Let's Encrypt may work with Pebble.


### PR DESCRIPTION
:wave: Support for RFC 8555 subproblems ([§ 6.7.1](https://www.rfc-editor.org/rfc/rfc8555#section-6.7.1)) was implemented in Pebble [v2.5.0](https://github.com/letsencrypt/pebble/releases/tag/v2.5.0) by https://github.com/letsencrypt/pebble/pull/383. Nice!