### PR TITLE
Replace agreementRequired problem with userActionRequired

### DIFF
--- a/acme/problems.go
+++ b/acme/problems.go
@@ -11,7 +11,7 @@ const (
 	malformedErr             = errNS + "malformed"
 	badNonceErr              = errNS + "badNonce"
 	badCSRErr                = errNS + "badCSR"
-	agreementReqErr          = errNS + "agreementRequired"
+	userActionReqErr         = errNS + "userActionRequired"
 	externalAccountReqErr    = errNS + "externalAccountRequired"
 	connectionErr            = errNS + "connection"
 	unauthorizedErr          = errNS + "unauthorized"
@@ -94,9 +94,9 @@ func Conflict(detail string) *ProblemDetails {
 	}
 }
 
-func AgreementRequiredProblem(detail string) *ProblemDetails {
+func UserActionRequiredProblem(detail string) *ProblemDetails {
 	return &ProblemDetails{
-		Type:       agreementReqErr,
+		Type:       userActionReqErr,
 		Detail:     detail,
 		HTTPStatus: http.StatusForbidden,
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1365,7 +1365,7 @@ func (wfe *WebFrontEndImpl) NewAccount(
 	if !newAcctReq.ToSAgreed {
 		response.Header().Add("Link", link(ToSURL, "terms-of-service"))
 		wfe.sendError(
-			acme.AgreementRequiredProblem(
+			acme.UserActionRequiredProblem(
 				"Provided account did not agree to the terms of service"),
 			response)
 		return


### PR DESCRIPTION
The "agreementRequired" problem type didn't make it into the final version of RFC 8555.

Fixes https://github.com/letsencrypt/pebble/issues/512