### PR TITLE
Release: include repo name in command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
         # https://cli.github.com/manual/gh_release_create
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: gh release create --generate-notes --verify-tag ${GITHUB_REF_NAME}
+        run: gh release create --repo ${{ github.repository }} --generate-notes --verify-tag ${GITHUB_REF_NAME}
       - name: Upload release files
         # https://cli.github.com/manual/gh_release_upload
         env:


### PR DESCRIPTION
Because this step is running in a separate job with no checkout, the --repo flag is actually required.