### PR TITLE
return logical and compliant ARI windows for expiring certs

### DIFF
--- a/core/types.go
+++ b/core/types.go
@@ -276,6 +276,10 @@ func RenewalInfoSimple(issued time.Time, expires time.Time, now time.Time) *Rene
 	if windowEnd.After(expires){
 		windowEnd = expires
 	}
+	// Ensure correct start for future issueds
+	if windowStart.After(issued){
+		windowStart = issued
+	}
 	
 	// draft-ietf-acme-ari states:
 	// A RenewalInfo object in which the end timestamp

--- a/core/types.go
+++ b/core/types.go
@@ -279,7 +279,7 @@ func RenewalInfoSimple(issued time.Time, expires time.Time) *RenewalInfo {
         windowEnd = expires
     }
     
-    if !windowEnd.after(windowStart) {
+    if !windowEnd.After(windowStart) {
         // Ensure windowStart is before windowEnd
         windowEnd = expires.Add(-1 * time.Second)
     }

--- a/core/types.go
+++ b/core/types.go
@@ -267,31 +267,26 @@ func RenewalInfoSimple(issued time.Time, expires time.Time, now time.Time) *Rene
 	windowStart := idealRenewal.Add(-24 * time.Hour)
 	windowEnd := idealRenewal.Add(24 * time.Hour)
 
-	if expires.Before(now) {
-		// If the cert has expired, return `RenewalInfoImmediate` instead.
-		return RenewalInfoImmediate(now)
-	}
-	
 	// Ensure RenewalWindow is not after the expiry
-	if windowEnd.After(expires){
+	if windowEnd.After(expires) {
 		windowEnd = expires
 	}
 	// Ensure correct start for future issueds
-	if windowStart.After(issued){
+	if windowStart.Before(issued) {
 		windowStart = issued
 	}
-	
+
 	// draft-ietf-acme-ari states:
 	// A RenewalInfo object in which the end timestamp
 	// equals or precedes the start timestamp is invalid.
-	if !windowStart.Before(windowEnd){
+	if !windowStart.Before(windowEnd) {
 		windowStart = windowStart.Add(-1 * time.Second)
 	}
 
 	return &RenewalInfo{
 		SuggestedWindow: SuggestedWindow{
 			Start: windowStart,
-			End: windowEnd,
+			End:   windowEnd,
 		},
 	}
 }

--- a/core/types.go
+++ b/core/types.go
@@ -302,7 +302,7 @@ func RenewalInfoImmediate(now time.Time) *RenewalInfo {
 	return &RenewalInfo{
 		SuggestedWindow: SuggestedWindow{
 			Start: oneHourAgo,
-			End:   oneHourAgo.Add(time.Minute * 30),
+			End:   oneHourAgo.Add(1 * time.Second),
 		},
 	}
 }

--- a/core/types.go
+++ b/core/types.go
@@ -260,9 +260,6 @@ type RenewalInfo struct {
 // using a very simple renewal calculation: calculate a point 2/3rds of the way
 // through the validity period, then give a 2-day window around that. Both the
 // `issued` and `expires` timestamps are expected to be UTC.
-// If the cert has expired, return `RenewalInfoImmediate` instead.
-// If the windowEnd is after the cert's expiry, adjust it to the window end.
-// Ensure windowStart is before windowEnd.
 func RenewalInfoSimple(issued time.Time, expires time.Time) *RenewalInfo {
 	validity := expires.Add(time.Second).Sub(issued)
 	renewalOffset := validity / time.Duration(3)
@@ -272,15 +269,18 @@ func RenewalInfoSimple(issued time.Time, expires time.Time) *RenewalInfo {
 	now := time.Now().In(time.UTC)
 
     if expires.Before(now) {
+        // If the cert has expired, return `RenewalInfoImmediate` instead.
         return RenewalInfoImmediate(now)
     }
 
     if expires.Before(windowEnd) {
+        // If the windowEnd is after the cert's expiry, adjust it to the window end.
         windowStart = expires.Add(-1 * time.Second)
         windowEnd = expires
     }
     
     if !windowEnd.after(windowStart) {
+        // Ensure windowStart is before windowEnd
         windowEnd = expires.Add(-1 * time.Second)
     }
 

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1914,7 +1914,7 @@ func (wfe *WebFrontEndImpl) determineARIWindow(id *core.CertID) (*core.RenewalIn
 		return nil, errors.New("failed to retrieve existing certificate serial")
 	}
 
-	return core.RenewalInfoSimple(cert.Cert.NotBefore, cert.Cert.NotAfter), nil
+	return core.RenewalInfoSimple(cert.Cert.NotBefore, cert.Cert.NotAfter, time.Now().In(time.UTC)), nil
 }
 
 // parseCertID parses a unique identifier (certID) as specified in


### PR DESCRIPTION
While testing ARI functionality with extremely short lived certs, Pebble returned illogical data - such as the windowEnd appearing in the future for already expired certs, or after the cert's notAfter.

This PR adjusts `RenewalInfoSimple` to do the following:

* if the cert has expired, just return `RenewalInfoImmediate`
* if the cert will expire before the `windowEnd`, set the `windowEnd` to the cert's `notAfter`
* cleanup: RFC requires the `windowStart` to be before `windowEnd`, so remove a second from the `windowStart` if needed.

I also made the `RenewalInfoImmediate` window change from `-60:-30` minutes to `-60:-59.59` minutes; the sole reason for this change is that it is visually easier to see the change (and not need to do mental math) and recognize this is a `RenewalInfoImmediate` from logs. 

There are likely better ways to accomplish this, and I may be overlooking some elements from the RFC.

With these changes, Pebble can be configured for certificate validity periods as low as 5-10seconds, enabling quick testing of real (unmocked) flows such as:

* issue cert
* query ari
* wait for expiry or query ari
* renew with `replaces`

Also: The linting errors existed on creating my fork; there may be some linting errors in this PR - but there is a library issue.