### PR TITLE
Update golangci-lint

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ permissions:
 env:
   CGO_ENABLED: 0
   GO_VERSION: stable
-  GOLANGCI_LINT_VERSION: v1.60.2
+  GOLANGCI_LINT_VERSION: v1.64.5
   SHELLCHECK_SCRIPTS: ./*.sh
 jobs:
   go-lint-checks:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,8 +1,6 @@
 linters-settings:
   gocyclo:
     min-complexity: 25
-  govet:
-    check-shadowing: false
   misspell:
     locale: "US"
 
@@ -55,7 +53,6 @@ linters:
     - revive
     - staticcheck
     - tagalign
-    - tenv
     - testableexamples
     - testifylint
     - thelper
@@ -63,6 +60,7 @@ linters:
     - unparam
     - unused
     - usestdlibvars
+    - usetesting
     - wastedassign
 
 issues:

--- a/core/types.go
+++ b/core/types.go
@@ -260,7 +260,7 @@ type RenewalInfo struct {
 // using a very simple renewal calculation: calculate a point 2/3rds of the way
 // through the validity period, then give a 2-day window around that. Both the
 // `issued` and `expires` timestamps are expected to be UTC.
-func RenewalInfoSimple(issued time.Time, expires time.Time, now time.Time) *RenewalInfo {
+func RenewalInfoSimple(issued time.Time, expires time.Time) *RenewalInfo {
 	validity := expires.Add(time.Second).Sub(issued)
 	renewalOffset := validity / time.Duration(3)
 	idealRenewal := expires.Add(-renewalOffset)

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1914,7 +1914,7 @@ func (wfe *WebFrontEndImpl) determineARIWindow(id *core.CertID) (*core.RenewalIn
 		return nil, errors.New("failed to retrieve existing certificate serial")
 	}
 
-	return core.RenewalInfoSimple(cert.Cert.NotBefore, cert.Cert.NotAfter, time.Now().In(time.UTC)), nil
+	return core.RenewalInfoSimple(cert.Cert.NotBefore, cert.Cert.NotAfter), nil
 }
 
 // parseCertID parses a unique identifier (certID) as specified in


### PR DESCRIPTION
golangci-lint is failing on main due to a config problem.  Update configs, version of golangci-lint, and remove a variable that's unused and causing a lint failure