### PR TITLE
Add accounturi to dns-persist-01 challenges

### DIFF
--- a/acme/common.go
+++ b/acme/common.go
@@ -86,6 +86,7 @@ type Challenge struct {
 	URL               string          `json:"url"`
 	Token             string          `json:"token,omitempty"`
 	Status            string          `json:"status"`
+	AccountURI        string          `json:"accounturi,omitempty"`
 	IssuerDomainNames []string        `json:"issuer-domain-names,omitempty"`
 	Validated         string          `json:"validated,omitempty"`
 	Error             *ProblemDetails `json:"error,omitempty"`

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1625,6 +1625,7 @@ func (wfe *WebFrontEndImpl) makeChallenge(
 	}
 	if chalType == acme.ChallengeDNSPersist01 {
 		chal.IssuerDomainNames = append([]string(nil), wfe.caaIdentities...)
+		chal.AccountURI = wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", acctPath, authz.Order.AccountID))
 	}
 
 	// Add it to the in-memory database

--- a/wfe/wfe.go
+++ b/wfe/wfe.go
@@ -1625,6 +1625,9 @@ func (wfe *WebFrontEndImpl) makeChallenge(
 	}
 	if chalType == acme.ChallengeDNSPersist01 {
 		chal.IssuerDomainNames = append([]string(nil), wfe.caaIdentities...)
+		// Note: By using web.relativeEndpoint here, Pebble will reflect the Host header
+		// into the accountURI here. This would not be acceptable in a security-conscious
+		// context, but is okay for Pebble.
 		chal.AccountURI = wfe.relativeEndpoint(request, fmt.Sprintf("%s%s", acctPath, authz.Order.AccountID))
 	}
 


### PR DESCRIPTION
This has been added to draft 01: https://www.ietf.org/archive/id/draft-ietf-acme-dns-persist-01.html#section-3.1 vs. https://www.ietf.org/archive/id/draft-ietf-acme-dns-persist-00.html#section-3.1

Diff: https://author-tools.ietf.org/iddiff?url1=draft-ietf-acme-dns-persist-00&url2=draft-ietf-acme-dns-persist-01