### PR TITLE
Require User-Agent header for all requests

### DIFF
--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -272,6 +272,13 @@ func (wfe *WebFrontEndImpl) HandleFunc(
 					return
 				}
 
+				// Reject all requests that do not include a User-Agent, which RFC 8555
+				// Section 6.1 requires all clients to supply in all requests.
+				if len(request.UserAgent()) == 0 {
+					wfe.sendError(acme.MalformedProblem("All requests MUST include a User-Agent header"), response)
+					return
+				}
+
 				// Modern ACME only sends a Replay-Nonce in responses to GET/HEAD
 				// requests to the dedicated newNonce endpoint, or in replies to POST
 				// requests that consumed a nonce.


### PR DESCRIPTION
RFC 8555 says:

> ACME clients MUST send a User-Agent header field, in accordance with RFC 7231.  This header field SHOULD include the name and version of the ACME software in addition to the name and version of the underlying HTTP client software.

Since Pebble is a test-bed for developing ACME clients, it is useful for it to enforce this constraint here, even though it is not enforced in Boulder.

Fixes https://github.com/letsencrypt/pebble/issues/529