### PR TITLE
Allow generating ECDSA roots and intermediates

### DIFF
--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -27,7 +27,7 @@ var (
 func makeCa() *CAImpl {
 	logger := log.New(os.Stdout, "Pebble ", log.LstdFlags)
 	db := db.NewMemoryStore()
-	return New(logger, db, "", 0, 1, map[string]Profile{"default": {}})
+	return New(logger, db, "", "ecdsa", 0, 1, map[string]Profile{"default": {}})
 }
 
 func makeCertOrderWithExtensions(extensions []pkix.Extension) core.Order {

--- a/test/config/pebble-config.json
+++ b/test/config/pebble-config.json
@@ -13,6 +13,7 @@
         "authz": 3,
         "order": 5
     },
+    "keyAlgorithm": "ecdsa",
     "profiles": {
       "default": {
         "description": "The profile you know and love",


### PR DESCRIPTION
Add a new "keyAlgorithm" entry to Pebble's config, which can take the value "rsa" or "ecdsa". Leaving it unset or setting it to "rsa" preserves the same behavior as today, in which Pebble uses RSA 2048 to generate all of its root and intermediate keys and certificates. Setting it to "ecdsa" causes Pebble to use ECDSA P-256 for all of its root and intermediate keys and certificates.

This paves the way for having pebble support other not-approved-by-the-BRs key algorithms, such as ML-DSA.