### PR TITLE
ca: Profile tweaks (default, promote CA flag)

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -45,8 +45,10 @@ type chain struct {
 }
 
 type Profile struct {
-	Description    string
-	ValidityPeriod uint64
+	Description       string
+	Default           bool
+	PromoteCommonName bool
+	ValidityPeriod    uint64
 }
 
 func (c *chain) String() string {
@@ -309,6 +311,22 @@ func (ca *CAImpl) newCertificate(domains []string, ips []net.IP, key crypto.Publ
 		IsCA:                  false,
 	}
 
+	// Check to see if the profile allows for the promotion of first domain to
+	// the common name. This helps emulate the Let's Encrypt "classic" profile or
+	// other CAs that follow similar behavior.
+	if prof.PromoteCommonName {
+		var cn string
+		switch {
+		case len(domains) > 0:
+			cn = domains[0]
+		case len(ips) > 0:
+			cn = ips[0].String()
+		}
+		if cn != "" {
+			template.Subject.CommonName = cn
+		}
+	}
+
 	if ca.ocspResponderURL != "" {
 		template.OCSPServer = []string{ca.ocspResponderURL}
 	}
@@ -375,7 +393,13 @@ func New(log *log.Logger, db *db.MemoryStore, ocspResponderURL string, alternate
 			prof.ValidityPeriod = defaultValidityPeriod
 		}
 		ca.profiles[name] = &prof
-		ca.log.Printf("Loaded profile %q with certificate validity period of %d seconds", name, prof.ValidityPeriod)
+		ca.log.Printf(
+			"Loaded profile %q with certificate validity period of %d seconds (default=%t, promote CN=%t)",
+			name,
+			prof.ValidityPeriod,
+			prof.Default,
+			prof.PromoteCommonName,
+		)
 	}
 
 	return ca
@@ -524,4 +548,12 @@ func (ca *CAImpl) GetProfiles() map[string]string {
 		res[name] = prof.Description
 	}
 	return res
+}
+
+func (ca *CAImpl) IsProfileDefault(name string) bool {
+	if profile, ok := ca.profiles[name]; ok {
+		return profile.Default
+	}
+
+	return false
 }

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1729,12 +1729,21 @@ func (wfe *WebFrontEndImpl) NewOrder(
 	profileName := newOrder.Profile
 	if profileName == "" {
 		// In true pebble chaos fashion, pick a random profile for orders that
-		// don't specify one.
+		// don't specify one. Search for a default profile first though, this helps
+		// emulate CAs that have one.
 		profNames := make([]string, 0, len(profiles))
+		var hasDefault bool
 		for name := range profiles {
+			if wfe.ca.IsProfileDefault(name) {
+				profileName = name
+				hasDefault = true
+				break
+			}
 			profNames = append(profNames, name)
 		}
-		profileName = profNames[rand.Intn(len(profiles))]
+		if !hasDefault {
+			profileName = profNames[rand.Intn(len(profiles))]
+		}
 	}
 	_, ok := profiles[profileName]
 	if !ok {


### PR DESCRIPTION
This adds a couple of things to the profile functionality:

* The ability to flag a profile to promote the first domain/IP to the common name. This was previously removed when promotion was deprecated, but is still allowed in the Let's Encrypt "classic" profile, so this helps mock this behavior (and also allows it to be mocked in CAs that still do the same).

* The ability to flag a profile as the default profile. Again, this is targeted at emulating classic behavior, since Let's Encrypt uses the classic profile when there is no profile supplied. A profile is still picked at random if there is no default profile flagged.