### PR TITLE
wfe: return conflict on re-revocation

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -3011,13 +3011,13 @@ func (wfe *WebFrontEndImpl) processRevocation(
 		return acme.MalformedProblem("Error decoding Base64url-encoded DER: " + err.Error())
 	}
 
+	revokedCert := wfe.db.GetRevokedCertificateByDER(derBytes)
+	if revokedCert != nil {
+		return acme.AlreadyRevokedProblem("Certificate has already been revoked.")
+	}
+
 	cert := wfe.db.GetCertificateByDER(derBytes)
 	if cert == nil {
-		cert := wfe.db.GetRevokedCertificateByDER(derBytes)
-		if cert != nil {
-			return acme.AlreadyRevokedProblem("Certificate has already been revoked.")
-		}
-
 		return acme.MalformedProblem("Unable to find specified certificate.")
 	}
 


### PR DESCRIPTION
This worked previously but was broken in #501 by changing how the database stores revoked certificates.

Fixes #504, thanks @shred !