### PR TITLE
Return invalidProfile error for unsupported profiles

### DIFF
--- a/acme/problems.go
+++ b/acme/problems.go
@@ -16,6 +16,7 @@ const (
 	connectionErr            = errNS + "connection"
 	unauthorizedErr          = errNS + "unauthorized"
 	invalidContactErr        = errNS + "invalidContact"
+	invalidProfileErr        = errNS + "invalidProfile"
 	unsupportedContactErr    = errNS + "unsupportedContact"
 	accountDoesNotExistErr   = errNS + "accountDoesNotExist"
 	badRevocationReasonErr   = errNS + "badRevocationReason"
@@ -129,6 +130,14 @@ func UnauthorizedProblem(detail string) *ProblemDetails {
 func InvalidContactProblem(detail string) *ProblemDetails {
 	return &ProblemDetails{
 		Type:       invalidContactErr,
+		Detail:     detail,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+func InvalidProfileProblem(detail string) *ProblemDetails {
+	return &ProblemDetails{
+		Type:       invalidProfileErr,
 		Detail:     detail,
 		HTTPStatus: http.StatusBadRequest,
 	}

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1747,7 +1747,7 @@ func (wfe *WebFrontEndImpl) NewOrder(
 	_, ok := profiles[profileName]
 	if !ok {
 		wfe.sendError(
-			acme.MalformedProblem(fmt.Sprintf("Order includes unrecognized profile name %q", profileName)), response)
+			acme.InvalidProfileProblem(fmt.Sprintf("Order includes unrecognized profile name %q", profileName)), response)
 		return
 	}
 


### PR DESCRIPTION
The error type is defined in all the published drafts of the spec and already implemented in Boulder.