### PR TITLE
permit `Transfer-Encoding: chunked` HTTP request bodies

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -803,10 +803,6 @@ func (wfe *WebFrontEndImpl) validPOST(request *http.Request) *acme.ProblemDetail
 				`Content-Type must be "application/jose+json"`)
 	}
 
-	if _, present := request.Header["Content-Length"]; !present {
-		return acme.MalformedProblem("missing Content-Length header on POST")
-	}
-
 	// Per 6.4.1  "Replay-Nonce" clients should not send a Replay-Nonce header in
 	// the HTTP request, it needs to be part of the signed JWS request body
 	if _, present := request.Header["Replay-Nonce"]; present {


### PR DESCRIPTION
Drop the requirement for POST requests to contain a Content-Length header, which breaks support for chunked transfer encoded requests. See letsencrypt/boulder#8403 for more context.