### PR TITLE
chore: update workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,18 +5,18 @@ on:
     branches:
       - main
   pull_request:
-permissions:
-  contents: read
-  pull-requests: read
+
+permissions: {}
+
 env:
   CGO_ENABLED: 0
-  GOLANGCI_LINT_VERSION: v2.9.0
-  SHELLCHECK_SCRIPTS: ./*.sh
+  GOLANGCI_LINT_VERSION: v2.12
+
 jobs:
   go-lint-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -29,17 +29,14 @@ jobs:
   go-mod-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - name: Check if go.mod is tidy
-        run: |
-          go mod tidy
-          git diff --exit-code go.mod go.sum ||
-            (echo "::error::go.mod and go.sum need to be tidy" && exit 1)
+        run: go mod tidy --diff
       - name: Check if vendor directory is up to date
         run: |
           go mod vendor

--- a/.github/workflows/go-cross.yml
+++ b/.github/workflows/go-cross.yml
@@ -4,9 +4,9 @@ on:
     branches:
       - main
   pull_request:
-permissions:
-  contents: read
-  pull-requests: read
+
+permissions: {}
+
 jobs:
   cross:
     name: Build on ${{ matrix.os }} with Go ${{ matrix.go-version }}
@@ -25,7 +25,7 @@ jobs:
           - windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - name: Set up Go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,9 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
-permissions:
-  contents: read
+
+permissions: {}
+
 env:
   DOCKER_PLATFORMS: linux/amd64, linux/arm64, windows/amd64
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}
@@ -31,7 +32,7 @@ jobs:
           - linux
           - windows
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -50,7 +51,7 @@ jobs:
       - name: Display ${{ matrix.app }} artifacts
         run: tree /tmp/dist
       - name: Store ${{ matrix.app }} artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.app }}-${{ matrix.go-os }}-${{ matrix.go-arch }}
           path: /tmp/dist
@@ -69,11 +70,11 @@ jobs:
       contents: read
       packages: write # Allow docker/build-push-action to publish to GitHub Container Registry
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - name: Download ${{ matrix.app }} artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
           path: /tmp/dist
@@ -82,7 +83,7 @@ jobs:
         run: tree /tmp/dist
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.DOCKER_IMAGE_BASENAME }}/${{ matrix.app }}
           # generate Docker tags based on the following events/attributes
@@ -93,9 +94,9 @@ jobs:
             type=sha
             type=raw,value=latest
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Login to GitHub Container Registry
         run: printenv GITHUB_TOKEN | docker login -u "$GITHUB_ACTOR" --password-stdin ghcr.io
         env:
@@ -140,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       - name: Display build artifacts
         run: tree .
       - name: Create release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,9 @@ on:
     branches:
       - main
   pull_request:
-permissions:
-  contents: read
-  pull-requests: read
+
+permissions: {}
+
 jobs:
   certbot-linux:
     name: Run Certbot tests on Linux
@@ -18,12 +18,12 @@ jobs:
           echo "127.0.0.1 elpmaxe.letsencrypt.org" | sudo tee -a /etc/hosts
       # https://github.com/marketplace/actions/checkout
       - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       # https://github.com/marketplace/actions/setup-go-environment
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - name: Install packages
@@ -44,11 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - name: go install commands
@@ -67,14 +67,14 @@ jobs:
     name: Test lego with EAB
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: go.mod
+          go-version: stable
       - name: Install lego cli
-        run: go install github.com/go-acme/lego/v4/cmd/lego@latest
+        run: go install github.com/go-acme/lego/v5@latest
       - name: go install commands
         run: go install -v ./cmd/...
       - name: launch pebble
@@ -83,21 +83,20 @@ jobs:
           pebble -config test/config/pebble-config-external-account-bindings.json &
       - run: |
           LEGO_CA_CERTIFICATES=./test/certs/pebble.minica.pem \
-          lego --accept-tos \
+          lego run \
+               --accept-tos \
                --server=https://localhost:14000/dir \
-               --email="pebble-test@example.letsencrypt.org" \
                --domains=example.letsencrypt.org \
                --eab \
-                 --kid kid-3 \
-                 --hmac=HjudV5qnbreN-n9WyFSH-t4HXuEx_XFen45zuxY-G1h6fr74V3cUM_dVlwQZBWmc \
-               --http --http.port=:5002 \
-               run
+                 --eab.kid kid-3 \
+                 --eab.hmac=HjudV5qnbreN-n9WyFSH-t4HXuEx_XFen45zuxY-G1h6fr74V3cUM_dVlwQZBWmc \
+               --http --http.address=:5002
   go-linux:
     name: Run Go tests on Linux
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       # Run project unit tests (with the race detector enabled and atomic coverage profile collection)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,7 +21,6 @@ linters:
     - gocyclo
     - goheader
     - gomoddirectives
-    - gomodguard
     - goprintffuncname
     - importas
     - inamedparam
@@ -51,12 +50,12 @@ linters:
       min-complexity: 25
     misspell:
       locale: US
+    goconst:
+      ignore-tests: true
   exclusions:
-    generated: lax
     presets:
       - comments
       - common-false-positives
-      - legacy
       - std-error-handling
     rules:
       - path: ca/ca.go
@@ -71,10 +70,6 @@ linters:
         text: string `Incorrect validation certificate for %s challenge. ` has \d occurrences, make it a constant
       - path: (.+)\.go$
         text: fmt.Sprintf can be replaced with string
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
@@ -83,9 +78,3 @@ formatters:
     - gofmt
     - gofumpt
     - goimports
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$


### PR DESCRIPTION
I updated the versions of the actions to the latest possible and applied some security good practices.

I also updated golangci-lint to the latest version and lego to v5.

---

Not in this PR, but I recommend several things to improve security and maintainability:
- use goreleaser to simplify the maintenance of the release process and review the permissions related to this process
- use immutable releases (I think this is not possible with the current release process)
- pin the versions of the actions and use dependabot or renovatebot to keep them up to date
- add [zizmor](https://github.com/zizmorcore/zizmor-action) as a check

The fact to use goreleaser was rejected in 2019, but it's still think that it's the best way to automate the release process.
This is more maintainable than the current process with upload and download of artifacts.
