### PR TITLE
add overriding of ARI response

### DIFF
--- a/core/types.go
+++ b/core/types.go
@@ -149,6 +149,8 @@ type Certificate struct {
 	DER          []byte
 	IssuerChains [][]*Certificate
 	AccountID    string
+	// When non-empty, this is the ARI response sent for this certificate.
+	ARIResponse string
 }
 
 func (c Certificate) PEM() []byte {

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -549,3 +549,19 @@ func (m *MemoryStore) IsDomainBlocked(name string) bool {
 
 	return false
 }
+
+// SetARIResponse looks up a certificate by serial number and sets its ARI response field
+func (m *MemoryStore) SetARIResponse(serial *big.Int, ariResponse string) error {
+	m.Lock()
+	defer m.Unlock()
+
+	for _, cert := range m.certificatesByID {
+		if cert.Cert.SerialNumber.Cmp(serial) == 0 {
+			cert.ARIResponse = ariResponse
+			return nil
+		}
+	}
+
+	// Certificate not found
+	return fmt.Errorf("certificate with serial number %s not found", serial.String())
+}

--- a/db/memorystore.go
+++ b/db/memorystore.go
@@ -413,7 +413,6 @@ func (m *MemoryStore) RevokeCertificate(cert *core.RevokedCertificate) {
 	m.Lock()
 	defer m.Unlock()
 	m.revokedCertificatesByID[cert.Certificate.ID] = cert
-	delete(m.certificatesByID, cert.Certificate.ID)
 }
 
 /*


### PR DESCRIPTION
Fixes #486

This moves the GetCertificateBySerial call earlier, which means that call needs to succeed even for revoked certificates. So this also follows up on #252 by keeping revoked certs in the primary certificatesByID map (while still adding them to the revokedCertificatesByID map).