### PR TITLE
use newer validation subdomain for dns-account-01 (fix CI eggsampler/acme error)

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -367,11 +367,7 @@ func (va VAImpl) validateDNS01(task *vaTask) *core.ValidationRecord {
 func (va VAImpl) validateDNSAccount01(task *vaTask) *core.ValidationRecord {
 	acctHash := sha256.Sum256([]byte(task.AccountURL))
 	acctLabel := strings.ToLower(base32.StdEncoding.EncodeToString(acctHash[0:10]))
-	scope := "host"
-	if task.Wildcard {
-		scope = "wildcard"
-	}
-	challengeSubdomain := fmt.Sprintf("_%s._acme-%s-challenge.%s", acctLabel, scope, task.Identifier.Value)
+	challengeSubdomain := fmt.Sprintf("_%s._acme-challenge.%s", acctLabel, task.Identifier.Value)
 
 	result := &core.ValidationRecord{
 		URL:         challengeSubdomain,


### PR DESCRIPTION

at 2024 November draft writers of draft-ietf-acme-dns-account-label decide to drop concept in dns-account-01 challenge. This changed validation subdomain schema and breaks test about it as they are inserting record in newer subdomain and pebble was checking old subdomain.

this patch makes pebble use new subdoman in newer draft, finally solve CI error from eggsampler/acme lingered in every PR here for few months.
